### PR TITLE
Minor fixes with force votes and lock teams

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -33,6 +33,7 @@ void CGameContext::Construct(int Resetting)
 	m_pVoteOptionFirst = 0;
 	m_pVoteOptionLast = 0;
 	m_NumVoteOptions = 0;
+	m_LockTeams = 0;
 
 	if(Resetting==NO_RESET)
 		m_pVoteOptionHeap = new CHeap();


### PR DESCRIPTION
i changed so that if u use the vote rcon command (vote yes/no) that it returns if there is no vote running.
Also i init the lock teams variable with 0 so it doesnt get some random value and so the server doesnt start with lock teams (happens for me in windows in debug version)
