### PR TITLE
Masterserver firewall error report delay

### DIFF
--- a/src/mastersrv/mastersrv.cpp
+++ b/src/mastersrv/mastersrv.cpp
@@ -530,9 +530,10 @@ int main(int argc, const char **argv) // ignore_convention
 			LastBuild = time_get();
 
 			PurgeServers();
-			UpdateServers();
 			BuildPackets();
 		}
+
+		UpdateServers();
 
 		// be nice to the CPU
 		thread_sleep(1);


### PR DESCRIPTION
When a server trys to register with the master the master checks wether people can connect to the server.
This takes around 60 seconds with the current code because the function UpdateServers() isn't called every tick but every 5 seconds, which is wrong.
Just look at the function UpdateServers() and you'll see that it has it's own timer so it can be run every tick.
After this patch the time will be reduced to approximately 10 seconds.

The master server from minus (master3) has been running with this patch for a while now.