### PR TITLE
Made the voting menu tabbed again

### DIFF
--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -558,10 +558,16 @@ Free-View
 Friends
 == 
 
+Kick
+== 
+
 Kick player
 == 
 
 Length:
+== 
+
+Make spec.
 == 
 
 Map:
@@ -579,16 +585,7 @@ Netversion:
 New name:
 == 
 
-Next
-== 
-
-Page %d of %d
-== 
-
 Player options
-== 
-
-Prev
 == 
 
 Quit anyway?
@@ -667,4 +664,13 @@ no limit
 == 
 
 ##### old translations #####
+
+Page %d of %d
+== 
+
+Next
+== 
+
+Prev
+== 
 

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -346,9 +346,6 @@ New name:
 News
 == Novinky
 
-Next
-== Další
-
 Next weapon
 == Další zbraň
 
@@ -372,9 +369,6 @@ Ok
 
 Open
 == Otevřít
-
-Page %d of %d
-== Strana %d z %d
 
 Parent Folder
 == Nadřazená složka
@@ -405,9 +399,6 @@ Players
 
 Please balance teams!
 == Prosím vyrovnejte týmy!
-
-Prev
-== Předchozí
 
 Prev. weapon
 == Předchozí zbraň
@@ -666,5 +657,20 @@ no limit
 
 ##### needs translation #####
 
+Kick
+== 
+
+Make spec.
+== 
+
 ##### old translations #####
+
+Page %d of %d
+== Strana %d z %d
+
+Next
+== Další
+
+Prev
+== Předchozí
 

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -346,9 +346,6 @@ New name:
 News
 == Nieuws
 
-Next
-== Volgende
-
 Next weapon
 == Volgend wapen
 
@@ -372,9 +369,6 @@ Ok
 
 Open
 == Open
-
-Page %d of %d
-== Pagina %d van %d
 
 Parent Folder
 == Bovenliggende map
@@ -405,9 +399,6 @@ Players
 
 Please balance teams!
 == Balanceer teams!
-
-Prev
-== Vorige
 
 Prev. weapon
 == Vorig wapen
@@ -666,5 +657,20 @@ no limit
 
 ##### needs translation #####
 
+Kick
+== 
+
+Make spec.
+== 
+
 ##### old translations #####
+
+Page %d of %d
+== Pagina %d van %d
+
+Next
+== Volgende
+
+Prev
+== Vorige
 

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -540,10 +540,16 @@ Friends
 Invalid Demo
 == 
 
+Kick
+== 
+
 Kick player
 == 
 
 Length:
+== 
+
+Make spec.
 == 
 
 Map:
@@ -567,22 +573,13 @@ Netversion:
 New name:
 == 
 
-Next
-== 
-
 Open
-== 
-
-Page %d of %d
 == 
 
 Parent Folder
 == 
 
 Player options
-== 
-
-Prev
 == 
 
 Quit anyway?
@@ -667,4 +664,13 @@ no limit
 == 
 
 ##### old translations #####
+
+Page %d of %d
+== 
+
+Next
+== 
+
+Prev
+== 
 

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -370,9 +370,6 @@ Ok
 Open
 == Ouvrir
 
-Page %d of %d
-== Page %d sur %d
-
 Parent Folder
 == Dossier parent
 
@@ -660,11 +657,20 @@ no limit
 
 ##### needs translation #####
 
+Kick
+== 
+
+Make spec.
+== 
+
+##### old translations #####
+
+Page %d of %d
+== Page %d sur %d
+
 Next
 == 
 
 Prev
 == 
-
-##### old translations #####
 

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -83,7 +83,7 @@ Call vote
 == Abstimmen
 
 Change settings
-== Einstellungen ändern
+== Optionen ändern
 
 Chat
 == Chat
@@ -274,6 +274,9 @@ Join red
 Jump
 == Springen
 
+Kick
+== Kicken
+
 Kick player
 == Spieler kicken
 
@@ -294,6 +297,9 @@ Loading
 
 MOTD
 == Nachricht des Tages
+
+Make spec.
+== Zu Zusch. machen
 
 Map
 == Karte
@@ -346,9 +352,6 @@ New name:
 News
 == News
 
-Next
-== Weiter
-
 Next weapon
 == Nächste Waffe
 
@@ -372,9 +375,6 @@ Ok
 
 Open
 == Öffnen
-
-Page %d of %d
-== Seite %d von %d
 
 Parent Folder
 == Übergeordneter Ordner
@@ -405,9 +405,6 @@ Players
 
 Please balance teams!
 == Bitte Teams ausgleichen!
-
-Prev
-== Zurück
 
 Prev. weapon
 == Vorherige Waffe
@@ -667,4 +664,13 @@ no limit
 ##### needs translation #####
 
 ##### old translations #####
+
+Page %d of %d
+== Seite %d von %d
+
+Next
+== Weiter
+
+Prev
+== Zurück
 

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -564,10 +564,16 @@ Free-View
 Friends
 == 
 
+Kick
+== 
+
 Kick player
 == 
 
 Length:
+== 
+
+Make spec.
 == 
 
 Map:
@@ -588,16 +594,7 @@ Netversion:
 New name:
 == 
 
-Next
-== 
-
-Page %d of %d
-== 
-
 Player options
-== 
-
-Prev
 == 
 
 Quit anyway?
@@ -667,4 +664,13 @@ Warmup
 == 
 
 ##### old translations #####
+
+Page %d of %d
+== 
+
+Next
+== 
+
+Prev
+== 
 

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -543,10 +543,16 @@ Friends
 Invalid Demo
 == 
 
+Kick
+== 
+
 Kick player
 == 
 
 Length:
+== 
+
+Make spec.
 == 
 
 Map:
@@ -570,19 +576,10 @@ Netversion:
 New name:
 == 
 
-Next
-== 
-
-Page %d of %d
-== 
-
 Parent Folder
 == 
 
 Player options
-== 
-
-Prev
 == 
 
 Quit anyway?
@@ -667,4 +664,13 @@ no limit
 == 
 
 ##### old translations #####
+
+Page %d of %d
+== 
+
+Next
+== 
+
+Prev
+== 
 

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -540,10 +540,16 @@ Friends
 Invalid Demo
 == 
 
+Kick
+== 
+
 Kick player
 == 
 
 Length:
+== 
+
+Make spec.
 == 
 
 Map:
@@ -567,22 +573,13 @@ Netversion:
 New name:
 == 
 
-Next
-== 
-
 Open
-== 
-
-Page %d of %d
 == 
 
 Parent Folder
 == 
 
 Player options
-== 
-
-Prev
 == 
 
 Quit anyway?
@@ -667,4 +664,13 @@ no limit
 == 
 
 ##### old translations #####
+
+Page %d of %d
+== 
+
+Next
+== 
+
+Prev
+== 
 

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -346,9 +346,6 @@ New name:
 News
 == Știri
 
-Next
-== Următoarea
-
 Next weapon
 == Arma următoare
 
@@ -372,9 +369,6 @@ Ok
 
 Open
 == Deschide
-
-Page %d of %d
-== Pagina %d din %d
 
 Parent Folder
 == Dosarul părinte
@@ -405,9 +399,6 @@ Players
 
 Please balance teams!
 == Echilibrați echipele!
-
-Prev
-== Anterioara
 
 Prev. weapon
 == Arma precedentă
@@ -666,5 +657,20 @@ no limit
 
 ##### needs translation #####
 
+Kick
+== 
+
+Make spec.
+== 
+
 ##### old translations #####
+
+Page %d of %d
+== Pagina %d din %d
+
+Next
+== Următoarea
+
+Prev
+== Anterioara
 

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -343,9 +343,6 @@ New name:
 News
 == Новости
 
-Next
-== Далее
-
 Next weapon
 == След. оружие
 
@@ -369,9 +366,6 @@ Ok
 
 Open
 == Открыть
-
-Page %d of %d
-== Страница %d из %d
 
 Parent Folder
 == Родительский каталог
@@ -402,9 +396,6 @@ Players
 
 Please balance teams!
 == Сбалансируйте команды!
-
-Prev
-== Пред.
 
 Prev. weapon
 == Пред. оружие
@@ -663,8 +654,23 @@ no limit
 
 ##### needs translation #####
 
+Kick
+== 
+
+Make spec.
+== 
+
 Name plates size
 == 
 
 ##### old translations #####
+
+Page %d of %d
+== Страница %d из %d
+
+Next
+== Далее
+
+Prev
+== Пред.
 

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -540,10 +540,16 @@ Friends
 Invalid Demo
 == 
 
+Kick
+== 
+
 Kick player
 == 
 
 Length:
+== 
+
+Make spec.
 == 
 
 Map:
@@ -567,22 +573,13 @@ Netversion:
 New name:
 == 
 
-Next
-== 
-
 Open
-== 
-
-Page %d of %d
 == 
 
 Parent Folder
 == 
 
 Player options
-== 
-
-Prev
 == 
 
 Quit anyway?
@@ -667,4 +664,13 @@ no limit
 == 
 
 ##### old translations #####
+
+Page %d of %d
+== 
+
+Next
+== 
+
+Prev
+== 
 

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -346,9 +346,6 @@ New name:
 News
 == Novinky
 
-Next
-== Ďalší
-
 Next weapon
 == Ďalšia zbraň
 
@@ -372,9 +369,6 @@ Ok
 
 Open
 == Otvoriť
-
-Page %d of %d
-== Strana %d z %d
 
 Parent Folder
 == Nadradený Priečinok
@@ -405,9 +399,6 @@ Players
 
 Please balance teams!
 == Prosím vyrovnajte týmy!
-
-Prev
-== Predošlé
 
 Prev. weapon
 == Predošlá zbraň
@@ -666,5 +657,20 @@ no limit
 
 ##### needs translation #####
 
+Kick
+== 
+
+Make spec.
+== 
+
 ##### old translations #####
+
+Page %d of %d
+== Strana %d z %d
+
+Next
+== Ďalší
+
+Prev
+== Predošlé
 

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -582,10 +582,16 @@ Free-View
 Friends
 == 
 
+Kick
+== 
+
 Kick player
 == 
 
 Length:
+== 
+
+Make spec.
 == 
 
 Map:
@@ -600,16 +606,7 @@ Netversion:
 New name:
 == 
 
-Next
-== 
-
-Page %d of %d
-== 
-
 Player options
-== 
-
-Prev
 == 
 
 Quit anyway?
@@ -667,4 +664,13 @@ Vote description:
 == 
 
 ##### old translations #####
+
+Page %d of %d
+== 
+
+Next
+== 
+
+Prev
+== 
 

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -343,9 +343,6 @@ New name:
 News
 == Nyheter
 
-Next
-== Nästa
-
 Next weapon
 == Nästa vapen
 
@@ -369,9 +366,6 @@ Ok
 
 Open
 == Öppna
-
-Page %d of %d
-== Sida %d av %d
 
 Parent Folder
 == Uppliggande mapp
@@ -402,9 +396,6 @@ Players
 
 Please balance teams!
 == Balansera lagen!
-
-Prev
-== Föregående
 
 Prev. weapon
 == Föregående vapen
@@ -666,5 +657,20 @@ no limit
 %s wins!
 == 
 
+Kick
+== 
+
+Make spec.
+== 
+
 ##### old translations #####
+
+Page %d of %d
+== Sida %d av %d
+
+Next
+== Nästa
+
+Prev
+== Föregående
 

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -555,10 +555,16 @@ Free-View
 Friends
 == 
 
+Kick
+== 
+
 Kick player
 == 
 
 Length:
+== 
+
+Make spec.
 == 
 
 Map:
@@ -582,19 +588,10 @@ Netversion:
 New name:
 == 
 
-Next
-== 
-
-Page %d of %d
-== 
-
 Parent Folder
 == 
 
 Player options
-== 
-
-Prev
 == 
 
 Quit anyway?
@@ -667,4 +664,13 @@ no limit
 == 
 
 ##### old translations #####
+
+Page %d of %d
+== 
+
+Next
+== 
+
+Prev
+== 
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -389,7 +389,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 
 
 	// render background and tabbar
-	MainView.VSplitRight(150.0f, &MainView, &TabBar);
+	MainView.VSplitRight(170.0f, &MainView, &TabBar);
 	RenderTools()->DrawUIRect(&MainView, ms_ColorTabbarActive, CUI::CORNER_B|CUI::CORNER_TL, 10.0f);
 	TabBar.HSplitTop(50.0f, &Temp, &TabBar);
 	RenderTools()->DrawUIRect(&Temp, ms_ColorTabbarActive, CUI::CORNER_R, 10.0f);
@@ -397,9 +397,9 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	MainView.HSplitBottom(10.0f, &MainView, 0);
 
 	const char *aTabs[] = {
-		Localize("Change settings"),
-		Localize("Kick player"),
-		Localize("Move player")};
+		Localize("Settings"),
+		Localize("Kick"),
+		Localize("Make spec.")};
 		
 	int NumTabs = (int)(sizeof(aTabs)/sizeof(*aTabs));
 


### PR DESCRIPTION
Well, the best is probably to have a look at it yourself. The tabs are a bit larger than those of the settings menu, however I believe this is still better than the pages thing. I don't know if translations will all fit in there, but at least the german one does with a little abbreviation.

Implementing this also would of course mean that we can get rid of the whole pages stuff in general, if we want that. I did not do that yet though, i case we need it for something else.

(this pull request might be conflicting with the fix of the upper right corner in my other pull request, so don't get both ;))
