### PR TITLE
Fixed Mapchecker, search subdirectorys for valid standard map

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1176,16 +1176,11 @@ char *CServer::GetMapName()
 
 int CServer::LoadMap(const char *pMapName)
 {
-	//DATAFILE *df;
 	char aBuf[512];
 	str_format(aBuf, sizeof(aBuf), "maps/%s.map", pMapName);
-
-	/*df = datafile_load(buf);
-	if(!df)
-		return 0;*/
-
+	
 	// check for valid standard map
-	if(!m_MapChecker.ReadAndValidateMap(Storage(), aBuf, IStorage::TYPE_ALL))
+	if(!m_MapChecker.ReadAndValidateMap(Storage(), aBuf, IStorage::TYPE_ALL, aBuf, sizeof(aBuf)))
 	{
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "mapchecker", "invalid standard map");
 		return 0;

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -224,32 +224,6 @@ bool CDataFileReader::Open(class IStorage *pStorage, const char *pFilename, int 
 	return true;
 }
 
-bool CDataFileReader::GetCrcSize(class IStorage *pStorage, const char *pFilename, int StorageType, unsigned *pCrc, unsigned *pSize)
-{
-	IOHANDLE File = pStorage->OpenFile(pFilename, IOFLAG_READ, StorageType);
-	if(!File)
-		return false;
-
-	// get crc and size
-	unsigned Crc = 0;
-	unsigned Size = 0;
-	unsigned char aBuffer[64*1024];
-	while(1)
-	{
-		unsigned Bytes = io_read(File, aBuffer, sizeof(aBuffer));
-		if(Bytes <= 0)
-			break;
-		Crc = crc32(Crc, aBuffer, Bytes); // ignore_convention
-		Size += Bytes;
-	}
-
-	io_close(File);
-
-	*pCrc = Crc;
-	*pSize = Size;
-	return true;
-}
-
 int CDataFileReader::NumData()
 {
 	if(!m_pDataFile) { return 0; }

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -17,8 +17,6 @@ public:
 	bool Open(class IStorage *pStorage, const char *pFilename, int StorageType);
 	bool Close();
 
-	static bool GetCrcSize(class IStorage *pStorage, const char *pFilename, int StorageType, unsigned *pCrc, unsigned *pSize);
-
 	void *GetData(int Index);
 	void *GetDataSwapped(int Index); // makes sure that the data is 32bit LE ints when saved
 	int GetDataSize(int Index);

--- a/src/engine/shared/mapchecker.cpp
+++ b/src/engine/shared/mapchecker.cpp
@@ -82,16 +82,10 @@ bool CMapChecker::ReadAndValidateMap(IStorage *pStorage, const char *pFilename, 
 	{
 		if(str_comp(pCurrent->m_aMapName, aMapName) == 0)
 		{
-			dbg_msg("DEBUG", "CHECKING MAP: %s", aMapName);
 			char aBuffer[512]; // TODO: MAX_PATH_LENGTH (512) should be defined in a more central header and not in storage.cpp and editor.h
 			bool CrcSizeMatch = false;
 			if(!pStorage->FindFile(aMapNameExt, "maps", StorageType, aBuffer, sizeof(aBuffer), pCurrent->m_MapCrc, pCurrent->m_MapSize, &CrcSizeMatch))
-			{
-				dbg_msg("DEBUG", "FindFile returned false");
 				return true;
-			}
-			
-			dbg_msg("DEBUG", "FindFile returned true, CrcSizeMatch: %s", CrcSizeMatch ? "y" : "n");
 			
 			// output filename
 			if(pBuffer != 0 && BufferSize > 0)

--- a/src/engine/shared/mapchecker.cpp
+++ b/src/engine/shared/mapchecker.cpp
@@ -8,8 +8,6 @@
 #include <versionsrv/versionsrv.h>
 #include <versionsrv/mapversions.h>
 
-#include "datafile.h"
-#include "memheap.h"
 #include "mapchecker.h"
 
 CMapChecker::CMapChecker()
@@ -50,30 +48,20 @@ void CMapChecker::AddMaplist(CMapVersion *pMaplist, int Num)
 
 bool CMapChecker::IsMapValid(const char *pMapName, unsigned MapCrc, unsigned MapSize)
 {
-	return true;
-	/*bool StandardMap = false;
 	for(CWhitelistEntry *pCurrent = m_pFirst; pCurrent; pCurrent = pCurrent->m_pNext)
 	{
-		if(str_comp(pCurrent->m_aMapName, pMapName) == 0)
-		{
-			StandardMap = true;
-			if(pCurrent->m_MapCrc == MapCrc && pCurrent->m_MapSize == MapSize)
-				return true;
-		}
+		if(str_comp(pCurrent->m_aMapName, pMapName) == 0 && pCurrent->m_MapCrc == MapCrc && pCurrent->m_MapSize == MapSize)
+			return true;
 	}
-	return StandardMap?false:true;*/
+	
+	return false;
 }
 
-bool CMapChecker::ReadAndValidateMap(IStorage *pStorage, const char *pFilename, int StorageType)
+bool CMapChecker::ReadAndValidateMap(IStorage *pStorage, const char *pFilename, int StorageType, char *pBuffer, int BufferSize)
 {
-	return true;
-	/*bool LoadedMapInfo = false;
-	bool StandardMap = false;
-	unsigned MapCrc = 0;
-	unsigned MapSize = 0;
-
 	// extract map name
 	char aMapName[MAX_MAP_LENGTH];
+	char aMapNameExt[MAX_MAP_LENGTH+4];
 	const char *pExtractedName = pFilename;
 	const char *pEnd = 0;
 	for(const char *pSrc = pFilename; *pSrc; ++pSrc)
@@ -87,23 +75,31 @@ bool CMapChecker::ReadAndValidateMap(IStorage *pStorage, const char *pFilename, 
 	if(Length <= 0 || Length >= MAX_MAP_LENGTH)
 		return true;
 	str_copy(aMapName, pExtractedName, min((int)MAX_MAP_LENGTH, (int)(pEnd-pExtractedName+1)));
+	str_format(aMapNameExt, sizeof(aMapNameExt), "%s.map", aMapName);
 
 	// check for valid map
 	for(CWhitelistEntry *pCurrent = m_pFirst; pCurrent; pCurrent = pCurrent->m_pNext)
 	{
 		if(str_comp(pCurrent->m_aMapName, aMapName) == 0)
 		{
-			StandardMap = true;
-			if(!LoadedMapInfo)
+			dbg_msg("DEBUG", "CHECKING MAP: %s", aMapName);
+			char aBuffer[512]; // TODO: MAX_PATH_LENGTH (512) should be defined in a more central header and not in storage.cpp and editor.h
+			bool CrcSizeMatch = false;
+			if(!pStorage->FindFile(aMapNameExt, "maps", StorageType, aBuffer, sizeof(aBuffer), pCurrent->m_MapCrc, pCurrent->m_MapSize, &CrcSizeMatch))
 			{
-				if(!CDataFileReader::GetCrcSize(pStorage, pFilename, StorageType, &MapCrc, &MapSize))
-					return true;
-				LoadedMapInfo = true;
-			}
-
-			if(pCurrent->m_MapCrc == MapCrc && pCurrent->m_MapSize == MapSize)
+				dbg_msg("DEBUG", "FindFile returned false");
 				return true;
+			}
+			
+			dbg_msg("DEBUG", "FindFile returned true, CrcSizeMatch: %s", CrcSizeMatch ? "y" : "n");
+			
+			// output filename
+			if(pBuffer != 0 && BufferSize > 0)
+				str_format(pBuffer, BufferSize, "%s", aBuffer);
+				
+			return CrcSizeMatch;
 		}
 	}
-	return StandardMap?false:true;*/
+	
+	return false;
 }

--- a/src/engine/shared/mapchecker.h
+++ b/src/engine/shared/mapchecker.h
@@ -32,7 +32,7 @@ public:
 	CMapChecker();
 	void AddMaplist(struct CMapVersion *pMaplist, int Num);
 	bool IsMapValid(const char *pMapName, unsigned MapCrc, unsigned MapSize);
-	bool ReadAndValidateMap(class IStorage *pStorage, const char *pFilename, int StorageType);
+	bool ReadAndValidateMap(class IStorage *pStorage, const char *pFilename, int StorageType, char *pBuffer = 0, int BufferSize = 0);
 };
 
 #endif

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -323,30 +323,27 @@ public:
 			if(Data->pBuffer[0])
 				return 1;
 		}
-		else
+		else if(!str_comp(pName, Data->pFilename))
 		{
-			if(!str_comp(pName, Data->pFilename))
+			// found the file
+			str_format(Data->pBuffer, Data->BufferSize, "%s/%s", Data->pPath, Data->pFilename);
+			
+			// check crc and size
+			if(Data->pCrcSizeMatch != 0)
 			{
-				// found the file
-				str_format(Data->pBuffer, Data->BufferSize, "%s/%s", Data->pPath, Data->pFilename);
-				
-				// check crc and size
-				if(Data->pCrcSizeMatch != 0)
+				unsigned Crc = 0;
+				unsigned Size = 0;
+				if(!Data->pStorage->GetCrcSize(Data->pBuffer, Type, &Crc, &Size) || Crc != Data->WantedCrc || Size != Data->WantedSize)
 				{
-					unsigned Crc = 0;
-					unsigned Size = 0;
-					if(!Data->pStorage->GetCrcSize(Data->pBuffer, Type, &Crc, &Size) || Crc != Data->WantedCrc || Size != Data->WantedSize)
-					{
-						*Data->pCrcSizeMatch = false;
-						Data->pBuffer[0] = 0;
-						return 0;
-					}
-					else
-						*Data->pCrcSizeMatch = true;
+					*Data->pCrcSizeMatch = false;
+					Data->pBuffer[0] = 0;
+					return 0;
 				}
-				
-				return 1;
+				else
+					*Data->pCrcSizeMatch = true;
 			}
+			
+			return 1;
 		}
 
 		return 0;

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -296,51 +296,51 @@ public:
 
 	struct CFindCBData
 	{
-		CStorage *pStorage;
-		const char *pFilename;
-		const char *pPath;
-		char *pBuffer;
-		int BufferSize;
-		unsigned WantedCrc;
-		unsigned WantedSize;
-		bool *pCrcSizeMatch;
+		CStorage *m_pStorage;
+		const char *m_pFilename;
+		const char *m_pPath;
+		char *m_pBuffer;
+		int m_BufferSize;
+		unsigned m_WantedCrc;
+		unsigned m_WantedSize;
+		bool *m_pCrcSizeMatch;
 	};
 
 	static int FindFileCallback(const char *pName, int IsDir, int Type, void *pUser)
 	{
-		CFindCBData *Data = static_cast<CFindCBData *>(pUser);
+		CFindCBData *pData = static_cast<CFindCBData *>(pUser);
 		if(IsDir)
 		{
 			if(pName[0] == '.')
 				return 0;
-				
+
 			// search within the folder
 			char aBuf[MAX_PATH_LENGTH];
 			char aPath[MAX_PATH_LENGTH];
-			str_format(aPath, sizeof(aPath), "%s/%s", Data->pPath, pName);
-			Data->pPath = aPath;
-			fs_listdir(Data->pStorage->GetPath(Type, aPath, aBuf, sizeof(aBuf)), FindFileCallback, Type, Data);
-			if(Data->pBuffer[0])
+			str_format(aPath, sizeof(aPath), "%s/%s", pData->m_pPath, pName);
+			pData->m_pPath = aPath;
+			fs_listdir(pData->m_pStorage->GetPath(Type, aPath, aBuf, sizeof(aBuf)), FindFileCallback, Type, pData);
+			if(pData->m_pBuffer[0])
 				return 1;
 		}
-		else if(!str_comp(pName, Data->pFilename))
+		else if(!str_comp(pName, pData->m_pFilename))
 		{
 			// found the file
-			str_format(Data->pBuffer, Data->BufferSize, "%s/%s", Data->pPath, Data->pFilename);
+			str_format(pData->m_pBuffer, pData->m_BufferSize, "%s/%s", pData->m_pPath, pData->m_pFilename);
 			
 			// check crc and size
-			if(Data->pCrcSizeMatch != 0)
+			if(pData->m_pCrcSizeMatch != 0)
 			{
 				unsigned Crc = 0;
 				unsigned Size = 0;
-				if(!Data->pStorage->GetCrcSize(Data->pBuffer, Type, &Crc, &Size) || Crc != Data->WantedCrc || Size != Data->WantedSize)
+				if(!pData->m_pStorage->GetCrcSize(pData->m_pBuffer, Type, &Crc, &Size) || Crc != pData->m_WantedCrc || Size != pData->m_WantedSize)
 				{
-					*Data->pCrcSizeMatch = false;
-					Data->pBuffer[0] = 0;
+					*pData->m_pCrcSizeMatch = false;
+					pData->m_pBuffer[0] = 0;
 					return 0;
 				}
 				else
-					*Data->pCrcSizeMatch = true;
+					*pData->m_pCrcSizeMatch = true;
 			}
 			
 			return 1;
@@ -349,24 +349,24 @@ public:
 		return 0;
 	}
 
-	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize, unsigned WantedCrc, unsigned WantedSize, bool *pCrcSizeMatch)
+	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize, unsigned WantedCrc = 0, unsigned WantedSize = 0, bool *pCrcSizeMatch = 0)
 	{
 		if(BufferSize < 1)
 			return false;
-		
+
 		pBuffer[0] = 0;
 		*pCrcSizeMatch = false;
 		
 		char aBuf[MAX_PATH_LENGTH];
 		CFindCBData Data;
-		Data.pStorage = this;
-		Data.pFilename = pFilename;
-		Data.pPath = pPath;
-		Data.pBuffer = pBuffer;
-		Data.BufferSize = BufferSize;
-		Data.WantedCrc = WantedCrc;
-		Data.WantedSize = WantedSize;
-		Data.pCrcSizeMatch = pCrcSizeMatch;
+		Data.m_pStorage = this;
+		Data.m_pFilename = pFilename;
+		Data.m_pPath = pPath;
+		Data.m_pBuffer = pBuffer;
+		Data.m_BufferSize = BufferSize;
+		Data.m_WantedCrc = WantedCrc;
+		Data.m_WantedSize = WantedSize;
+		Data.m_pCrcSizeMatch = pCrcSizeMatch;
 		
 		if(Type == TYPE_ALL)
 		{

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -355,7 +355,8 @@ public:
 			return false;
 
 		pBuffer[0] = 0;
-		*pCrcSizeMatch = false;
+		if(pCrcSizeMatch != 0)
+			*pCrcSizeMatch = false;
 		
 		char aBuf[MAX_PATH_LENGTH];
 		CFindCBData Data;

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -21,11 +21,12 @@ public:
 
 	virtual void ListDirectory(int Type, const char *pPath, FS_LISTDIR_CALLBACK pfnCallback, void *pUser) = 0;
 	virtual IOHANDLE OpenFile(const char *pFilename, int Flags, int Type, char *pBuffer = 0, int BufferSize = 0) = 0;
-	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize) = 0;
+	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize, unsigned WantedCrc = 0, unsigned WantedSize = 0, bool *pCrcSizeMatch = 0) = 0;
 	virtual bool RemoveFile(const char *pFilename, int Type) = 0;
 	virtual bool RenameFile(const char* pOldFilename, const char* pNewFilename, int Type) = 0;
 	virtual bool CreateFolder(const char *pFoldername, int Type) = 0;
 	virtual void GetCompletePath(int Type, const char *pDir, char *pBuffer, unsigned BufferSize) = 0;
+	virtual bool GetCrcSize(const char *pFilename, int StorageType, unsigned *pCrc, unsigned *pSize) = 0;
 };
 
 extern IStorage *CreateStorage(const char *pApplicationName, int StorageType, int NumArgs, const char **ppArguments);


### PR DESCRIPTION
Fixes #1052.

Had to change some storage-engine parts, so that it can search for files not only by comparing names but also by comparing the crc and size (name is still checked first).