### PR TITLE
Fixed a missing check if killer is alive in tdm

### DIFF
--- a/src/game/server/gamemodes/tdm.cpp
+++ b/src/game/server/gamemodes/tdm.cpp
@@ -17,7 +17,7 @@ int CGameControllerTDM::OnCharacterDeath(class CCharacter *pVictim, class CPlaye
 	IGameController::OnCharacterDeath(pVictim, pKiller, Weapon);
 
 
-	if(Weapon != WEAPON_GAME)
+	if(pKiller && Weapon != WEAPON_GAME)
 	{
 		// do team scoring
 		if(pKiller == pVictim->GetPlayer() || pKiller->GetTeam() == pVictim->GetPlayer()->GetTeam())


### PR DESCRIPTION
In gametype TDM servers can crash if a player kills another player and leaves the server quickly.
