### PR TITLE
fixed so you can't add a friend with only the clan but the real name missing

### DIFF
--- a/src/engine/client/friends.cpp
+++ b/src/engine/client/friends.cpp
@@ -57,7 +57,7 @@ bool CFriends::IsFriend(const char *pName, const char *pClan, bool PlayersOnly) 
 
 void CFriends::AddFriend(const char *pName, const char *pClan)
 {
-	if(m_NumFriends == MAX_FRIENDS || (pName[0] == 0 && pClan[0] == 0))
+	if(m_NumFriends == MAX_FRIENDS || pName[0] == 0)
 		return;
 
 	// make sure we don't have the friend already


### PR DESCRIPTION
I am not sure if this is wanted though. By this it was possible to add a whole clan as friend. That looked a bit weird to me, but whatever.
