### PR TITLE
Fix walking animation

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -265,7 +265,12 @@ void CPlayers::RenderPlayer(
 	bool WantOtherDir = (Player.m_Direction == -1 && Vel.x > 0) || (Player.m_Direction == 1 && Vel.x < 0);
 
 	// evaluate animation
-	float WalkTime = fmod(absolute(Position.x), 100.0f)/100.0f;
+	const float WalkTimeMagic = 100.0f;
+	float WalkTime =
+		((Position.x >= 0)
+			? fmod(Position.x, WalkTimeMagic)
+			: WalkTimeMagic - fmod(-Position.x, WalkTimeMagic))
+		/ WalkTimeMagic;
 	CAnimState State;
 	State.Set(&g_pData->m_aAnimations[ANIM_BASE], 0);
 


### PR DESCRIPTION
Previously, when walking with negative x-coordinate, your walking direction was
inversed.

**EDIT:** This fixes #1153.
