### PR TITLE
NetBSD's default installation prefix is /usr/pkg

### DIFF
--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -211,6 +211,8 @@ public:
 				"/usr/share/games/teeworlds/data",
 				"/usr/local/share/teeworlds/data",
 				"/usr/local/share/games/teeworlds/data",
+				"/usr/pkg/share/teeworlds/data",
+				"/usr/pkg/share/games/teeworlds/data",
 				"/opt/teeworlds/data"
 			};
 			const int DirsCount = sizeof(aDirs) / sizeof(aDirs[0]);


### PR DESCRIPTION
NetBSD's default installation prefix for software built from [pkgsrc](https://www.pkgsrc.org/) is "/usr/pkg"
I [have added](http://gnats.netbsd.org/cgi-bin/query-pr-single.pl?number=50235) teeworlds to pkgsrc, so it would be nice if we looked there by default, too, eliminating one of the patches currently required to make it work

The attached commit accomplishes that.