### PR TITLE
fix network hash which was changed by a renamed function in gamecore

### DIFF
--- a/scripts/cmd5.py
+++ b/scripts/cmd5.py
@@ -30,6 +30,6 @@ for filename in sys.argv[1:]:
 
 hash = hashlib.md5(f).hexdigest().lower()[16:]
 #TODO 0.7: improve nethash creation
-if hash == "3dc531e4296de555":
+if hash == "e42d81cd67b8c7bc":
 	hash = "626fce9a778df4d4"
 print('#define GAME_NETVERSION_HASH "%s"' % hash)


### PR DESCRIPTION
Sushi's last commit changed the network hash due to a function being renamed, but failed to account for that in cmd5.py