### PR TITLE
Fixed econ clients not getting dropped when banned

### DIFF
--- a/src/engine/shared/econ.cpp
+++ b/src/engine/shared/econ.cpp
@@ -135,10 +135,9 @@ void CEcon::Update()
 				m_NetConsole.Send(ClientID, aMsg);
 				if(m_aClients[ClientID].m_AuthTries >= MAX_AUTH_TRIES)
 				{
-					if(!g_Config.m_EcBantime)
-						m_NetConsole.Drop(ClientID, "Too many authentication tries");
-					else
+					if(g_Config.m_EcBantime)
 						m_NetConsole.NetBan()->BanAddr(m_NetConsole.ClientAddr(ClientID), g_Config.m_EcBantime*60, "Too many authentication tries");
+					m_NetConsole.Drop(ClientID, "Too many authentication tries");
 				}
 			}
 		}


### PR DESCRIPTION
If ec_bantime is greater than 0 the server fails to drop Econ clients after too many failed authentication attempts, allowing for an arbitrary number of tries. This pull request should fix that.

Is committing to 0.6 correct or should this go to master?

Please check everything twice. I'm new to this and I don't know what I'm doing :)