### PR TITLE
Fixed FreeBSD build

### DIFF
--- a/src/base/detect.h
+++ b/src/base/detect.h
@@ -78,7 +78,12 @@
 
 /* use gcc endianness definitions when available */
 #if defined(__GNUC__) && !defined(__APPLE__)
-	#include <endian.h>
+	#if defined(__FreeBSD__) || defined(__OpenBSD__)
+		#include <sys/endian.h>
+	#else
+		#include <endian.h>
+	#endif
+
 	#if __BYTE_ORDER == __LITTLE_ENDIAN
 		#define CONF_ARCH_ENDIAN_LITTLE 1
 	#elif __BYTE_ORDER == __BIG_ENDIAN


### PR DESCRIPTION
3d7bdaee8f1b21409acebef8f87259d01ed8d244 broke it, due to BSDs having 'endian.h' being below sys/ in their include root dir.
