### PR TITLE
Added Installer creation script (NSIS)

### DIFF
--- a/scripts/installer.nsi
+++ b/scripts/installer.nsi
@@ -1,0 +1,73 @@
+# there should be passed on command line via /D
+#!define RELEASE_DIR "teeworlds"
+#!define SOURCE_DIR "source"
+#########
+
+!define NAME "Teeworlds"
+!define COMPANY "teeworlds.com"
+!define VERSION "0.6.1"
+
+
+Name "${NAME} ${VERSION} Installer"
+Icon "${SOURCE_DIR}\other\icons\Teeworlds.ico"
+ 
+# define name of installer
+#outFile "teeworlds-${VERSION}-installer.exe"
+outFile "teeworlds-installer.exe"
+
+# define installation directory
+installDir "$PROGRAMFILES\${NAME}"
+
+VIProductVersion "${VERSION}.0"
+VIAddVersionKey "ProductName" "${NAME}"
+VIAddVersionKey "Comments" ""
+VIAddVersionKey "CompanyName" "${COMPANY}"
+VIAddVersionKey "FileDescription" "${NAME} ${VERSION} Installer"
+VIAddVersionKey "FileVersion" "${VERSION}"
+
+# installer ui stuff
+LicenseData "${RELEASE_DIR}\license.txt"
+
+Page license
+#Page components
+Page directory
+Page instfiles
+
+UninstPage uninstConfirm
+UninstPage instfiles
+
+setcompressor /SOLID lzma
+
+# default section
+section
+ 
+	# set the installation directory as the destination for the following actions
+	setOutPath $INSTDIR
+	
+	file /r "${RELEASE_DIR}\*"
+	createShortCut "$SMPROGRAMS\${NAME}\Teeworlds.lnk" "$INSTDIR\teeworlds.exe"
+	
+	# Uninstall information
+	writeUninstaller "$INSTDIR\uninstall.exe"
+	createShortCut "$SMPROGRAMS\${NAME}\Uninstall.lnk" "$INSTDIR\uninstall.exe"
+	
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${NAME}" \
+				 "DisplayName" "${NAME} ${VERSION}"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${NAME}" \
+				 "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
+sectionEnd
+ 
+# uninstaller section start
+section "uninstall"
+ 
+	# first, delete the uninstaller
+	RMDir /r "$INSTDIR"
+ 
+	# second, remove the link from the start menu
+	SetShellVarContext all
+	RMDir /r "$SMPROGRAMS\${NAME}"
+	
+	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${NAME}"
+ 
+# uninstaller section end
+sectionEnd

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -52,7 +52,7 @@ def copydir(src, dst, excl=[]):
 				shutil.copy(os.path.join(root, name), os.path.join(dst, root, name))
 				
 package = "%s-%s-%s" %(name, version, platform)
-package_dir = package
+package_dir = name
 
 print("cleaning target")
 shutil.rmtree(package_dir, True)


### PR DESCRIPTION
Added NSIS script to create a windows installer. Version is still hardcoded unfortunately.
Modified make_release.py so resulting zip/tar.gz has a directory "teeworlds" in them instead of "teeworlds-version-platform".

Installer for 0.6.1: http://www.teeworlds.com/files/teeworlds-0.6.1-installer.exe
