### PR TITLE
Pull request, Solved Issues #86 & #149

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -126,7 +126,7 @@ void CMapLayers::OnRender()
 					Render = true;
 			}
 			
-			if(pLayer->m_Type == LAYERTYPE_TILES && Input()->KeyPressed(KEY_KP0))
+			if(pLayer->m_Type == LAYERTYPE_TILES && Input()->KeyPressed(KEY_KP0) && g_Config.m_DbgLayers)//This is what caused the client to lag when kp0 is pressed ingame also caused crashes on linux
 			{
 				CMapItemLayerTilemap *pTMap = (CMapItemLayerTilemap *)pLayer;
 				CTile *pTiles = (CTile *)m_pLayers->Map()->GetData(pTMap->m_Data);

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -74,6 +74,7 @@ MACRO_CONFIG_INT(SvVoteTimelimit, sv_vote_timelimit, 0, 0, 1, CFGFLAG_SERVER, "A
 	MACRO_CONFIG_INT(DbgDummies, dbg_dummies, 0, 0, 15, CFGFLAG_SERVER, "")
 #endif
 
+MACRO_CONFIG_INT(DbgLayers, dbg_layers, 0, 0, 1, CFGFLAG_CLIENT, "")
 MACRO_CONFIG_INT(DbgFocus, dbg_focus, 0, 0, 1, CFGFLAG_CLIENT, "")
 MACRO_CONFIG_INT(DbgTuning, dbg_tuning, 0, 0, 1, CFGFLAG_CLIENT, "")
 #endif


### PR DESCRIPTION
Fixed lags and crashes on kp0 in-game. Closes #149
Closes #86

Added dbg_layers which is 0 by default to prevent Debug files output when when ingame and pressing kp0
