### PR TITLE
ban_range bans ips outside the range

### DIFF
--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -461,7 +461,7 @@ bool CNetBan::IsBanned(const NETADDR *pAddr, char *pBuf, unsigned BufferSize) co
 	{
 		for(CBanRange *pBan = m_BanRangePool.First(&aHash[i]); pBan; pBan = pBan->m_pHashNext)
 		{
-			if(NetMatch(&pBan->m_Data, pAddr, i, Length))
+			if(NetMatch(&pBan->m_Data, pAddr))
 			{
 				MakeBanInfo(pBan, pBuf, BufferSize, MSGTYPE_PLAYER);
 				return true;


### PR DESCRIPTION
i accidentally myself from rcon and looked into codez to find this

i and Length are bucket indexes in hashtable but for some reason are used in netmatch (maybe its some optimization using hash function properties)
