### PR TITLE
Change panic quit binding to <lctrl><lshift>ESC

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1969,7 +1969,7 @@ void CClient::Run()
 		}
 
 		// panic quit button
-		if(Input()->KeyPressed(KEY_LCTRL) && Input()->KeyPressed(KEY_LSHIFT) && Input()->KeyPressed('q'))
+		if(Input()->KeyPressed(KEY_LCTRL) && Input()->KeyPressed(KEY_LSHIFT) && Input()->KeyPressed(KEY_ESCAPE))
 			break;
 
 		if(Input()->KeyPressed(KEY_LCTRL) && Input()->KeyPressed(KEY_LSHIFT) && Input()->KeyDown('d'))


### PR DESCRIPTION
<lctrl>, <shift> and Q are too close one to the other, making too easy
to type the binding by accident when e.g. one have lctrl mapped to
something.

This is particularly true on French keyboards, on which Q is typically
bound to +left (Q is where A is on US keyboards).
