### PR TITLE
Using tile skip

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -36,6 +36,8 @@ enum
 
 	DIALOG_NONE=0,
 	DIALOG_FILE,
+
+	MAX_SKIP=(1<<8)-1
 };
 
 struct CEntity
@@ -438,6 +440,8 @@ public:
 	CColor m_Color;
 	int m_ColorEnv;
 	int m_ColorEnvOffset;
+	CTile *m_pSaveTiles;
+	int m_SaveTilesSize;
 	CTile *m_pTiles;
 	int m_SelectedRuleSet;
 	int m_SelectedAmount;

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -323,7 +323,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				Item.m_Height = pLayer->m_Height;
 				Item.m_Flags = pLayer->m_Game ? TILESLAYERFLAG_GAME : 0;
 				Item.m_Image = pLayer->m_Image;
-				Item.m_Data = df.AddData(pLayer->m_Width*pLayer->m_Height*sizeof(CTile), pLayer->m_pTiles);
+				Item.m_Data = df.AddData(pLayer->m_SaveTilesSize, pLayer->m_pSaveTiles);
 
 				// save layer name
 				StrToInts(Item.m_aName, sizeof(Item.m_aName)/sizeof(int), pLayer->m_aName);


### PR DESCRIPTION
Using this little optimization, maps' sizes already change significantly. These optimizations were made:

```
ctf1: -0.7%
ctf2: 10.0%
ctf3: 4.4%
ctf4: 16.5%
ctf5: 34.6%
ctf6: 21.3%
ctf7: 0.6%
dm1: 3.4%
dm2: 6.9%
dm6: 5.4%
dm7: 16.7%
dm8: 0.9%
dm9: -0.8%
```

Note that the bigger the map's dimensions, the more useful is this tile skip.
For example, with a real big map like `NUT_race9` a improvement of 25.9%, despite it has embedded images.

The optimization works by skipping tiles of the same type and rotation, which means that layers with lots of empty space (which is not that uncommon on bigger maps), it can reduce up to 256 tiles into one.

Not to be merged yet, want some feedback first. Still missing are map loading and compatiblity.
