### PR TITLE
Use tokenized serverinfo (gie2/SERVERBROWSE_GETINFO instead of legacy gief/SERVERBROWSE_OLD_GETINFO)

### DIFF
--- a/src/engine/client/srvbrowse.cpp
+++ b/src/engine/client/srvbrowse.cpp
@@ -530,7 +530,7 @@ void CServerBrowser::Refresh(int Type)
 
 void CServerBrowser::RequestImpl(const NETADDR &Addr, CServerEntry *pEntry) const
 {
-	//unsigned char buffer[sizeof(SERVERBROWSE_GETINFO)+1];
+	unsigned char Buffer[sizeof(SERVERBROWSE_GETINFO)+1];
 	CNetChunk Packet;
 
 	if(g_Config.m_Debug)
@@ -542,19 +542,15 @@ void CServerBrowser::RequestImpl(const NETADDR &Addr, CServerEntry *pEntry) cons
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "client_srvbrowse", aBuf);
 	}
 
-	/*mem_copy(buffer, SERVERBROWSE_GETINFO, sizeof(SERVERBROWSE_GETINFO));
-	buffer[sizeof(SERVERBROWSE_GETINFO)] = current_token;*/
+	mem_copy(Buffer, SERVERBROWSE_GETINFO, sizeof(SERVERBROWSE_GETINFO));
+	Buffer[sizeof(SERVERBROWSE_GETINFO)] = m_CurrentToken;
 
 	Packet.m_ClientID = -1;
 	Packet.m_Address = Addr;
 	Packet.m_Flags = NETSENDFLAG_CONNLESS;
-	/*p.data_size = sizeof(buffer);
-	p.data = buffer;
-	netclient_send(net, &p);*/
-
-	// send old request style aswell
-	Packet.m_DataSize = sizeof(SERVERBROWSE_OLD_GETINFO);
-	Packet.m_pData = SERVERBROWSE_OLD_GETINFO;
+	Packet.m_DataSize = sizeof(Buffer);
+	Packet.m_pData = Buffer;
+	
 	m_pNetClient->Send(&Packet);
 
 	if(pEntry)


### PR DESCRIPTION
Discards incoming serverinfo from old requests (since token increases each refresh)
