### PR TITLE
Minor script cleanup #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 bam
 .bam
 config.lua
-datasrc/__pycache__
-datasrc/*.pyc
 objs
-src/game/generated
+__pycache__/
+*.pyc
+*.pyo
+scripts/work/
+src/game/generated/
 SDL.dll
 freetype.dll
 autoexec.cfg

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,31 +1,12 @@
 import imp, optparse, os, re, shutil, sys, zipfile
-from optparse import OptionParser
-if sys.version_info[0] == 2:
-	import urllib
-	url_lib = urllib
-elif sys.version_info[0] == 3:
-	import urllib.request
-	url_lib = urllib.request
-match = re.search('(.*)/', sys.argv[0])
-if match != None:
-	os.chdir(match.group(1))
-os.chdir('../')
+os.chdir(os.path.dirname(os.path.realpath(sys.argv[0])) + "/..")
+import twlib
 
-url_bam = "http://github.com/matricks/bam/zipball/master"
-url_teeworlds = "http://github.com/teeworlds/teeworlds/zipball/master"
-release_type = "server_release client_release"
-
-arguments = OptionParser()
-arguments.add_option("-b", "--url_bam", dest = "url_bam")
-arguments.add_option("-t", "--url_teeworlds", dest = "url_teeworlds")
-arguments.add_option("-r", "--release_type", dest = "release_type")
+arguments = optparse.OptionParser()
+arguments.add_option("-b", "--url-bam", default = "http://github.com/matricks/bam/zipball/master", help = "URL from which the bam source code will be downloaded")
+arguments.add_option("-t", "--url-teeworlds", default = "http://github.com/teeworlds/teeworlds/zipball/master", help = "URL from which the teeworlds source code will be downloaded")
+arguments.add_option("-r", "--release-type", default = "server_release client_release", help = "Parts of the game which should be builded (for example client_release, debug, server_release or a combination of any of them)")
 (options, arguments) = arguments.parse_args()
-if options.url_bam == None:
-	options.url_bam = url_bam
-if options.url_teeworlds == None:
-	options.url_teeworlds = url_teeworlds
-if options.release_type == None:
-	options.release_type = release_type
 
 bam = options.url_bam[7:].split("/")
 version_bam = re.search(r"\d\.\d\.\d", bam[len(bam)-1])
@@ -78,15 +59,6 @@ print("%s-%s-%s" % (name, version_teeworlds, platform))
 
 root_dir = os.getcwd() + os.sep
 work_dir = root_dir + "scripts/work"
-
-def fetch_file(url):
-	try:
-		print("trying %s" % url)
-		local = dict(url_lib.urlopen(url).info())['content-disposition'].split('=')[1]
-		url_lib.urlretrieve(url, local)
-		return local
-	except:
-		return False
 
 def unzip(filename, where):
 	try:
@@ -157,7 +129,7 @@ os.chdir(work_dir)
 # download
 if flag_download:
 	print("*** downloading bam source package ***")
-	src_package_bam = fetch_file(options.url_bam)
+	src_package_bam = twlib.fetch_file(options.url_bam)
 	if src_package_bam:
 		if version_bam == 'trunk':
 			version = re.search(r"-[^-]*?([^-]*?)\.[^.]*$", src_package_bam)
@@ -167,7 +139,7 @@ if flag_download:
 		bail("couldn't find bam source package and couldn't download it")
 
 	print("*** downloading %s source package ***" % name)
-	src_package_teeworlds = fetch_file(options.url_teeworlds)
+	src_package_teeworlds = twlib.fetch_file(options.url_teeworlds)
 	if src_package_teeworlds:
 		if version_teeworlds == 'trunk':
 			version = re.search(r"-[^-]*?([^-]*?)\.[^.]*$", src_package_teeworlds)
@@ -271,7 +243,7 @@ if flag_make_release:
 		if not src_dir_teeworlds:
 			bail("couldn't find %s source" % name)
 	os.chdir(src_dir_teeworlds)
-	command = '"%s/%s/scripts/make_release.py" %s %s' % (work_dir, src_dir_teeworlds, version_teeworlds, platform)
+	command = '"%s/%s/scripts/make_release.py" -p "%s" -s "%s/%s" -v "%s"' % (work_dir, src_dir_teeworlds, platform, work_dir, src_dir_teeworlds, version_teeworlds)
 	if os.name != "nt":
 		command = "python %s" % command
 	if os.system(command) != 0:

--- a/scripts/copyright.py
+++ b/scripts/copyright.py
@@ -1,8 +1,5 @@
-import os, re, sys
-match = re.search('(.*)/', sys.argv[0])
-if match != None:
-	os.chdir(match.group(1))
-os.chdir('../')
+import os, sys
+os.chdir(os.path.dirname(os.path.realpath(sys.argv[0])) + "/..")
 
 notice = [b"/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */\n", b"/* If you are missing that file, acquire a complete release at teeworlds.com.                */\n"]
 exclude = ["src%sengine%sexternal" % (os.sep, os.sep), "src%sosxlaunch" % os.sep]

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -1,22 +1,31 @@
-import shutil, os, re, sys, zipfile
-if sys.version_info[0] == 2:
-	import urllib
-	url_lib = urllib
-elif sys.version_info[0] == 3:
-	import urllib.request
-	url_lib = urllib.request
+import shutil, optparse, os, re, sys, zipfile
+os.chdir(os.path.dirname(os.path.realpath(sys.argv[0])) + "/..")
+import twlib
 
-#valid_platforms = ["win32", "linux86", "linux86_64", "src"]
+arguments = optparse.OptionParser()
+arguments.add_option("-l", "--url-languages", default = "http://github.com/teeworlds/teeworlds-translation/zipball/master", help = "URL from which the teeworlds language files will be downloaded")
+arguments.add_option("-p", "--platform", help = "Target platform for the package (for example linux86, linux86_64, osx, src, win32)")
+arguments.add_option("-s", "--source-dir", help = "Source directory which is used for building the package")
+arguments.add_option("-v", "--version", help = "Version number which the package should get")
+(options, arguments) = arguments.parse_args()
+if options.platform == None:
+	print("-p, --platform needed")
+	exit(1)
+elif options.source_dir == None:
+	print("-s, --source-dir")
+	exit(1)
+elif os.path.exists(options.source_dir) == False:
+	print("Source directory " + options.source_dir + " doesn't exist")
+	exit(1)
+elif options.version == None:
+	print("-v, --version")
+	exit(1)
 
-if len(sys.argv) != 3:
-	print("wrong number of arguments")
-	print(sys.argv[0], "VERSION PLATFORM")
-	sys.exit(-1)
+#valid_platforms = ["win32", "osx", "linux86", "linux86_64", "src"]
+
+os.chdir(options.source_dir)
 
 name = "teeworlds"
-url_languages = "https://github.com/teeworlds/teeworlds-translation/zipball/master"
-version = sys.argv[1]
-platform = sys.argv[2]
 exe_ext = ""
 use_zip = 0
 use_gz = 1
@@ -26,35 +35,23 @@ include_data = True
 include_exe = True
 include_src = False
 
-if platform == "src":
-	include_data = True
-	include_exe = False
-	include_src = True
-	use_zip = 1
-	use_gz = 1
-
-#if not platform in valid_platforms:
+#if not options.platform in valid_platforms:
 #	print("not a valid platform")
 #	print(valid_platforms)
 #	sys.exit(-1)
 
-if platform == 'win32':
+if options.platform == "src":
+	include_exe = False
+	include_src = True
+	use_zip = 1
+elif options.platform == 'win32':
 	exe_ext = ".exe"
 	use_zip = 1
 	use_gz = 0
-if platform == 'osx':
+elif options.platform == 'osx':
 	use_dmg = 1
 	use_gz = 0
 	use_bundle = 1
-
-def fetch_file(url):
-	try:
-		print("trying %s" % url)
-		local = dict(url_lib.urlopen(url).info())['content-disposition'].split('=')[1]
-		url_lib.urlretrieve(url, local)
-		return local
-	except:
-		return False
 
 def unzip(filename, where):
 	try:
@@ -62,8 +59,8 @@ def unzip(filename, where):
 	except:
 		return False
 	for name in z.namelist():
-				if "/data/languages/" in name:
-						z.extract(name, where)
+		if "/data/languages/" in name:
+				z.extract(name, where)
 	z.close()
 	return z.namelist()[0]
 
@@ -81,12 +78,12 @@ def copydir(src, dst, excl=[]):
 def clean():
 	print("*** cleaning ***")
 	try:
-				shutil.rmtree(package_dir)
-				shutil.rmtree(languages_dir)
-				os.remove(src_package_languages)
+		shutil.rmtree(package_dir)
+		shutil.rmtree(languages_dir)
+		os.remove(src_package_languages)
 	except: pass
 	
-package = "%s-%s-%s" %(name, version, platform)
+package = "%s-%s-%s" %(name, options.version, options.platform)
 package_dir = package
 
 print("cleaning target")
@@ -94,14 +91,14 @@ shutil.rmtree(package_dir, True)
 os.mkdir(package_dir)
 
 print("download and extract languages")
-src_package_languages = fetch_file(url_languages)
+src_package_languages = twlib.fetch_file(options.url_languages)
 if not src_package_languages:
-		print("couldn't download languages")
-		sys.exit(-1)
+	print("couldn't download languages")
+	sys.exit(-1)
 languages_dir = unzip(src_package_languages, ".")
 if not languages_dir:
-		print("couldn't unzip languages")
-		sys.exit(-1)
+	print("couldn't unzip languages")
+	sys.exit(-1)
 
 print("adding files")
 shutil.copy("readme.txt", package_dir)
@@ -114,7 +111,7 @@ if include_data and not use_bundle:
 	os.chdir(languages_dir)
 	copydir("data", "../"+package_dir)
 	os.chdir("..")
-	if platform[:3] == "win":
+	if options.platform[:3] == "win":
 		shutil.copy("other/config_directory.bat", package_dir)
 		shutil.copy("SDL.dll", package_dir)
 		shutil.copy("freetype.dll", package_dir)
@@ -165,23 +162,23 @@ if use_bundle:
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-		<key>CFBundleDevelopmentRegion</key>
-		<string>English</string>
-		<key>CFBundleExecutable</key>
-		<string>teeworlds</string>
-		<key>CFBundleIconFile</key>
-		<string>Teeworlds</string>
-		<key>CFBundleInfoDictionaryVersion</key>
-		<string>6.0</string>
-		<key>CFBundlePackageType</key>
-		<string>APPL</string>
-		<key>CFBundleSignature</key>
-		<string>????</string>
-		<key>CFBundleVersion</key>
-		<string>%s</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>teeworlds</string>
+	<key>CFBundleIconFile</key>
+	<string>Teeworlds</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>%s</string>
 </dict>
 </plist>
-	""" % (version))
+	""" % (options.version))
 	file(os.path.join(clientbundle_content_dir, "PkgInfo"), "w").write("APPL????")
 
 	# create Teeworlds Server appfolder
@@ -204,23 +201,23 @@ if use_bundle:
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-		<key>CFBundleDevelopmentRegion</key>
-		<string>English</string>
-		<key>CFBundleExecutable</key>
-		<string>teeworlds_server</string>
-		<key>CFBundleIconFile</key>
-		<string>Teeworlds_srv</string>
-		<key>CFBundleInfoDictionaryVersion</key>
-		<string>6.0</string>
-		<key>CFBundlePackageType</key>
-		<string>APPL</string>
-		<key>CFBundleSignature</key>
-		<string>????</string>
-		<key>CFBundleVersion</key>
-		<string>%s</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>teeworlds_server</string>
+	<key>CFBundleIconFile</key>
+	<string>Teeworlds_srv</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>%s</string>
 </dict>
 </plist>
-	""" % (version))
+	""" % (options.version))
 	file(os.path.join(serverbundle_content_dir, "PkgInfo"), "w").write("APPL????")
 
 if use_zip:

--- a/scripts/twlib.py
+++ b/scripts/twlib.py
@@ -1,0 +1,16 @@
+import sys
+if sys.version_info[0] == 2:
+	import urllib
+	url_lib = urllib
+elif sys.version_info[0] == 3:
+	import urllib.request
+	url_lib = urllib.request
+
+def fetch_file(url):
+	try:
+		print("trying %s" % url)
+		local = dict(url_lib.urlopen(url).info())["content-disposition"].split("=")[1]
+		url_lib.urlretrieve(url, local)
+		return local
+	except:
+		return False


### PR DESCRIPTION
I have changed some things:
- make_release.py uses now arguments with optparse instead of sys. There are also help descriptions now for build.py and make_release.py (which can be called with -h, --help or on missing required arguments). This makes a direct call to make_release.py easier to understand.
- I have excluded fetch_file() to twlib.py. This is because this function was used multiple times by scripts. The idea of twlib.py is to be a place for generic functions for all scripts which could be usefull. This way the maintenance should be easier (in the future some of the other functions could be excluded to this place too).
- I have removed some whitespaces which have broken some indentions. I'm wondering a little about this because I remember of a commit which should already do this.

Changes to the first pull request:
- Checking for the existence of the source directory in make_release.py.

If my commit will be used I have a question: What is with make_src.py because make_release.py is able too to create a source package archive too?
