### PR TITLE
Tournament chat mode

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -745,6 +745,13 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 
 			pPlayer->m_LastChat = Server()->Tick();
 
+			// don't allow spectators to disturb players during a running game in tournament mode
+			if(g_Config.m_SvTournamentMode &&
+				pPlayer->GetTeam() == TEAM_SPECTATORS &&
+				m_pController->IsGameRunning() &&
+				!Server()->IsAuthed(ClientID))
+				Team = TEAM_SPECTATORS;
+
 			SendChat(ClientID, Team, pMsg->m_pMessage);
 		}
 		else if(MsgID == NETMSGTYPE_CL_CALLVOTE)

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -188,6 +188,7 @@ public:
 	// info
 	bool IsFriendlyFire(int ClientID1, int ClientID2) const;
 	bool IsGamePaused() const { return m_GameState == IGS_GAME_PAUSED || m_GameState == IGS_START_COUNTDOWN; }
+	bool IsGameRunning() const { return m_GameState == IGS_GAME_RUNNING; }
 	bool IsPlayerReadyMode() const;
 	bool IsTeamChangeAllowed() const;
 	bool IsTeamplay() const { return m_GameFlags&GAMEFLAG_TEAMS; }


### PR DESCRIPTION
This feature limits the chat to team mode for spectators, when a tournament is running and the game is not paused/in warmup state/ended. You can bypass this limitation by being authed.

Should close #1368.