### PR TITLE
Fixed adding of ban commands to moderator rcon.

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1291,7 +1291,6 @@ int CServer::Run()
 
 	m_NetServer.SetCallbacks(NewClientCallback, DelClientCallback, this);
 
-	m_ServerBan.Init(Console(), Storage(), this);
 	m_Econ.Init(Console(), &m_ServerBan);
 
 	char aBuf[256];
@@ -1706,6 +1705,8 @@ int main(int argc, const char **argv) // ignore_convention
 	// register all console commands
 	pServer->RegisterCommands();
 	pGameServer->OnConsoleInit();
+
+	pServer->m_ServerBan.Init(pConsole, pStorage, pServer);
 
 	// execute autoexec file
 	pConsole->ExecuteFile("autoexec.cfg");


### PR DESCRIPTION
Currently you can't use mod_command (only in the config) to give moderators access to the ban commands.
Here's a short and working fix.
