### PR TITLE
Add Spacebar for toggling Play/Pause in demo player

### DIFF
--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -143,6 +143,19 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 
 	bool IncreaseDemoSpeed = false, DecreaseDemoSpeed = false;
 
+	//add spacebar for toggling Play/Pause
+	if(Input()->KeyDown(KEY_SPACE))
+	{
+		if(!pInfo->m_Paused)
+		{
+			DemoPlayer()->Pause();
+		}
+		else
+		{
+			DemoPlayer()->Unpause();
+		}
+	}
+	
 	if(m_MenuActive)
 	{
 		// do buttons


### PR DESCRIPTION
This may close #1268
Pressing the spacebar will now swich between play/pause in demoplayer