### PR TITLE
RFC physically correct projectile start velocity

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -323,6 +323,8 @@ void CCharacter::FireWeapon()
 
 		case WEAPON_GUN:
 		{
+			Direction.x += m_Core.m_Vel.x / GameServer()->Tuning()->m_GunSpeed * Server()->TickSpeed();
+			Direction.y += m_Core.m_Vel.y / GameServer()->Tuning()->m_GunSpeed * Server()->TickSpeed();
 			CProjectile *pProj = new CProjectile(GameWorld(), WEAPON_GUN,
 				m_pPlayer->GetCID(),
 				ProjStartPos,
@@ -347,6 +349,8 @@ void CCharacter::FireWeapon()
 		case WEAPON_SHOTGUN:
 		{
 			int ShotSpread = 2;
+			Direction.x += m_Core.m_Vel.x / GameServer()->Tuning()->m_ShotgunSpeed * Server()->TickSpeed();
+			Direction.y += m_Core.m_Vel.y / GameServer()->Tuning()->m_ShotgunSpeed * Server()->TickSpeed();
 
 			CMsgPacker Msg(NETMSGTYPE_SV_EXTRAPROJECTILE);
 			Msg.AddInt(ShotSpread*2+1);
@@ -380,6 +384,8 @@ void CCharacter::FireWeapon()
 
 		case WEAPON_GRENADE:
 		{
+			Direction.x += m_Core.m_Vel.x / GameServer()->Tuning()->m_GrenadeSpeed * Server()->TickSpeed();
+			Direction.y += m_Core.m_Vel.y / GameServer()->Tuning()->m_GrenadeSpeed * Server()->TickSpeed();
 			CProjectile *pProj = new CProjectile(GameWorld(), WEAPON_GRENADE,
 				m_pPlayer->GetCID(),
 				ProjStartPos,


### PR DESCRIPTION
The current teeworlds projectile velocity is calculated exclusively by
the tunables *Speed. This patch adds the tee's velocity to the
projectile. This has an big impact on the game, so it's a RFC merge
request. However this will give the player more opportunities to shoot
projectiles, but it is more difficult to handle because the projectiles don't
fly in the aimed direction.

Signed-off-by: Markus Pargmann mpargmann@allfex.org
