### PR TITLE
mastersrv nullpointer vulnerability

### DIFF
--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -228,6 +228,9 @@ int CHuffman::Decompress(const void *pInput, int InputSize, void *pOutput, int O
 		// {C} load symbol now if we didn't that earlier at location {A}
 		if(!pNode)
 			pNode = m_apDecodeLut[Bits&HUFFMAN_LUTMASK];
+		
+		if(!pNode)
+			return -1;
 
 		// {D} check if we hit a symbol already
 		if(pNode->m_NumBits)


### PR DESCRIPTION
You were able to crash masterservers by sending them a packet with compressed flag set.
Fixed by additional nullpointer check. This fix was on matricks' mastersrv for a long time already but wasn't commited.
