### PR TITLE
ft: correctly include FreeType

### DIFF
--- a/other/freetype/freetype.lua
+++ b/other/freetype/freetype.lua
@@ -23,14 +23,11 @@ FreeType = {
 		end
 		
 		local apply = function(option, settings)
-			-- include path
-			settings.cc.includes:Add(FreeType.basepath .. "/include")
-			
 			if option.use_ftconfig == true then
 				settings.cc.flags:Add("`freetype-config --cflags`")
 				settings.link.flags:Add("`freetype-config --libs`")
-				
 			elseif option.use_winlib > 0 then
+				settings.cc.includes:Add(FreeType.basepath .. "/include")
 				if option.use_winlib == 32 then
 					settings.link.libpath:Add(FreeType.basepath .. "/lib32")
 				else


### PR DESCRIPTION
We shouldn't include bundled freetype libs if we found freetype-config

Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
