### PR TITLE
Indicate selfdamage by red stars

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -224,6 +224,7 @@ Objects = [
 
 	NetEvent("DamageInd:Common", [
 		NetIntAny("m_Angle"),
+		NetBool("m_SelfDamage"),
 	]),
 ]
 

--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -31,7 +31,7 @@ void CDamageInd::DestroyI(CDamageInd::CItem *i)
 	*i = m_aItems[m_NumItems];
 }
 
-void CDamageInd::Create(vec2 Pos, vec2 Dir)
+void CDamageInd::Create(vec2 Pos, vec2 Dir, bool SelfDamage)
 {
 	CItem *i = CreateI();
 	if (i)
@@ -40,6 +40,7 @@ void CDamageInd::Create(vec2 Pos, vec2 Dir)
 		i->m_StartTime = Client()->LocalTime();
 		i->m_Dir = Dir*-1;
 		i->m_StartAngle = (( (float)rand()/(float)RAND_MAX) - 1.0f) * 2.0f * pi;
+		i->m_SelfDamage = SelfDamage;
 	}
 }
 
@@ -70,7 +71,10 @@ void CDamageInd::OnRender()
 		else
 		{
 			vec2 Pos = mix(m_aItems[i].m_Pos+m_aItems[i].m_Dir*75.0f, m_aItems[i].m_Pos, clamp((Life-0.60f)/0.15f, 0.0f, 1.0f));
-			Graphics()->SetColor(1.0f,1.0f,1.0f, Life/0.1f);
+			if(m_aItems[i].m_SelfDamage)
+				Graphics()->SetColor(1.0f,0.1f,0.3f, Life/0.1f);
+			else
+				Graphics()->SetColor(1.0f,1.0f,1.0f, Life/0.1f);
 			Graphics()->QuadsSetRotation(m_aItems[i].m_StartAngle + Life * 2.0f);
 			RenderTools()->SelectSprite(SPRITE_STAR1);
 			RenderTools()->DrawSprite(Pos.x, Pos.y, 48.0f);

--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -13,6 +13,8 @@ class CDamageInd : public CComponent
 		vec2 m_Dir;
 		float m_StartTime;
 		float m_StartAngle;
+
+		bool m_SelfDamage;
 	};
 
 	enum
@@ -29,7 +31,7 @@ class CDamageInd : public CComponent
 public:
 	CDamageInd();
 
-	void Create(vec2 Pos, vec2 Dir);
+	void Create(vec2 Pos, vec2 Dir, bool SelfDamage);
 	virtual void OnRender();
 	virtual void OnReset();
 };

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -47,9 +47,9 @@ void CEffects::AirJump(vec2 Pos)
 	m_pClient->m_pSounds->PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_AIRJUMP, 1.0f, Pos);
 }
 
-void CEffects::DamageIndicator(vec2 Pos, vec2 Dir)
+void CEffects::DamageIndicator(vec2 Pos, vec2 Dir, bool SelfDamage)
 {
-	m_pClient->m_pDamageind->Create(Pos, Dir);
+	m_pClient->m_pDamageind->Create(Pos, Dir, SelfDamage);
 }
 
 void CEffects::PowerupShine(vec2 Pos, vec2 size)

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -19,7 +19,7 @@ public:
 	void Explosion(vec2 Pos);
 	void HammerHit(vec2 Pos);
 	void AirJump(vec2 Pos);
-	void DamageIndicator(vec2 Pos, vec2 Dir);
+	void DamageIndicator(vec2 Pos, vec2 Dir, bool SelfDamage);
 	void PlayerSpawn(vec2 Pos);
 	void PlayerDeath(vec2 Pos, int ClientID);
 	void PowerupShine(vec2 Pos, vec2 Size);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -820,7 +820,7 @@ void CGameClient::ProcessEvents()
 		if(Item.m_Type == NETEVENTTYPE_DAMAGEIND)
 		{
 			CNetEvent_DamageInd *ev = (CNetEvent_DamageInd *)pData;
-			m_pEffects->DamageIndicator(vec2(ev->m_X, ev->m_Y), direction(ev->m_Angle/256.0f));
+			m_pEffects->DamageIndicator(vec2(ev->m_X, ev->m_Y), direction(ev->m_Angle/256.0f), ev->m_SelfDamage);
 		}
 		else if(Item.m_Type == NETEVENTTYPE_EXPLOSION)
 		{

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -696,12 +696,12 @@ bool CCharacter::TakeDamage(vec2 Force, int Dmg, int From, int Weapon)
 	if(Server()->Tick() < m_DamageTakenTick+25)
 	{
 		// make sure that the damage indicators doesn't group together
-		GameServer()->CreateDamageInd(m_Pos, m_DamageTaken*0.25f, Dmg);
+		GameServer()->CreateDamageInd(m_Pos, m_DamageTaken*0.25f, Dmg, From == m_pPlayer->GetCID());
 	}
 	else
 	{
 		m_DamageTaken = 0;
-		GameServer()->CreateDamageInd(m_Pos, 0, Dmg);
+		GameServer()->CreateDamageInd(m_Pos, 0, Dmg, From == m_pPlayer->GetCID());
 	}
 
 	if(Dmg)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -92,7 +92,7 @@ class CCharacter *CGameContext::GetPlayerChar(int ClientID)
 	return m_apPlayers[ClientID]->GetCharacter();
 }
 
-void CGameContext::CreateDamageInd(vec2 Pos, float Angle, int Amount)
+void CGameContext::CreateDamageInd(vec2 Pos, float Angle, int Amount, bool SelfDamage)
 {
 	float a = 3*pi/2 + Angle;
 	//float a = get_angle(dir);
@@ -107,6 +107,7 @@ void CGameContext::CreateDamageInd(vec2 Pos, float Angle, int Amount)
 			pEvent->m_X = (int)Pos.x;
 			pEvent->m_Y = (int)Pos.y;
 			pEvent->m_Angle = (int)(f*256.0f);
+			pEvent->m_SelfDamage = SelfDamage;
 		}
 	}
 }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -121,7 +121,7 @@ public:
 	CVoteOptionServer *m_pVoteOptionLast;
 
 	// helper functions
-	void CreateDamageInd(vec2 Pos, float AngleMod, int Amount);
+	void CreateDamageInd(vec2 Pos, float AngleMod, int Amount, bool SelfDamage);
 	void CreateExplosion(vec2 Pos, int Owner, int Weapon, int MaxDamage);
 	void CreateHammerHit(vec2 Pos);
 	void CreatePlayerSpawn(vec2 Pos);


### PR DESCRIPTION
In reference to #1411 1411.

Simply colors the damageindicator red, when the damage inflicted was caused by yourself.
![screenshot_2015-10-13_12-00-24](https://cloud.githubusercontent.com/assets/13798139/10451708/146dcfe0-71a2-11e5-811a-ac1800fea7cf.png)
