### PR TITLE
Fixed spelling in src/engine/docs/snapshots.txt

### DIFF
--- a/src/engine/docs/snapshots.txt
+++ b/src/engine/docs/snapshots.txt
@@ -33,7 +33,7 @@ Section: In depth
 
 Topic: Compression
 
-After a snapshot have been created, compression is applyed to reduce the bandwidth. There are several steps taken inorder to reduce the size of the size of the snapshot.
+After a snapshot have been created, compression is applied to reduce the bandwidth. There are several steps taken in order to reduce the size of the snapshot.
 
 - *Delta*. The server looks in a clients backlog of snapshots to find a previous acked snapshot. It then compares the two snapshots and creates a delta snapshot containing the changes from the previous acked snapshot to the new one.
 - *Variable Integers*. The delta snapshot which is only consisting of 32-bit integers is then encoded into variable integers similar to UTF-8. Each byte has a bit that tells the decoder that it needs one more byte to decode the 32-bit integer. The first byte also contains a bit for telling the sign of the integer.
@@ -48,11 +48,11 @@ After a snapshot have been created, compression is applyed to reduce the bandwid
 
 Topic: Interval
 
-The interval for how often a client recives a snapshot changes during the course of the connection. There are three different snapshot rates.
+The interval for how often a client receives a snapshot changes during the course of the connection. There are three different snapshot rates.
 
-- *Init*. 5 snapshots per second. Used when a client is connecting and used until the client has acknowlaged a snapshot. This mechanism is used because the first snapshot because no delta compression can be done.
+- *Init*. 5 snapshots per second. Used when a client is connecting and used until the client has acknowledged a snapshot. This mechanism is used because delta compression can not be applied to the first snapshot.
 
 - *Full*. Snapshot for every tick or every even tick depending on server configuration. This is used during normal gameplay and everything is running smooth.
 
-- *Recovery*. 1 snapshot each second. A client enters recovery rate when it havn't acknowlaged a snapshot over 1 second. This is to let the client to beable to recover if it has a slow connection.
+- *Recovery*. 1 snapshot each second. A client enters recovery rate when it haven't acknowledged a snapshot over 1 second. This is to let the client to be able to recover if it has a slow connection.
 


### PR DESCRIPTION
Fixed spelling in /src/engine/docs/snapshots.txt
I am not a native speaker so I may have added new spelling mistakes on my own.
