### PR TITLE
radius for checking occupied spawn points

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -208,7 +208,7 @@ void CPlayer::TryRespawn()
 
 	// check if the position is occupado
 	CEntity *pEnt;
-	int NumEnts = GameServer()->m_World.FindEntities(SpawnPos, CCharacter::ms_PhysSize/2.f - 10.f, &pEnt, 1, CGameWorld::ENTTYPE_CHARACTER);
+	int NumEnts = GameServer()->m_World.FindEntities(SpawnPos, 0.f, &pEnt, 1, CGameWorld::ENTTYPE_CHARACTER);
 	
 	if(NumEnts == 0)
 	{


### PR DESCRIPTION
i suspect this happened due to the offending line originally having been copy&pasted from somewhere, due to the integer 64 being frequently used as the size of the destination array given to FindEntities(). however, here it was being used as the radius, which is unlikely to have been intended.
reduced it to a value which i tuned to make a tee occupy  only those spawns it actually touches.
