### PR TITLE
Fix disconnecting from server

### DIFF
--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -76,8 +76,10 @@ int CNetServer::Update()
 		if(m_aSlots[i].m_Connection.State() == NET_CONNSTATE_ERROR)
 		{
 			if(Now - m_aSlots[i].m_Connection.ConnectTime() < time_freq() && NetBan())
+			{
 				if(NetBan()->BanAddr(ClientAddr(i), 60, "Stressing network") == -1)
 					Drop(i, m_aSlots[i].m_Connection.ErrorString());
+			}
 			else
 				Drop(i, m_aSlots[i].m_Connection.ErrorString());
 		}


### PR DESCRIPTION
> 02:21:25 allu2: I may have messed something up, but seem I can join and play alright, but the server doesn't get any message or indication on the log when I leave it, and then I can't join in it again.. still testing it though

An ambiguous else statement in network_server.cpp appears to break disconnecting.