### PR TITLE
Fixed getting the correct filename

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -82,11 +82,8 @@ work_dir = root_dir + "scripts/work"
 def fetch_file(url):
 	try:
 		print("trying %s" % url)
-		real_url = url_lib.urlopen(url).geturl()
-		local = real_url.split("/")
-		local = local[len(local)-1].split("?")
-		local = local[0]
-		url_lib.urlretrieve(real_url, local)
+		local = dict(url_lib.urlopen(url).info())['content-disposition'].split('=')[1]
+		url_lib.urlretrieve(url, local)
 		return local
 	except:
 		return False

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -50,11 +50,8 @@ if platform == 'osx':
 def fetch_file(url):
 	try:
 		print("trying %s" % url)
-		real_url = url_lib.urlopen(url).geturl()
-		local = real_url.split("/")
-		local = local[len(local)-1].split("?")
-		local = local[0]
-		url_lib.urlretrieve(real_url, local)
+		local = dict(url_lib.urlopen(url).info())['content-disposition'].split('=')[1]
+		url_lib.urlretrieve(url, local)
 		return local
 	except:
 		return False


### PR DESCRIPTION
It seems github has changed something on the server because trying to resolving the url until the filename is get doesn't work anymore. The new solution gets the filename directly from the header information.
