### PR TITLE
Fix a render issue

### DIFF
--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -1,0 +1,28 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <engine/graphics.h>
+#include <engine/storage.h>
+#include <game/client/component.h>
+
+#include "background.h"
+
+int CBackground::m_BackgroundTexture;
+
+void CBackground::OnInit()
+{
+	m_BackgroundTexture = Graphics()->LoadTexture("editor/checker.png", IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, 0);
+}
+
+void CBackground::OnRender()
+{
+	CUIRect Screen;
+	Graphics()->GetScreen(&Screen.x, &Screen.y, &Screen.w, &Screen.h);
+	Graphics()->TextureSet(m_BackgroundTexture);
+	Graphics()->BlendNormal();
+	Graphics()->QuadsBegin();
+	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+	Graphics()->QuadsSetSubset(0,0, Screen.w/32.0f, Screen.h/32.0f);
+	IGraphics::CQuadItem QuadItem(Screen.x, Screen.y, Screen.w, Screen.h);
+	Graphics()->QuadsDrawTL(&QuadItem, 1);
+	Graphics()->QuadsEnd();
+}

--- a/src/game/client/components/background.h
+++ b/src/game/client/components/background.h
@@ -1,0 +1,15 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_CLIENT_COMPONENTS_BACKGROUND_H
+#define GAME_CLIENT_COMPONENTS_BACKGROUND_H
+#include <game/client/component.h>
+
+class CBackground : public CComponent
+{
+	static int m_BackgroundTexture;
+public:
+	virtual void OnInit();
+	virtual void OnRender();
+};
+
+#endif

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -44,6 +44,7 @@
 #include "components/skins.h"
 #include "components/sounds.h"
 #include "components/voting.h"
+#include "components/background.h"
 
 CGameClient g_GameClient;
 
@@ -68,6 +69,7 @@ static CSounds gs_Sounds;
 static CEmoticon gs_Emoticon;
 static CDamageInd gsDamageInd;
 static CVoting gs_Voting;
+static CBackground gs_Background;
 
 static CPlayers gs_Players;
 static CNamePlates gs_NamePlates;
@@ -135,6 +137,7 @@ void CGameClient::OnConsoleInit()
 	m_pMapimages = &::gs_MapImages;
 	m_pVoting = &::gs_Voting;
 	m_pScoreboard = &::gs_Scoreboard;
+	m_pBackground = &::gs_Background;
 	
 	// make a list of all the systems, make sure to add them in the corrent render order
 	m_All.Add(m_pSkins);
@@ -148,6 +151,7 @@ void CGameClient::OnConsoleInit()
 	m_All.Add(m_pVoting);
 	m_All.Add(m_pParticles); // doesn't render anything, just updates all the particles
 	
+	m_All.Add(m_pBackground);
 	m_All.Add(&gs_MapLayersBackGround); // first to render
 	m_All.Add(&m_pParticles->m_RenderTrail);
 	m_All.Add(&gs_Items);

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -212,6 +212,7 @@ public:
 	class CMapImages *m_pMapimages;
 	class CVoting *m_pVoting;
 	class CScoreboard *m_pScoreboard;
+	class CBackground *m_pBackground;
 };
 
 


### PR DESCRIPTION
There is a render issue on maps with a small background Quad : 

Before this fix : http://pix.toile-libre.org/upload/original/1300914149.png

After this fix : http://pix.toile-libre.org/upload/original/1300914093.png

This fix simply add a default background (the same as editor's one), so the whole screen is cleaned between each render (no remaining stuff from previous render where there is no quad).

But i don't know if this is the good way to add this background :/
