### PR TITLE
fix different hook strengths bug

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -16,7 +16,6 @@
 #include <engine/textrender.h>
 #include <engine/shared/config.h>
 
-#include <game/version.h>
 #include <game/generated/protocol.h>
 
 #include <game/generated/client_data.h>

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -11,7 +11,6 @@
 #include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
 
-#include <game/version.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
 #include <game/client/components/countryflags.h>

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -5,7 +5,6 @@
 
 #include <engine/shared/config.h>
 
-#include <game/version.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
 
@@ -134,7 +133,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 		UI()->DoLabelScaled(&Version, aBuf, 14.0f, 0);
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 	}
-	UI()->DoLabelScaled(&Version, GAME_VERSION, 14.0f, 1);	
+	UI()->DoLabelScaled(&Version, m_pClient->Version(), 14.0f, 1);	
 }
 
 void CMenus::RenderLogo(CUIRect MainView)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -433,6 +433,7 @@ void CGameClient::EvolveCharacter(CNetObj_Character *pCharacter, int Tick)
 	{
 		pCharacter->m_Tick++;
 		TempCore.Tick(false);
+		TempCore.PostTick();
 		TempCore.Move();
 		TempCore.Quantize();
 	}
@@ -1268,6 +1269,7 @@ void CGameClient::OnPredict()
 			if(!World.m_apCharacters[c])
 				continue;
 
+			World.m_apCharacters[c]->PostTick();
 			World.m_apCharacters[c]->Move();
 			World.m_apCharacters[c]->Quantize();
 		}

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -92,27 +92,30 @@ inline vec2 CalcPos(vec2 Pos, vec2 Velocity, float Curvature, float Speed, float
 	return n;
 }
 
-
+// Saturated adds Modifier on Current
+// Returns the difference between new and old value
 template<typename T>
 inline T SaturatedAdd(T Min, T Max, T Current, T Modifier)
 {
+	T Old = Current;
+
 	if(Modifier < 0)
 	{
 		if(Current < Min)
-			return Current;
+			return Current - Old;
 		Current += Modifier;
 		if(Current < Min)
 			Current = Min;
-		return Current;
+		return Current - Old;
 	}
 	else
 	{
 		if(Current > Max)
-			return Current;
+			return Current - Old;
 		Current += Modifier;
 		if(Current > Max)
 			Current = Max;
-		return Current;
+		return Current - Old;
 	}
 }
 
@@ -149,6 +152,7 @@ class CCharacterCore
 public:
 	vec2 m_Pos;
 	vec2 m_Vel;
+	vec2 m_VelDiff; // caused by external forces, applied on posttick
 
 	vec2 m_HookPos;
 	vec2 m_HookDir;
@@ -167,6 +171,7 @@ public:
 	void Init(CWorldCore *pWorld, CCollision *pCollision);
 	void Reset();
 	void Tick(bool UseInput);
+	void PostTick();
 	void Move();
 
 	void Read(const CNetObj_CharacterCore *pObjCore);

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -580,11 +580,13 @@ void CCharacter::TickDefered()
 		CWorldCore TempWorld;
 		m_ReckoningCore.Init(&TempWorld, GameServer()->Collision());
 		m_ReckoningCore.Tick(false);
+		m_ReckoningCore.PostTick();
 		m_ReckoningCore.Move();
 		m_ReckoningCore.Quantize();
 	}
 
 	//lastsentcore
+	m_Core.PostTick();
 	vec2 StartPos = m_Core.m_Pos;
 	vec2 StartVel = m_Core.m_Vel;
 	bool StuckBefore = GameServer()->Collision()->TestBox(m_Core.m_Pos, vec2(28.0f, 28.0f));


### PR DESCRIPTION
Hook strength currently depends on player id (lower id has stronger hook on higher id)
To fix this the velocity change caused by the hook has to be applied after the tick.

Also cleanup some comments and deadcode, and removed unnecessary dependencies on version.h