### PR TITLE
Update French translations

### DIFF
--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -683,7 +683,7 @@ Handle rendering async from updates
 == Rendre sans attendre les mises à jour
 
 Respawn
-== Revivre
+== Réapparaître
 
 Show only chat messages from friends
 == Afficher seulement les message des amis

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -68,7 +68,7 @@ Automatically record demos
 == Enregistrer automatiquement une démo
 
 Automatically take game over screenshot
-== Sauvegarder les résultats à la fin de la partie
+== Prendre une capture d'écran des résultats
 
 Blue team
 == Équipe bleue
@@ -539,10 +539,10 @@ Sound
 == Son
 
 Sound error
-== Erreur de son
+== Erreur audio
 
 Sound volume
-== Volume du son
+== Volume audio
 
 Spectate
 == Regarder
@@ -673,28 +673,26 @@ Your skin
 no limit
 == pas de limite
 
-##### needs translation #####
-
 Borderless window
-== 
+== Fenêtre sans bordure
 
 Game paused
-== 
+== Jeu en pause
 
 Handle rendering async from updates
-== 
+== Rendre sans attendre les mises à jour
 
 Respawn
-== 
+== Revivre
 
 Show only chat messages from friends
-== 
+== Afficher seulement les message des amis
 
 Threaded rendering
-== 
+== Rendu en parallèle
 
 Threaded sound loading
-== 
+== Chargement des sons en paralèlle
 
 ##### old translations #####
 


### PR DESCRIPTION
"Handle rendering async from updates" was hard to translate. I think it's okay, but if someone has a better idea, do tell.

See #1336, the same problem has been encountered in German. They've finnaly gone with "spielunabhängige Bilddarstellung" that I'd translate as "Rendu indépendant du jeu" but honestly I think "Rendre sans attendre les mises à jour" makes more sense for someone who knows how online games works, while still making as much sense (i.e. no sense) for someone who doesn't know.