### PR TITLE
Fix vector2_base::operator!=

### DIFF
--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -41,7 +41,7 @@ public:
 	const vector2_base &operator /=(const vector2_base &v) { x /= v.x; y /= v.y; return *this; }
 
 	bool operator ==(const vector2_base &v) const { return x == v.x && y == v.y; } //TODO: do this with an eps instead
-	bool operator !=(const vector2_base &v) const { return x != v.y || y != v.y; }
+	bool operator !=(const vector2_base &v) const { return x != v.x || y != v.y; }
 
 	operator const T* () { return &x; }
 };


### PR DESCRIPTION
Previously it compared the x coordinate of the one vector with the y coordinate
of the other vector.
