### PR TITLE
Change libpath of freetype on windows

### DIFF
--- a/other/freetype/freetype.lua
+++ b/other/freetype/freetype.lua
@@ -1,18 +1,18 @@
 FreeType = {
 	basepath = PathDir(ModuleFilename()),
-	
-	OptFind = function (name, required)	
+
+	OptFind = function (name, required)
 		local check = function(option, settings)
 			option.value = false
 			option.use_ftconfig = false
 			option.use_winlib = 0
 			option.lib_path = nil
-			
+
 			if ExecuteSilent("freetype-config") > 0 and ExecuteSilent("freetype-config --cflags") == 0 then
 				option.value = true
 				option.use_ftconfig = true
 			end
-				
+
 			if platform == "win32" then
 				option.value = true
 				option.use_winlib = 32
@@ -21,7 +21,7 @@ FreeType = {
 				option.use_winlib = 64
 			end
 		end
-		
+
 		local apply = function(option, settings)
 			if option.use_ftconfig == true then
 				settings.cc.flags:Add("`freetype-config --cflags`")
@@ -29,20 +29,20 @@ FreeType = {
 			elseif option.use_winlib > 0 then
 				settings.cc.includes:Add(FreeType.basepath .. "/include")
 				if option.use_winlib == 32 then
-					settings.link.libpath:Add(FreeType.basepath .. "/lib32")
+					settings.link.libpath:Add(FreeType.basepath .. "/lib/x86")
 				else
-					settings.link.libpath:Add(FreeType.basepath .. "/lib64")
+					settings.link.libpath:Add(FreeType.basepath .. "/lib/x64")
 				end
 				settings.link.libs:Add("freetype")
 			end
 		end
-		
+
 		local save = function(option, output)
 			output:option(option, "value")
 			output:option(option, "use_ftconfig")
 			output:option(option, "use_winlib")
 		end
-		
+
 		local display = function(option)
 			if option.value == true then
 				if option.use_ftconfig == true then return "using freetype-config" end
@@ -57,7 +57,7 @@ FreeType = {
 				end
 			end
 		end
-		
+
 		local o = MakeOption(name, 0, check, save, display)
 		o.Apply = apply
 		o.include_path = nil


### PR DESCRIPTION
Make libpath of freetype libraries consistent with sdl2 libpath (/lib/arch)
(Remove trailing whitespaces in freetype.lua)