### PR TITLE
Clang build on OS X.

### DIFF
--- a/configure.lua
+++ b/configure.lua
@@ -376,6 +376,8 @@ function OptCCompiler(name, default_driver, default_c, default_cxx, desc)
 			SetDriversCL(settings)
 		elseif option.driver == "gcc" then
 			SetDriversGCC(settings)
+		elseif option.driver == "clang" then
+			SetDriversClang(settings)
 		else
 			error(option.driver.." is not a known c/c++ compile driver")
 		end
@@ -393,7 +395,7 @@ function OptCCompiler(name, default_driver, default_c, default_cxx, desc)
 	local printhelp = function(option)
 		local a = ""
 		if option.desc then a = "for "..option.desc end
-		print("\t"..option.name.."=gcc|cl")
+		print("\t"..option.name.."=gcc|cl|clang")
 		print("\t\twhat c/c++ compile driver to use"..a)
 		print("\t"..option.name..".c=FILENAME")
 		print("\t\twhat c compiler executable to use"..a)


### PR DESCRIPTION
- The first commit is straight-forward, and depends on a related [bam pull request](https://github.com/matricks/bam/pull/39).
- The second commit is more a discussion point. Simply not setting the SDK path works dandy on Xcode 4.3. Is there a particular reason it's set? I was under the impression that the latest SDK is always recommended, and simply setting `macosx-version-min` is enough to gain compatibility.
