### PR TITLE
Make clearer comments on why the current path checking suffices 

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1644,6 +1644,9 @@ int str_check_pathname(const char* str)
 
 		++str;
 	}
+	// If there's "." or ".." at the end, fail too.
+	if(parse_counter >= 1 && parse_counter <= 2)
+		return -1;
 	return 0;
 }
 

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1610,7 +1610,7 @@ void str_sanitize_cc(char *str_in)
 	}
 }
 
-/* check if the string contains '.' or '..' paths */
+/* check if the string contains '..' (parent directory) paths */
 int str_check_pathname(const char* str)
 {
 	// State machine. Non-negative numbers mean that we're at the beginning
@@ -1625,9 +1625,9 @@ int str_check_pathname(const char* str)
 			// A path separator. Check how many dots we found since
 			// the last path separator.
 			//
-			// One or two dots => "." or ".." contained in the
-			// path. Return an error.
-			if(parse_counter >= 1 && parse_counter <= 2)
+			// Two dots => ".." contained in the path. Return an
+			// error.
+			if(parse_counter == 2)
 				return -1;
 			else
 				parse_counter = 0;
@@ -1644,8 +1644,8 @@ int str_check_pathname(const char* str)
 
 		++str;
 	}
-	// If there's "." or ".." at the end, fail too.
-	if(parse_counter >= 1 && parse_counter <= 2)
+	// If there's a ".." at the end, fail too.
+	if(parse_counter == 2)
 		return -1;
 	return 0;
 }

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1613,20 +1613,34 @@ void str_sanitize_cc(char *str_in)
 /* check if the string contains '.' or '..' paths */
 int str_check_pathname(const char* str)
 {
-	int parse_counter = 1;
+	// State machine. Non-negative numbers mean that we're at the beginning
+	// of a new directory/filename, and the number represents the number of
+	// dots ('.') we found. -1 means we encountered a different character
+	// since the last path separator (or the beginning of the string).
+	int parse_counter = 0;
 	while(*str)
 	{
 		if(*str == '\\' || *str == '/')
 		{
-			if(parse_counter >= 2 && parse_counter <= 3)
+			// A path separator. Check how many dots we found since
+			// the last path separator.
+			//
+			// One or two dots => "." or ".." contained in the
+			// path. Return an error.
+			if(parse_counter >= 1 && parse_counter <= 2)
 				return -1;
 			else
-				parse_counter = 1;
+				parse_counter = 0;
 		}
-		else if(*str != '.')
-			parse_counter = 0;
-		else
-			++parse_counter;
+		else if(parse_counter >= 0)
+		{
+			// If we have not encountered a non-dot character since
+			// the last path separator, count the dots.
+			if(*str == '.')
+				parse_counter++;
+			else
+				parse_counter = -1;
+		}
 
 		++str;
 	}

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -816,7 +816,7 @@ void str_sanitize(char *str);
 
 /*
 	Function: str_check_pathname
-		Check if the string contains '.' or '..' paths.
+		Check if the string contains '..' (parent directory) paths.
 
 		NOTE: This does not check whether the path is absolute, other
 		checking must be in place for this case.

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -815,8 +815,11 @@ void str_sanitize_cc(char *str);
 void str_sanitize(char *str);
 
 /*
-	Function: str_check_pathnam
+	Function: str_check_pathname
 		Check if the string contains '.' or '..' paths.
+
+		NOTE: This does not check whether the path is absolute, other
+		checking must be in place for this case.
 
 	Parameters:
 		str - String to check.

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -254,6 +254,8 @@ public:
 		return pBuffer;
 	}
 
+	// Open a file. This checks that the path appears to be a subdirectory
+	// of one of the storage paths.
 	virtual IOHANDLE OpenFile(const char *pFilename, int Flags, int Type, char *pBuffer = 0, int BufferSize = 0)
 	{
 		char aBuffer[MAX_PATH_LENGTH];
@@ -263,7 +265,14 @@ public:
 			BufferSize = sizeof(aBuffer);
 		}
 
-		// check for valid path
+		// Check whether the path contains sole '..' or '.'. We'd
+		// normally still have to check whether it is an absolute path
+		// (starts with a path separator (or a drive name on windows)),
+		// but since we concatenate this path with another path later
+		// on, this can't become absolute.
+		//
+		// E. g. "/etc/passwd" => "/path/to/storage//etc/passwd", which
+		// is safe.
 		if(str_check_pathname(pFilename) != 0)
 		{
 			pBuffer[0] = 0;


### PR DESCRIPTION
I couldn't figure out why this is safe, so I added comments.

Also, don't count dots when having already encountered a non-dot, forbid ".." at the end too, and don't forbid ".".

See also #1302.