### PR TITLE
whole-line comments cause warnings to be displayed

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -247,6 +247,9 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr)
 		if(ParseStart(&Result, pStr, (pEnd-pStr) + 1) != 0)
 			return;
 
+		if (!*Result.m_pCommand)
+			return;
+
 		CCommand *pCommand = FindCommand(Result.m_pCommand, m_FlagMask);
 
 		if(pCommand)


### PR DESCRIPTION
stumbled upon this one while writing the openfng reference configuration, which features excessive commenting.

while lines like this:
  sv_name whatever #set the server name
are fine, doing it like this:
  # long interesting text blah
  sv_name whatever
will cause incorrect errors about not finding an empty command to be displayed on server launch.

(it seems like a length variable is always one off the actual length which later gets compensated by however the arguments get parsed so it in the end works ;), however maybe if someone is bored that code should be revised)

anyhow, there is one invariant for lines which are entirely comments (independent of whether or not they are indented by whitespace), which this commit exploits in order to suppress the errors
