### PR TITLE
IPV6 fix

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -781,7 +781,9 @@ int net_addr_from_str(NETADDR *addr, const char *string)
 				return -1;
 		}
 #else
-		if(inet_pton(AF_INET6, buf, &sa6) != 1)
+		sa6.sin6_family = AF_INET6;
+
+		if(inet_pton(AF_INET6, buf, &sa6.sin6_addr) != 1)
 			return -1;
 #endif
 		sockaddr_to_netaddr((struct sockaddr *)&sa6, addr);


### PR DESCRIPTION
The client can't connect using ipv6 because net_addr_from_str() is broken. (net_addr_from_str() hasn't been used for connecting in 0.6.*)

inet_pton() is being used wrong:
https://github.com/teeworlds/teeworlds/blob/master/src/base/system.c#L784

man:
int inet_pton(int af, const char *src, void *dst);

"src points to a character string containing an IPv6 network address. The address is converted to a struct in6_addr and copied to dst, which must be sizeof(struct in6_addr) (16) bytes (128 bits) long. The allowed formats for IPv6 addresses follow these rules: [...]"
