### PR TITLE
Add chat answer feature

### DIFF
--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -29,6 +29,7 @@ class CChat : public CComponent
 
 	CLine m_aLines[MAX_LINES];
 	int m_CurrentLine;
+	char m_ChatPartner[16][16];
 
 	// chat
 	enum
@@ -77,7 +78,7 @@ public:
 
 	void AddLine(int ClientID, int Team, const char *pLine);
 
-	void EnableMode(int Team);
+	void EnableMode(int Team, int Answer=0);
 
 	void Say(int Team, const char *pLine);
 


### PR DESCRIPTION
Added a chat-answer feature with which you can directly answer to tees who wrote to you, without the need to always search and type their name before your message (basically, this is done for you by this feature).

- Changed the `chat` command's arguments to `s?i`. The (optional) second parameter is an integer which tells who to answer, chronologically backwards.
- e.g. you can bind `chat all 1` to key '6', `chat all 2` to key '7' and so on if you want
- the most common use may be just to bind `chat all 1` to r

How it works:
- Whenever you are highlighted, the name of the player who wrote the message is pushed onto a kind of stack.
- When the stack is full, the element at the very end will just get lost.
- With `chat all/team [number]` you can refer to the element at position [number] on this stack to automatically start of the chat message with it.

P.S.: This commit does basically what was described by @GreYFoX in this comment: https://github.com/teeworlds/teeworlds/issues/529#issuecomment-887886