### PR TITLE
tower bug

### DIFF
--- a/scripts/cmd5.py
+++ b/scripts/cmd5.py
@@ -31,6 +31,6 @@ for filename in sys.argv[1:]:
 hash = hashlib.md5(f.encode()).hexdigest().lower()[16:]
 # TODO: refactor hash that is equal to the 0.5 hash, remove when we 
 # TODO: remove when we don't need it any more
-if hash == "026b8eceb4cdd369":
+if hash == "f16c2456fc487748":
 	hash = "b67d1f1a1eea234e"
 print('#define GAME_NETVERSION_HASH "%s"' % hash)

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -320,13 +320,15 @@ void CCharacterCore::Tick(bool UseInput)
 			if(d < PhysSize*1.25f && d > 1.0f)
 			{
 				float a = (PhysSize*1.45f - d);
-				
+				float v = 0.5f;
+
 				// make sure that we don't add excess force by checking the
-				// direction against the current velocity
-				vec2 VelDir = normalize(m_Vel);
-				float v = 1-(dot(VelDir, Dir)+1)/2;
-				m_Vel = m_Vel + Dir*a*(v*0.75f);
-				m_Vel = m_Vel * 0.85f;
+				// direction against the current velocity. if not zero.
+				if (length(m_Vel) > 0.0001)
+					v = 1-(dot(normalize(m_Vel), Dir)+1)/2;
+
+				m_Vel += Dir*a*(v*0.75f);
+				m_Vel *= 0.85f;
 			}
 			
 			// handle hook influence


### PR DESCRIPTION
me again, i was sufficiently bored to track down the famous tower bug. ironically, turned out the bug has apparently been introduced as part of a fix targeting a very related issue. i commented on some lines for more information, but roughly it all begins with a tees velocity happening to be exactly zero while encountering a player collision.
a zero length vector is then being normalized, yielding the first nan, subsequent operations do the same leaving us with m_Vel being (nan, nan).
on the next tick, those seem to have been re-interpreted (i suspect it happens in Quantize) into valid, but arbitrarily high or low floats (around -4000, -4000 on my platform, causing the massive drag left- and upwards).

ps: old clients will still predict the bug, for a tiny moment, of course

regards, fisted
