### PR TITLE
Adding the command save_conf that allows to save current server

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1610,6 +1610,22 @@ void str_sanitize_cc(char *str_in)
 	}
 }
 
+void str_sanitize_pathname(char* str_in)
+{
+	str_sanitize_pathname_from_character(str_in, 0);
+}
+
+void str_sanitize_pathname_from_character(char* str_in, unsigned int fromCharN)
+{
+	unsigned char *str = ((unsigned char *) str_in) + fromCharN;
+	while(*str)
+	{
+		if (*str == '\\' || *str == '/' || *str == '~')
+			*str = '-';
+		str++;
+	}
+}
+
 /* makes sure that the string only contains the characters between 32 and 255 + \r\n\t */
 void str_sanitize(char *str_in)
 {

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1610,20 +1610,16 @@ void str_sanitize_cc(char *str_in)
 	}
 }
 
-void str_sanitize_pathname(char* str_in)
+int str_safe_as_pathname(const char* str_in)
 {
-	str_sanitize_pathname_from_character(str_in, 0);
-}
-
-void str_sanitize_pathname_from_character(char* str_in, unsigned int fromCharN)
-{
-	unsigned char *str = ((unsigned char *) str_in) + fromCharN;
+	unsigned char *str = (unsigned char *)str_in;
 	while(*str)
 	{
-		if (*str == '\\' || *str == '/' || *str == '~')
-			*str = '-';
+		if (*str == '\\' || *str == '/')
+			return -1;
 		str++;
 	}
+	return 0;
 }
 
 /* makes sure that the string only contains the characters between 32 and 255 + \r\n\t */

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -815,22 +815,17 @@ void str_sanitize(char *str);
 
 /*
 	Function: str_sanitize_pathname_from_character
-		Replaces all characters '/' '\' and '~' which can lead path
-		hijacking, with '-', starting from character at position str_in fromCharN
+		Checks whether the input string contains \ or / characters, that could 
+		indicate an attempt of path hijacking.
+		Returns 0 if string is safe, -1 otherwise.
 
 	Parameters:
-		str - String to sanitize.
-		fromCharN - Positive integer of the first character to check (form 0)
+		str - String to check.
 
 	Remarks:
 		- The strings are treated as zero-terminated strings.
 */
-void str_sanitize_pathname_from_character(char* str_in, unsigned int fromCharN);
-
-/*
-	Same as the function above but starting from first character
-*/
-void str_sanitize_pathname(char* str_in);
+int str_safe_as_pathname(const char* str_in);
 
 /*
 	Function: str_clean_whitespaces

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -814,6 +814,25 @@ void str_sanitize_cc(char *str);
 void str_sanitize(char *str);
 
 /*
+	Function: str_sanitize_pathname_from_character
+		Replaces all characters '/' '\' and '~' which can lead path
+		hijacking, with '-', starting from character at position str_in fromCharN
+
+	Parameters:
+		str - String to sanitize.
+		fromCharN - Positive integer of the first character to check (form 0)
+
+	Remarks:
+		- The strings are treated as zero-terminated strings.
+*/
+void str_sanitize_pathname_from_character(char* str_in, unsigned int fromCharN);
+
+/*
+	Same as the function above but starting from first character
+*/
+void str_sanitize_pathname(char* str_in);
+
+/*
 	Function: str_clean_whitespaces
 		Removes leading and trailing spaces and limits the use of multiple spaces.
 

--- a/src/engine/config.h
+++ b/src/engine/config.h
@@ -4,6 +4,7 @@
 #define ENGINE_CONFIG_H
 
 #include "kernel.h"
+#include "console.h"
 
 class IConfig : public IInterface
 {
@@ -15,6 +16,7 @@ public:
 	virtual void Reset() = 0;
 	virtual void RestoreStrings() = 0;
 	virtual void Save() = 0;
+	virtual int SaveServerConfigs(const char *filename) = 0;
 
 	virtual void RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData) = 0;
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1493,6 +1493,7 @@ void CServer::ConRecord(IConsole::IResult *pResult, void *pUser)
 		str_timestamp(aDate, sizeof(aDate));
 		str_format(aFilename, sizeof(aFilename), "demos/demo_%s.demo", aDate);
 	}
+	str_sanitize_pathname_from_character(aFilename, 6);
 	pServer->m_DemoRecorder.Start(pServer->Storage(), pServer->Console(), aFilename, pServer->GameServer()->NetVersion(), pServer->m_aCurrentMap, pServer->m_CurrentMapCrc, "server");
 }
 
@@ -1513,14 +1514,15 @@ void CServer::ConSaveConfig(IConsole::IResult *pResult, void *pUser)
 	
 	char aFilename[128];
 	if(pResult->NumArguments())
-		str_format(aFilename, sizeof(aFilename), "%s.cfg", pResult->GetString(0));
+		str_format(aFilename, sizeof(aFilename), "serverconf/%s.cfg", (pResult->GetString(0)));
 	else
 	{
 		char aDate[20];
 		str_timestamp(aDate, sizeof(aDate));
-		str_format(aFilename, sizeof(aFilename), "server_config_%s.cfg", aDate);
+		str_format(aFilename, sizeof(aFilename), "serverconf/server_config_%s.cfg", aDate);
 	}
 	
+	str_sanitize_pathname_from_character(aFilename, 11);
 	char aBuf[256];
 	if (currentConfig->SaveServerConfigs(aFilename) == 0)
 	{
@@ -1628,7 +1630,7 @@ void CServer::RegisterCommands()
 
 	Console()->Register("reload", "", CFGFLAG_SERVER, ConMapReload, this, "Reload the map");
 
-	Console()->Register("save_conf", "?s", CFGFLAG_SERVER, ConSaveConfig, this, "Save current configuration to file");
+	Console()->Register("saveserverconf", "?s", CFGFLAG_SERVER, ConSaveConfig, this, "Save current configuration to file");
 
 	Console()->Chain("sv_name", ConchainSpecialInfoupdate, this);
 	Console()->Chain("password", ConchainSpecialInfoupdate, this);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1510,17 +1510,26 @@ void CServer::ConSaveConfig(IConsole::IResult *pResult, void *pUser)
 {
 	CServer *pThis = ((CServer *)pUser);
 	IConfig* currentConfig = pThis->Kernel()->RequestInterface<IConfig>();
-	const char *pFileName = pResult->GetString(0);
+	
+	char aFilename[128];
+	if(pResult->NumArguments())
+		str_format(aFilename, sizeof(aFilename), "%s.cfg", pResult->GetString(0));
+	else
+	{
+		char aDate[20];
+		str_timestamp(aDate, sizeof(aDate));
+		str_format(aFilename, sizeof(aFilename), "server_config_%s.cfg", aDate);
+	}
 	
 	char aBuf[256];
-	if (currentConfig->SaveServerConfigs(pFileName) == 0)
+	if (currentConfig->SaveServerConfigs(aFilename) == 0)
 	{
-		str_format(aBuf, sizeof(aBuf), "saved server configuration to %s", pFileName);
+		str_format(aBuf, sizeof(aBuf), "saved server configuration to %s", aFilename);
 		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 	}
 	else
 	{
-		str_format(aBuf, sizeof(aBuf), "failed to save server configuration to %s", pFileName);
+		str_format(aBuf, sizeof(aBuf), "failed to save server configuration to %s", aFilename);
 		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 	}
 }
@@ -1619,7 +1628,7 @@ void CServer::RegisterCommands()
 
 	Console()->Register("reload", "", CFGFLAG_SERVER, ConMapReload, this, "Reload the map");
 
-	Console()->Register("save_conf", "s", CFGFLAG_SERVER, ConSaveConfig, this, "Save current configuration to file");
+	Console()->Register("save_conf", "?s", CFGFLAG_SERVER, ConSaveConfig, this, "Save current configuration to file");
 
 	Console()->Chain("sv_name", ConchainSpecialInfoupdate, this);
 	Console()->Chain("password", ConchainSpecialInfoupdate, this);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1506,6 +1506,25 @@ void CServer::ConMapReload(IConsole::IResult *pResult, void *pUser)
 	((CServer *)pUser)->m_MapReload = 1;
 }
 
+void CServer::ConSaveConfig(IConsole::IResult *pResult, void *pUser)
+{
+	CServer *pThis = ((CServer *)pUser);
+	IConfig* currentConfig = pThis->Kernel()->RequestInterface<IConfig>();
+	const char *pFileName = pResult->GetString(0);
+	
+	char aBuf[256];
+	if (currentConfig->SaveServerConfigs(pFileName) == 0)
+	{
+		str_format(aBuf, sizeof(aBuf), "saved server configuration to %s", pFileName);
+		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+	}
+	else
+	{
+		str_format(aBuf, sizeof(aBuf), "failed to save server configuration to %s", pFileName);
+		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+	}
+}
+
 void CServer::ConLogout(IConsole::IResult *pResult, void *pUser)
 {
 	CServer *pServer = (CServer *)pUser;
@@ -1599,6 +1618,8 @@ void CServer::RegisterCommands()
 	Console()->Register("stoprecord", "", CFGFLAG_SERVER, ConStopRecord, this, "Stop recording");
 
 	Console()->Register("reload", "", CFGFLAG_SERVER, ConMapReload, this, "Reload the map");
+
+	Console()->Register("save_conf", "s", CFGFLAG_SERVER, ConSaveConfig, this, "Save current configuration to file");
 
 	Console()->Chain("sv_name", ConchainSpecialInfoupdate, this);
 	Console()->Chain("password", ConchainSpecialInfoupdate, this);

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -232,6 +232,7 @@ public:
 	static void ConRecord(IConsole::IResult *pResult, void *pUser);
 	static void ConStopRecord(IConsole::IResult *pResult, void *pUser);
 	static void ConMapReload(IConsole::IResult *pResult, void *pUser);
+	static void ConSaveConfig(IConsole::IResult *pResult, void *pUser);
 	static void ConLogout(IConsole::IResult *pResult, void *pUser);
 	static void ConchainSpecialInfoupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainMaxclientsperipUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -573,12 +573,20 @@ void CNetBan::ConBans(IConsole::IResult *pResult, void *pUser)
 void CNetBan::ConBansSave(IConsole::IResult *pResult, void *pUser)
 {
 	CNetBan *pThis = static_cast<CNetBan *>(pUser);
-
 	char aBuf[256];
-	IOHANDLE File = pThis->Storage()->OpenFile(pResult->GetString(0), IOFLAG_WRITE, IStorage::TYPE_SAVE);
+
+	const char *pFilename = pResult->GetString(0);
+	if (str_safe_as_pathname(pFilename) != 0)
+	{
+		str_format(aBuf, sizeof(aBuf), "failed to save server banlist: '%s' is not an allowed path", pFilename);
+		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", aBuf);
+		return;
+	}
+
+	IOHANDLE File = pThis->Storage()->OpenFile(pFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
 	if(!File)
 	{
-		str_format(aBuf, sizeof(aBuf), "failed to save banlist to '%s'", pResult->GetString(0));
+		str_format(aBuf, sizeof(aBuf), "failed to save banlist to '%s'", pFilename);
 		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", aBuf);
 		return;
 	}
@@ -604,6 +612,6 @@ void CNetBan::ConBansSave(IConsole::IResult *pResult, void *pUser)
 	}
 
 	io_close(File);
-	str_format(aBuf, sizeof(aBuf), "saved banlist to '%s'", pResult->GetString(0));
+	str_format(aBuf, sizeof(aBuf), "saved banlist to '%s'", pFilename);
 	pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", aBuf);
 }

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -68,6 +68,7 @@ public:
 				fs_makedir(GetPath(TYPE_SAVE, "dumps", aPath, sizeof(aPath)));
 				fs_makedir(GetPath(TYPE_SAVE, "demos", aPath, sizeof(aPath)));
 				fs_makedir(GetPath(TYPE_SAVE, "demos/auto", aPath, sizeof(aPath)));
+				fs_makedir(GetPath(TYPE_SAVE, "serverconf", aPath, sizeof(aPath)));
 			}
 			else
 			{


### PR DESCRIPTION
This should add the possibility of saving the server configuration using the command save_conf [filename] remotely - closes #1182  