### PR TITLE
Scale was always 0 causing Kerning not to be applied

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -593,7 +593,7 @@ public:
 		pSizeData = GetSize(pFont, ActualSize);
 		RenderSetup(pFont, ActualSize);
 
-		float Scale = 1/pSizeData->m_FontSize;
+		float Scale = 1.0f/pSizeData->m_FontSize;
 
 		// set length
 		if(Length < 0)


### PR DESCRIPTION
int / int = int. 1/x was rounded to 0.
