### PR TITLE
Make seek bar in demo player toggable/hide automatically

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -53,6 +53,8 @@ CMenus::CMenus()
 	m_RefreshSkinSelector = true;
 	m_pSelectedSkin = 0;
 	m_MenuActive = true;
+	m_SeekBarActivatedTick = 0;
+	m_SeekBarActive = true;
 	m_UseMouseButtons = true;
 
 	m_MenuPage = PAGE_START;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -18,7 +18,7 @@
 #include "skins.h"
 
 
-// compnent to fetch keypresses, override all other input
+// component to fetch keypresses, override all other input
 class CMenusKeyBinder : public CComponent
 {
 public:
@@ -249,6 +249,8 @@ class CMenus : public CComponent
 	int m_DemolistSelectedIndex;
 	bool m_DemolistSelectedIsDir;
 	int m_DemolistStorageType;
+	int m_SeekBarActivatedTick;
+	bool m_SeekBarActive;
 
 	void DemolistOnUpdate(bool Reset);
 	void DemolistPopulate();

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -48,7 +48,8 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	MainView.VSplitLeft(50.0f, 0, &MainView);
 	MainView.VSplitRight(450.0f, &MainView, 0);
 
-	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_T, 10.0f);
+	if (m_SeekBarActive || m_MenuActive) // only draw the background if SeekBar or Menu is active
+		RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_T, 10.0f);
 
 	MainView.Margin(5.0f, &MainView);
 
@@ -57,15 +58,28 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	int CurrentTick = pInfo->m_CurrentTick - pInfo->m_FirstTick;
 	int TotalTicks = pInfo->m_LastTick - pInfo->m_FirstTick;
 
-	if(m_MenuActive)
+	// we can toggle the seekbar using SHIFT or CTRL
+	if(Input()->KeyDown(KEY_LSHIFT) || Input()->KeyDown(KEY_RSHIFT) || Input()->KeyDown(KEY_LCTRL) || Input()->KeyDown(KEY_RCTRL))
+	{
+		if (m_SeekBarActive)
+			m_SeekBarActive = false;
+		else
+			m_SeekBarActive = true,
+			m_SeekBarActivatedTick = CurrentTick; // stores at which point of time the seekbar was activated, so we can automatically hide it after few seconds
+	}
+
+	if (m_SeekBarActivatedTick < CurrentTick - SERVER_TICK_SPEED * 3.5)
+		m_SeekBarActive = false;
+	
+	if(m_MenuActive || m_SeekBarActive)
 	{
 		MainView.HSplitTop(SeekBarHeight, &SeekBar, &ButtonBar);
 		ButtonBar.HSplitTop(Margins, 0, &ButtonBar);
 		ButtonBar.HSplitBottom(NameBarHeight, &ButtonBar, &NameBar);
 		NameBar.HSplitTop(4.0f, 0, &NameBar);
+		// causes bug which makes the seek bar fill the whole menu if (m_MenuActive && m_SeekBarActive) == true
+		/*SeekBar = MainView;*/
 	}
-	else
-		SeekBar = MainView;
 
 	// do seekbar
 	{


### PR DESCRIPTION
This closes #1267; the seekbar in demoplayer will hide after a few seconds, as described by the belonging issue.

It is tested and works fine, exactly as it is supposed to.