### PR TITLE
Loading map with invalid version crashes editor

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -711,6 +711,11 @@ void CEditor::CallbackOpenMap(const char *pFileName, int StorageType, void *pUse
 		pEditor->m_Dialog = DIALOG_NONE;
 		pEditor->m_Map.m_Modified = false;
 	}
+	else
+	{
+		pEditor->Reset();
+		pEditor->m_aFileName[0] = 0;
+	}
 }
 void CEditor::CallbackAppendMap(const char *pFileName, int StorageType, void *pUser)
 {

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -435,6 +435,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 		editor->reset();
 		editor_load_old(df, this);
 		*/
+		return 0;
 	}
 	else if(pItem->m_Version == 1)
 	{
@@ -650,6 +651,8 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 			}
 		}
 	}
+	else
+		return 0;
 
 	return 1;
 }


### PR DESCRIPTION
CEditorMap::Load returned true in some cases even if the map failed to load. CEditor::CallbackOpenMap didn't reset in case of a failed load.

In particular the editor checks MAPITEMTYPE_VERSION in the datafile to be 1 but just continues if it isn't (or if this item isn't even in the file) whereas the game itself doesn't use this item at all. It seems to have been used to distinguish the current map format from an older one (see CEditorMap::Load, game/editor/io.cpp:420)

This patch just gets rid of the crash (the map loading dialog will just stay open). It might be better to get rid of this version item along with the (mostly commented out) legacy code.

The patch is based on the 0.6 branch but the same problem exists in the development branch too.
