### PR TITLE
Color picking for editor

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -56,4 +56,60 @@ inline vec4 HexToRgba(int hex)
 	return c;
 }
 
+/*
+	Function: HsvToRgb
+		Converts Hsv to Rgb
+*/
+inline vec3 HsvToRgb(vec3 hsv)
+{
+	int h = int(hsv.x * 6.0f);
+	float f = hsv.x * 6.0f - h;
+	float p = hsv.z * (1.0f - hsv.y);
+	float q = hsv.z * (1.0f - hsv.y * f);
+	float t = hsv.z * (1.0f - hsv.y * (1.0f - f));
+
+	vec3 rgb = vec3(0.0f, 0.0f, 0.0f);
+
+	switch(h % 6)
+	{
+	case 0:
+		rgb.r = hsv.z;
+		rgb.g = t;
+		rgb.b = p;
+		break;
+
+	case 1:
+		rgb.r = q;
+		rgb.g = hsv.z;
+		rgb.b = p;
+		break;
+
+	case 2:
+		rgb.r = p;
+		rgb.g = hsv.z;
+		rgb.b = t;
+		break;
+
+	case 3:
+		rgb.r = p;
+		rgb.g = q;
+		rgb.b = hsv.z;
+		break;
+
+	case 4:
+		rgb.r = t;
+		rgb.g = p;
+		rgb.b = hsv.z;
+		break;
+
+	case 5:
+		rgb.r = hsv.z;
+		rgb.g = p;
+		rgb.b = q;
+		break;
+	}
+
+	return rgb;
+}
+
 #endif

--- a/src/base/color.h
+++ b/src/base/color.h
@@ -112,4 +112,41 @@ inline vec3 HsvToRgb(vec3 hsv)
 	return rgb;
 }
 
+/*
+	Function: RgbToHsv
+		Converts Rgb to Hsv
+*/
+inline vec3 RgbToHsv(vec3 rgb)
+{
+	float h_min = min(min(rgb.r, rgb.g), rgb.b);
+	float h_max = max(max(rgb.r, rgb.g), rgb.b);
+
+	// hue
+	float hue = 0.0f;
+
+	if(h_max == h_min)
+		hue = 0.0f;
+	else if(h_max == rgb.r)
+		hue = (rgb.g-rgb.b) / (h_max-h_min);
+	else if(h_max == rgb.g)
+		hue = 2.0f + (rgb.b-rgb.r) / (h_max-h_min);
+	else
+		hue = 4.0f + (rgb.r-rgb.g) / (h_max-h_min);
+
+	hue /= 6.0f;
+
+	if(hue < 0.0f)
+		hue += 1.0f;
+
+	// saturation
+	float s = 0.0f;
+	if(h_max != 0.0f)
+		s = (h_max - h_min)/h_max;
+
+	// lightness
+	float l = h_max;
+
+	return vec3(hue, s, l);
+}
+
 #endif

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -453,11 +453,11 @@ void CCommandProcessorFragment_OpenGL::Cmd_Screenshot(const CCommandBuffer::SCom
 	GLint aViewport[4] = {0,0,0,0};
 	glGetIntegerv(GL_VIEWPORT, aViewport);
 
-	int x = pCommand->m_X;
-	int y = aViewport[3] - pCommand->m_Y;
 	int w = pCommand->m_W == -1 ? aViewport[2] : pCommand->m_W;
 	int h = pCommand->m_H == -1 ? aViewport[3] : pCommand->m_H;
-
+	int x = pCommand->m_X;
+	int y = aViewport[3] - pCommand->m_Y - h;
+	
 	// we allocate one more row to use when we are flipping the texture
 	unsigned char *pPixelData = (unsigned char *)mem_alloc(w*(h+1)*3, 1);
 	unsigned char *pTempRow = pPixelData+w*h*3;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -453,8 +453,10 @@ void CCommandProcessorFragment_OpenGL::Cmd_Screenshot(const CCommandBuffer::SCom
 	GLint aViewport[4] = {0,0,0,0};
 	glGetIntegerv(GL_VIEWPORT, aViewport);
 
-	int w = aViewport[2];
-	int h = aViewport[3];
+	int x = pCommand->m_X;
+	int y = aViewport[3] - pCommand->m_Y;
+	int w = pCommand->m_W == -1 ? aViewport[2] : pCommand->m_W;
+	int h = pCommand->m_H == -1 ? aViewport[3] : pCommand->m_H;
 
 	// we allocate one more row to use when we are flipping the texture
 	unsigned char *pPixelData = (unsigned char *)mem_alloc(w*(h+1)*3, 1);
@@ -464,15 +466,15 @@ void CCommandProcessorFragment_OpenGL::Cmd_Screenshot(const CCommandBuffer::SCom
 	GLint Alignment;
 	glGetIntegerv(GL_PACK_ALIGNMENT, &Alignment);
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
-	glReadPixels(0,0, w, h, GL_RGB, GL_UNSIGNED_BYTE, pPixelData);
+	glReadPixels(x, y, w, h, GL_RGB, GL_UNSIGNED_BYTE, pPixelData);
 	glPixelStorei(GL_PACK_ALIGNMENT, Alignment);
 
 	// flip the pixel because opengl works from bottom left corner
-	for(int y = 0; y < h/2; y++)
+	for(int ty = 0; ty < h/2; ty++)
 	{
-		mem_copy(pTempRow, pPixelData+y*w*3, w*3);
-		mem_copy(pPixelData+y*w*3, pPixelData+(h-y-1)*w*3, w*3);
-		mem_copy(pPixelData+(h-y-1)*w*3, pTempRow,w*3);
+		mem_copy(pTempRow, pPixelData+ty*w*3, w*3);
+		mem_copy(pPixelData+ty*w*3, pPixelData+(h-ty-1)*w*3, w*3);
+		mem_copy(pPixelData+(h-ty-1)*w*3, pTempRow,w*3);
 	}
 
 	// fill in the information

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -463,6 +463,8 @@ void CGraphics_Threaded::ScreenshotDirect(const char *pFilename)
 
 	CCommandBuffer::SCommand_Screenshot Cmd;
 	Cmd.m_pImage = &Image;
+	Cmd.m_X = 0; Cmd.m_Y = 0;
+	Cmd.m_W = -1; Cmd.m_H = -1;
 	m_pCommandBuffer->AddCommand(Cmd);
 
 	// kick the buffer and wait for the result
@@ -877,6 +879,28 @@ int CGraphics_Threaded::WindowOpen()
 {
 	return m_pBackend->WindowOpen();
 
+}
+
+void CGraphics_Threaded::ReadBackbuffer(unsigned char **ppPixels, int x, int y, int w, int h)
+{
+	if(!ppPixels)
+		return;
+
+	// add swap command
+	CImageInfo Image;
+	mem_zero(&Image, sizeof(Image));
+
+	CCommandBuffer::SCommand_Screenshot Cmd;
+	Cmd.m_pImage = &Image;
+	Cmd.m_X = x; Cmd.m_Y = y;
+	Cmd.m_W = w; Cmd.m_H = h;
+	m_pCommandBuffer->AddCommand(Cmd);
+
+	// kick the buffer and wait for the result
+	KickCommandBuffer();
+	WaitForIdle();
+
+	*ppPixels = (unsigned char *)Image.m_pData; // take ownership!
 }
 
 void CGraphics_Threaded::TakeScreenshot(const char *pFilename)

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -184,6 +184,7 @@ public:
 	struct SCommand_Screenshot : public SCommand
 	{
 		SCommand_Screenshot() : SCommand(CMD_SCREENSHOT) {}
+		int m_X, m_Y, m_W, m_H; // specify rectangle size, -1 if fullscreen (width/height)
 		CImageInfo *m_pImage; // processor will fill this out, the one who adds this command must free the data as well
 	};
 
@@ -451,6 +452,7 @@ public:
 	virtual int Init();
 	virtual void Shutdown();
 
+	virtual void ReadBackbuffer(unsigned char **ppPixels, int x, int y, int w, int h);
 	virtual void TakeScreenshot(const char *pFilename);
 	virtual void Swap();
 	virtual bool SetVSync(bool State);

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -167,6 +167,7 @@ public:
 	virtual void SetColor(float r, float g, float b, float a) = 0;
 	virtual void SetColor4(vec4 TopLeft, vec4 TopRight, vec4 BottomLeft, vec4 BottomRight) = 0;
 
+	virtual void ReadBackbuffer(unsigned char **ppPixels, int x, int y, int w, int h) = 0;
 	virtual void TakeScreenshot(const char *pFilename) = 0;
 	virtual int GetVideoModes(CVideoMode *pModes, int MaxModes, int Screen) = 0;
 

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -319,7 +319,8 @@ int CUI::DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *
 		if(MouseButton(0))
 			SetActiveItem(pID);
 	}
-	else if(Inside)
+	
+	if(Inside)
 		SetHotItem(pID);
 
 	if(!CheckActiveItem(pID))

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2401,6 +2401,14 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 			static const char *s_paTexts[4] = {"R", "G", "B", "A"};
 			static int s_aShift[] = {24, 16, 8, 0};
 			int NewColor = 0;
+			
+			// extra space
+			CUIRect ColorBox, ColorSlots;
+
+			pToolBox->HSplitTop(3.0f*13.0f, &Slot, pToolBox);
+			Slot.VSplitMid(&ColorBox, &ColorSlots);
+			ColorBox.HMargin(1.0f, &ColorBox);
+			ColorBox.VMargin(6.0f, &ColorBox);
 
 			for(int c = 0; c < 4; c++)
 			{
@@ -2409,10 +2417,25 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 
 				if(c != 3)
 				{
-					pToolBox->HSplitTop(13.0f, &Slot, pToolBox);
-					Slot.VSplitMid(0, &Shifter);
+					ColorSlots.HSplitTop(13.0f, &Shifter, &ColorSlots);
 					Shifter.HMargin(1.0f, &Shifter);
 				}
+			}
+			
+			// color picker
+			vec4 Color = vec4(
+				((pProps[i].m_Value >> s_aShift[0])&0xff)/255.0f,
+				((pProps[i].m_Value >> s_aShift[1])&0xff)/255.0f,
+				((pProps[i].m_Value >> s_aShift[2])&0xff)/255.0f,
+				1.0f);
+			
+			static int s_ColorPicker, s_ColorPickerID;
+			
+			RenderTools()->DrawUIRect(&ColorBox, Color, 0, 0.0f);
+			if(DoButton_Editor_Common(&s_ColorPicker, 0x0, 0, &ColorBox, 0, 0x0))
+			{
+				// TODO: BeaR:
+				UiInvokePopupMenu(&s_ColorPickerID, 0, UI()->MouseX(), UI()->MouseY(), 180, 150, PopupColorPicker);
 			}
 
 			if(NewColor != pProps[i].m_Value)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -282,8 +282,6 @@ void CEditor::EnvelopeEval(float TimeOffset, int Env, float *pChannels, void *pU
  OTHER
 *********************************************************/
 
-// copied from gc_menu.cpp, should be more generalized
-//extern int ui_do_edit_box(void *id, const CUIRect *rect, char *str, int str_size, float font_size, bool hidden=false);
 int CEditor::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *Offset, bool Hidden, int Corners)
 {
 	int Inside = UI()->MouseInside(pRect);
@@ -1108,6 +1106,17 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 		if(m_GridFactor < 15)
 			m_GridFactor++;
 	}
+	
+	TB_Bottom.VSplitLeft(30.0f, 0, &TB_Bottom);
+	
+	// pipette / color picking
+	TB_Bottom.VSplitLeft(30.0f, &Button, &TB_Bottom);
+	static int s_ColorPickingButton = 0;
+	if(DoButton_Editor(&s_ColorPickingButton, "Pick", m_PickColor, &Button, 0, "Pick color from view"))
+	{
+		m_PickColor = !m_PickColor;
+	}
+	
 }
 
 static void Rotate(const CPoint *pCenter, CPoint *pPoint, float Rotation)
@@ -1759,7 +1768,7 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 {
 	// render all good stuff
-	if(!m_ShowPicker)
+	if(!m_ShowTilePicker)
 	{
 		for(int g = 0; g < m_Map.m_lGroups.size(); g++)
 		{
@@ -1809,11 +1818,14 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 		OP_BRUSH_PAINT,
 		OP_PAN_WORLD,
 		OP_PAN_EDITOR,
+		OP_PIPETTE,
 	};
 
-	// remap the screen so it can display the whole tileset
-	if(m_ShowPicker)
+	static int s_Operation = OP_NONE;
+	
+	if(m_ShowTilePicker)
 	{
+		// remap the screen so it can display the whole tileset
 		CUIRect Screen = *UI()->Screen();
 		float Size = 32.0*16.0f;
 		float w = Size*(Screen.w/View.w);
@@ -1835,14 +1847,11 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 		}
 	}
 
-	static int s_Operation = OP_NONE;
-
 	// draw layer borders
 	CLayer *pEditLayers[16];
 	int NumEditLayers = 0;
-	NumEditLayers = 0;
 
-	if(m_ShowPicker)
+	if(m_ShowTilePicker)
 	{
 		pEditLayers[0] = &m_TilesetPicker;
 		NumEditLayers++;
@@ -1900,155 +1909,194 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 				UI()->SetActiveItem(s_pEditorID);
 			}
 		}
-
-		// brush editing
+	
 		if(UI()->HotItem() == s_pEditorID)
 		{
-			if(m_Brush.IsEmpty())
-				m_pTooltip = "Use left mouse button to drag and create a brush.";
-			else
-				m_pTooltip = "Use left mouse button to paint with the brush. Right button clears the brush.";
-
-			if(UI()->CheckActiveItem(s_pEditorID))
+			if(m_PickColor)
 			{
-				CUIRect r;
-				r.x = s_StartWx;
-				r.y = s_StartWy;
-				r.w = wx-s_StartWx;
-				r.h = wy-s_StartWy;
-				if(r.w < 0)
+				m_pTooltip = "Use left mouse button to pick a color from screen.";
+				
+				if(UI()->CheckActiveItem(s_pEditorID))
 				{
-					r.x += r.w;
-					r.w = -r.w;
+					if(s_Operation == OP_PIPETTE)
+					{
+						const int Width = Graphics()->ScreenWidth();
+						const int Height = Graphics()->ScreenHeight();
+						
+						const int px = clamp(0, int(mx * Width/UI()->Screen()->w), Width);
+						const int py = clamp(0, int(my * Height/UI()->Screen()->h), Height);
+						
+						unsigned char *pPixelData = 0x0;
+						Graphics()->ReadBackbuffer(&pPixelData, px, py, 1, 1); // get pixel at location (px, py)
+						
+						vec3 PickedColor = vec3(pPixelData[0] / 255.0f, pPixelData[1] / 255.0f, pPixelData[2] / 255.0f);
+						
+						Graphics()->TextureClear();
+						Graphics()->QuadsBegin();
+						Graphics()->SetColor(PickedColor.r, PickedColor.g, PickedColor.b, 1.0f);
+						IGraphics::CQuadItem QuadItem(0.0f, 0.0f, 20.0f, 20.0f);
+						Graphics()->QuadsDraw(&QuadItem, 1);
+						Graphics()->QuadsEnd();
+						
+						mem_free(pPixelData);
+					}
 				}
-
-				if(r.h < 0)
+				else
 				{
-					r.y += r.h;
-					r.h = -r.h;
+					if(UI()->MouseButton(0))
+					{
+						UI()->SetActiveItem(s_pEditorID);
+						s_Operation = OP_PIPETTE;
+					}
 				}
-
-				if(s_Operation == OP_BRUSH_DRAW)
+			}
+			else
+			{
+				// brush editing
+				if(m_Brush.IsEmpty())
+					m_pTooltip = "Use left mouse button to drag and create a brush.";
+				else
+					m_pTooltip = "Use left mouse button to paint with the brush. Right button clears the brush.";
+	
+				if(UI()->CheckActiveItem(s_pEditorID))
 				{
+					CUIRect r;
+					r.x = s_StartWx;
+					r.y = s_StartWy;
+					r.w = wx-s_StartWx;
+					r.h = wy-s_StartWy;
+					if(r.w < 0)
+					{
+						r.x += r.w;
+						r.w = -r.w;
+					}
+	
+					if(r.h < 0)
+					{
+						r.y += r.h;
+						r.h = -r.h;
+					}
+	
+					if(s_Operation == OP_BRUSH_DRAW)
+					{
+						if(!m_Brush.IsEmpty())
+						{
+							// draw with brush
+							for(int k = 0; k < NumEditLayers; k++)
+							{
+								if(pEditLayers[k]->m_Type == m_Brush.m_lLayers[0]->m_Type)
+									pEditLayers[k]->BrushDraw(m_Brush.m_lLayers[0], wx, wy);
+							}
+						}
+					}
+					else if(s_Operation == OP_BRUSH_GRAB)
+					{
+						if(!UI()->MouseButton(0))
+						{
+							// grab brush
+							char aBuf[256];
+							str_format(aBuf, sizeof(aBuf),"grabbing %f %f %f %f", r.x, r.y, r.w, r.h);
+							Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "editor", aBuf);
+	
+							// TODO: do all layers
+							int Grabs = 0;
+							for(int k = 0; k < NumEditLayers; k++)
+								Grabs += pEditLayers[k]->BrushGrab(&m_Brush, r);
+							if(Grabs == 0)
+								m_Brush.Clear();
+						}
+						else
+						{
+							for(int k = 0; k < NumEditLayers; k++)
+								pEditLayers[k]->BrushSelecting(r);
+							Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
+						}
+					}
+					else if(s_Operation == OP_BRUSH_PAINT)
+					{
+						if(!UI()->MouseButton(0))
+						{
+							for(int k = 0; k < NumEditLayers; k++)
+								pEditLayers[k]->FillSelection(m_Brush.IsEmpty(), m_Brush.m_lLayers[0], r);
+						}
+						else
+						{
+							for(int k = 0; k < NumEditLayers; k++)
+								pEditLayers[k]->BrushSelecting(r);
+							Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
+						}
+					}
+				}
+				else
+				{
+					if(UI()->MouseButton(1))
+						m_Brush.Clear();
+	
+					if(UI()->MouseButton(0) && s_Operation == OP_NONE)
+					{
+						UI()->SetActiveItem(s_pEditorID);
+	
+						if(m_Brush.IsEmpty())
+							s_Operation = OP_BRUSH_GRAB;
+						else
+						{
+							s_Operation = OP_BRUSH_DRAW;
+							for(int k = 0; k < NumEditLayers; k++)
+							{
+								if(pEditLayers[k]->m_Type == m_Brush.m_lLayers[0]->m_Type)
+									pEditLayers[k]->BrushPlace(m_Brush.m_lLayers[0], wx, wy);
+							}
+	
+						}
+	
+						CLayerTiles *pLayer = (CLayerTiles*)GetSelectedLayerType(0, LAYERTYPE_TILES);
+						if((Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT)) && pLayer)
+							s_Operation = OP_BRUSH_PAINT;
+					}
+	
 					if(!m_Brush.IsEmpty())
 					{
-						// draw with brush
-						for(int k = 0; k < NumEditLayers; k++)
+						m_Brush.m_OffsetX = -(int)wx;
+						m_Brush.m_OffsetY = -(int)wy;
+						for(int i = 0; i < m_Brush.m_lLayers.size(); i++)
 						{
-							if(pEditLayers[k]->m_Type == m_Brush.m_lLayers[0]->m_Type)
-								pEditLayers[k]->BrushDraw(m_Brush.m_lLayers[0], wx, wy);
+							if(m_Brush.m_lLayers[i]->m_Type == LAYERTYPE_TILES)
+							{
+								m_Brush.m_OffsetX = -(int)(wx/32.0f)*32;
+								m_Brush.m_OffsetY = -(int)(wy/32.0f)*32;
+								break;
+							}
+						}
+	
+						CLayerGroup *g = GetSelectedGroup();
+						if(g)
+						{
+							m_Brush.m_OffsetX += g->m_OffsetX;
+							m_Brush.m_OffsetY += g->m_OffsetY;
+							m_Brush.m_ParallaxX = g->m_ParallaxX;
+							m_Brush.m_ParallaxY = g->m_ParallaxY;
+							m_Brush.Render();
+							float w, h;
+							m_Brush.GetSize(&w, &h);
+	
+							IGraphics::CLineItem Array[4] = {
+								IGraphics::CLineItem(0, 0, w, 0),
+								IGraphics::CLineItem(w, 0, w, h),
+								IGraphics::CLineItem(w, h, 0, h),
+								IGraphics::CLineItem(0, h, 0, 0)};
+							Graphics()->TextureClear();
+							Graphics()->LinesBegin();
+							Graphics()->LinesDraw(Array, 4);
+							Graphics()->LinesEnd();
 						}
 					}
 				}
-				else if(s_Operation == OP_BRUSH_GRAB)
-				{
-					if(!UI()->MouseButton(0))
-					{
-						// grab brush
-						char aBuf[256];
-						str_format(aBuf, sizeof(aBuf),"grabbing %f %f %f %f", r.x, r.y, r.w, r.h);
-						Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "editor", aBuf);
-
-						// TODO: do all layers
-						int Grabs = 0;
-						for(int k = 0; k < NumEditLayers; k++)
-							Grabs += pEditLayers[k]->BrushGrab(&m_Brush, r);
-						if(Grabs == 0)
-							m_Brush.Clear();
-					}
-					else
-					{
-						//editor.map.groups[selected_group]->mapscreen();
-						for(int k = 0; k < NumEditLayers; k++)
-							pEditLayers[k]->BrushSelecting(r);
-						Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
-					}
-				}
-				else if(s_Operation == OP_BRUSH_PAINT)
-				{
-					if(!UI()->MouseButton(0))
-					{
-						for(int k = 0; k < NumEditLayers; k++)
-							pEditLayers[k]->FillSelection(m_Brush.IsEmpty(), m_Brush.m_lLayers[0], r);
-					}
-					else
-					{
-						//editor.map.groups[selected_group]->mapscreen();
-						for(int k = 0; k < NumEditLayers; k++)
-							pEditLayers[k]->BrushSelecting(r);
-						Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
-					}
-				}
-			}
-			else
-			{
-				if(UI()->MouseButton(1))
-					m_Brush.Clear();
-
-				if(UI()->MouseButton(0) && s_Operation == OP_NONE)
-				{
-					UI()->SetActiveItem(s_pEditorID);
-
-					if(m_Brush.IsEmpty())
-						s_Operation = OP_BRUSH_GRAB;
-					else
-					{
-						s_Operation = OP_BRUSH_DRAW;
-						for(int k = 0; k < NumEditLayers; k++)
-						{
-							if(pEditLayers[k]->m_Type == m_Brush.m_lLayers[0]->m_Type)
-								pEditLayers[k]->BrushPlace(m_Brush.m_lLayers[0], wx, wy);
-						}
-
-					}
-
-					CLayerTiles *pLayer = (CLayerTiles*)GetSelectedLayerType(0, LAYERTYPE_TILES);
-					if((Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT)) && pLayer)
-						s_Operation = OP_BRUSH_PAINT;
-				}
-
-				if(!m_Brush.IsEmpty())
-				{
-					m_Brush.m_OffsetX = -(int)wx;
-					m_Brush.m_OffsetY = -(int)wy;
-					for(int i = 0; i < m_Brush.m_lLayers.size(); i++)
-					{
-						if(m_Brush.m_lLayers[i]->m_Type == LAYERTYPE_TILES)
-						{
-							m_Brush.m_OffsetX = -(int)(wx/32.0f)*32;
-							m_Brush.m_OffsetY = -(int)(wy/32.0f)*32;
-							break;
-						}
-					}
-
-					CLayerGroup *g = GetSelectedGroup();
-					if(g)
-					{
-						m_Brush.m_OffsetX += g->m_OffsetX;
-						m_Brush.m_OffsetY += g->m_OffsetY;
-						m_Brush.m_ParallaxX = g->m_ParallaxX;
-						m_Brush.m_ParallaxY = g->m_ParallaxY;
-						m_Brush.Render();
-						float w, h;
-						m_Brush.GetSize(&w, &h);
-
-						IGraphics::CLineItem Array[4] = {
-							IGraphics::CLineItem(0, 0, w, 0),
-							IGraphics::CLineItem(w, 0, w, h),
-							IGraphics::CLineItem(w, h, 0, h),
-							IGraphics::CLineItem(0, h, 0, 0)};
-						Graphics()->TextureClear();
-						Graphics()->LinesBegin();
-						Graphics()->LinesDraw(Array, 4);
-						Graphics()->LinesEnd();
-					}
-				}
-			}
+			}	
 		}
 
 		// quad editing
 		{
-			if(!m_ShowPicker && m_Brush.IsEmpty())
+			if(!m_ShowTilePicker && !m_PickColor && m_Brush.IsEmpty())
 			{
 				// fetch layers
 				CLayerGroup *g = GetSelectedGroup();
@@ -2125,27 +2173,27 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 
 				Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
 			}
+		}
 
-			// do panning
-			if(UI()->CheckActiveItem(s_pEditorID))
+		// do panning
+		if(UI()->CheckActiveItem(s_pEditorID))
+		{
+			if(s_Operation == OP_PAN_WORLD)
 			{
-				if(s_Operation == OP_PAN_WORLD)
-				{
-					m_WorldOffsetX -= m_MouseDeltaX*m_WorldZoom;
-					m_WorldOffsetY -= m_MouseDeltaY*m_WorldZoom;
-				}
-				else if(s_Operation == OP_PAN_EDITOR)
-				{
-					m_EditorOffsetX -= m_MouseDeltaX*m_WorldZoom;
-					m_EditorOffsetY -= m_MouseDeltaY*m_WorldZoom;
-				}
+				m_WorldOffsetX -= m_MouseDeltaX*m_WorldZoom;
+				m_WorldOffsetY -= m_MouseDeltaY*m_WorldZoom;
+			}
+			else if(s_Operation == OP_PAN_EDITOR)
+			{
+				m_EditorOffsetX -= m_MouseDeltaX*m_WorldZoom;
+				m_EditorOffsetY -= m_MouseDeltaY*m_WorldZoom;
+			}
 
-				// release mouse
-				if(!UI()->MouseButton(0))
-				{
-					s_Operation = OP_NONE;
-					UI()->SetActiveItem(0);
-				}
+			// release mouse
+			if(!UI()->MouseButton(0))
+			{
+				s_Operation = OP_NONE;
+				UI()->SetActiveItem(0);
 			}
 		}
 	}
@@ -2159,7 +2207,7 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 		}
 	}
 
-	if(!m_ShowPicker && GetSelectedGroup() && GetSelectedGroup()->m_UseClipping)
+	if(!m_ShowTilePicker && GetSelectedGroup() && GetSelectedGroup()->m_UseClipping)
 	{
 		CLayerGroup *g = m_Map.m_pGameGroup;
 		g->MapScreen();
@@ -2185,7 +2233,7 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 	}
 
 	// render screen sizes
-	if(!m_ShowPicker && m_ProofBorders)
+	if(!m_ShowTilePicker && m_ProofBorders)
 	{
 		CLayerGroup *g = m_Map.m_pGameGroup;
 		g->MapScreen();
@@ -2267,7 +2315,7 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 		Graphics()->LinesEnd();
 	}
 
-	if (!m_ShowPicker && m_ShowTileInfo && m_ShowEnvelopePreview != SHOWENV_NONE && GetSelectedLayer(0) && GetSelectedLayer(0)->m_Type == LAYERTYPE_QUADS)
+	if (!m_ShowTilePicker && m_ShowTileInfo && m_ShowEnvelopePreview != SHOWENV_NONE && GetSelectedLayer(0) && GetSelectedLayer(0)->m_Type == LAYERTYPE_QUADS)
 	{
 		GetSelectedGroup()->MapScreen();
 
@@ -3432,15 +3480,10 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 			static int s_aChannelButtons[4] = {0};
 			int Bit = 1;
-			//ui_draw_button_func draw_func;
 
 			for(int i = 0; i < pEnvelope->m_Channels; i++, Bit<<=1)
 			{
 				ToolBar.VSplitLeft(15.0f, &Button, &ToolBar);
-
-				/*if(i == 0) draw_func = draw_editor_button_l;
-				else if(i == envelope->channels-1) draw_func = draw_editor_button_r;
-				else draw_func = draw_editor_button_m;*/
 
 				if(DoButton_Editor(&s_aChannelButtons[i], s_paNames[pEnvelope->m_Channels-3][i], s_ActiveChannels&Bit, &Button, 0, paDescriptions[pEnvelope->m_Channels-3][i]))
 					s_ActiveChannels ^= Bit;
@@ -3593,8 +3636,6 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				float t0 = pEnvelope->m_lPoints[i].m_Time/1000.0f/EndTime;
 				float t1 = pEnvelope->m_lPoints[i+1].m_Time/1000.0f/EndTime;
 
-				//dbg_msg("", "%f", end_time);
-
 				CUIRect v;
 				v.x = CurveBar.x + (t0+(t1-t0)*0.5f) * CurveBar.w;
 				v.y = CurveBar.y;
@@ -3634,9 +3675,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				Graphics()->SetColorVertex(Array, 4);
 
 				float x0 = pEnvelope->m_lPoints[i].m_Time/1000.0f/EndTime;
-//				float y0 = (fx2f(envelope->points[i].values[c])-bottom)/(top-bottom);
 				float x1 = pEnvelope->m_lPoints[i+1].m_Time/1000.0f/EndTime;
-				//float y1 = (fx2f(envelope->points[i+1].values[c])-bottom)/(top-bottom);
 				CUIRect v;
 				v.x = ColorBar.x + x0*ColorBar.w;
 				v.y = ColorBar.y;
@@ -4049,18 +4088,6 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	if(DoButton_Menu(&s_File, "File", 0, &s_File, 0, 0))
 		UiInvokePopupMenu(&s_File, 1, s_File.x, s_File.y+s_File.h-1.0f, 120, 150, PopupMenuFile, this);
 
-	/*
-	menubar.VSplitLeft(5.0f, 0, &menubar);
-	menubar.VSplitLeft(60.0f, &view, &menubar);
-	if(do_editor_button(&view, "View", 0, &view, draw_editor_button_menu, 0, 0))
-		(void)0;
-
-	menubar.VSplitLeft(5.0f, 0, &menubar);
-	menubar.VSplitLeft(60.0f, &help, &menubar);
-	if(do_editor_button(&help, "Help", 0, &help, draw_editor_button_menu, 0, 0))
-		(void)0;
-		*/
-
 	CUIRect Info;
 	MenuBar.VSplitLeft(40.0f, 0, &MenuBar);
 	MenuBar.VSplitLeft(MenuBar.w*0.75f, &MenuBar, &Info);
@@ -4092,7 +4119,7 @@ void CEditor::Render()
 	RenderBackground(View, m_CheckerTexture, 32.0f, 1.0f);
 
 	CUIRect MenuBar, CModeBar, ToolBar, StatusBar, EnvelopeEditor, ToolBox;
-	m_ShowPicker = Input()->KeyIsPressed(KEY_SPACE) != 0 && m_Dialog == DIALOG_NONE;
+	m_ShowTilePicker = Input()->KeyIsPressed(KEY_SPACE) != 0 && m_Dialog == DIALOG_NONE;
 
 	if(m_GuiActive)
 	{
@@ -4102,7 +4129,7 @@ void CEditor::Render()
 		View.VSplitLeft(100.0f, &ToolBox, &View);
 		View.HSplitBottom(16.0f, &View, &StatusBar);
 
-		if(m_ShowEnvelopeEditor && !m_ShowPicker)
+		if(m_ShowEnvelopeEditor && !m_ShowTilePicker)
 		{
 			float size = 125.0f;
 			if(m_ShowEnvelopeEditor == 2)
@@ -4395,8 +4422,8 @@ void CEditorMap::CreateDefault()
 	CLayerQuads *pLayer = new CLayerQuads;
 	pLayer->m_pEditor = m_pEditor;
 	CQuad *pQuad = pLayer->NewQuad();
-	const int Width = 800000;
-	const int Height = 600000;
+	const int Width = i2fx(800);
+	const int Height = i2fx(600);
 	pQuad->m_aPoints[0].x = pQuad->m_aPoints[2].x = -Width;
 	pQuad->m_aPoints[1].x = pQuad->m_aPoints[3].x = Width;
 	pQuad->m_aPoints[0].y = pQuad->m_aPoints[1].y = -Height;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2428,14 +2428,22 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 				((pProps[i].m_Value >> s_aShift[1])&0xff)/255.0f,
 				((pProps[i].m_Value >> s_aShift[2])&0xff)/255.0f,
 				1.0f);
-			
+	
 			static int s_ColorPicker, s_ColorPickerID;
 			
 			RenderTools()->DrawUIRect(&ColorBox, Color, 0, 0.0f);
 			if(DoButton_Editor_Common(&s_ColorPicker, 0x0, 0, &ColorBox, 0, 0x0))
 			{
-				// TODO: BeaR:
-				UiInvokePopupMenu(&s_ColorPickerID, 0, UI()->MouseX(), UI()->MouseY(), 180, 150, PopupColorPicker);
+				m_InitialPickerColor = RgbToHsv(vec3(Color.r, Color.g, Color.b));
+				m_SelectedPickerColor = m_InitialPickerColor;
+				UiInvokePopupMenu(&s_ColorPickerID, 0, UI()->MouseX(), UI()->MouseY(), 180, 180, PopupColorPicker);
+			}
+			
+			if(m_InitialPickerColor != m_SelectedPickerColor)
+			{
+				m_InitialPickerColor = m_SelectedPickerColor;
+				vec3 c = HsvToRgb(m_SelectedPickerColor);
+				NewColor = ((int)(c.r * 255.0f)&0xff) << 24 | ((int)(c.g * 255.0f)&0xff) << 16 | ((int)(c.b * 255.0f)&0xff) << 8 | (pProps[i].m_Value&0xff);		
 			}
 
 			if(NewColor != pProps[i].m_Value)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2162,15 +2162,8 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 							unsigned char *pPixelData = 0x0;
 							Graphics()->ReadBackbuffer(&pPixelData, px, py, 1, 1); // get pixel at location (px, py)
 							
-							vec3 PickedColor = vec3(pPixelData[0] / 255.0f, pPixelData[1] / 255.0f, pPixelData[2] / 255.0f);
-							
-							Graphics()->TextureClear();
-							Graphics()->QuadsBegin();
-							Graphics()->SetColor(PickedColor.r, PickedColor.g, PickedColor.b, 1.0f);
-							IGraphics::CQuadItem QuadItem(0.0f, 0.0f, 20.0f, 20.0f);
-							Graphics()->QuadsDraw(&QuadItem, 1);
-							Graphics()->QuadsEnd();
-							
+							m_SelectedColor = vec4(pPixelData[0] / 255.0f, pPixelData[1] / 255.0f, pPixelData[2] / 255.0f, 1.0f);
+													
 							mem_free(pPixelData);
 						}
 					}
@@ -4273,16 +4266,30 @@ void CEditor::Render()
 
 	if(m_ShowMousePointer)
 	{
-		// render butt ugly mouse cursor
 		float mx = UI()->MouseX();
 		float my = UI()->MouseY();
-		Graphics()->TextureSet(m_CursorTexture);
-		Graphics()->QuadsBegin();
-		if(ms_pUiGotContext == UI()->HotItem())
-			Graphics()->SetColor(1,0,0,1);
-		IGraphics::CQuadItem QuadItem(mx,my, 16.0f, 16.0f);
-		Graphics()->QuadsDrawTL(&QuadItem, 1);
-		Graphics()->QuadsEnd();
+			
+		{
+			// render butt ugly mouse cursor	
+			Graphics()->TextureSet(m_CursorTexture);
+			Graphics()->QuadsBegin();
+			if(ms_pUiGotContext == UI()->HotItem())
+				Graphics()->SetColor(1,0,0,1);
+			IGraphics::CQuadItem QuadItem(mx,my, 16.0f, 16.0f);
+			Graphics()->QuadsDrawTL(&QuadItem, 1);
+			Graphics()->QuadsEnd();
+		}
+			
+		if(m_MouseEdMode == MOUSE_PIPETTE)
+		{
+			// display selected color (pipette)
+			Graphics()->TextureClear();
+			Graphics()->QuadsBegin();
+			Graphics()->SetColor(m_SelectedColor.r, m_SelectedColor.g, m_SelectedColor.b, m_SelectedColor.a);
+			IGraphics::CQuadItem QuadItem(mx+1.0f,my-20.0f, 16.0f, 16.0f);
+			Graphics()->QuadsDrawTL(&QuadItem, 1);			
+			Graphics()->QuadsEnd();
+		}
 	}
 }
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1110,7 +1110,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 	TB_Bottom.VSplitLeft(10.0f, 0, &TB_Bottom);
 	
 	// pipette / color picking
-	TB_Bottom.VSplitLeft(40.0f, &Button, &TB_Bottom);
+	TB_Bottom.VSplitLeft(50.0f, &Button, &TB_Bottom);
 	static int s_ColorPickingButton = 0;
 	if(DoButton_Editor(&s_ColorPickingButton, "Pipette", m_MouseEdMode == MOUSE_PIPETTE, &Button, 0, "Pick color from view"))
 	{
@@ -1119,6 +1119,15 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			m_MouseEdMode = MOUSE_EDIT;
 		else
 			m_MouseEdMode = MOUSE_PIPETTE;
+	}
+	
+	// display selected color
+	if(m_SelectedColor.a > 0.0f)
+	{
+		TB_Bottom.VSplitLeft(4.0f, 0, &TB_Bottom);
+		
+		TB_Bottom.VSplitLeft(24.0f, &Button, &TB_Bottom);
+		RenderTools()->DrawUIRect(&Button, m_SelectedColor, 0, 0.0f);
 	}
 	
 }
@@ -2144,7 +2153,7 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 			} break;
 		
 			case MOUSE_PIPETTE:
-			{
+			{	
 				if(UI()->HotItem() == s_pEditorID)
 				{
 					m_pTooltip = "Use left mouse button to pick a color from screen.";
@@ -2176,6 +2185,11 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 						}
 					}
 				}
+				
+				// leave pipette mode on right-click
+				if(UI()->MouseButton(1))
+					m_MouseEdMode = MOUSE_EDIT;
+					
 			} break;
 		}
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -587,6 +587,7 @@ public:
 		m_SelectedEnvelopePoint = -1;
 		
 		m_SelectedColor = vec4(0,0,0,0);
+		m_InitialPickerColor = vec3(1,0,0);
 		m_SelectedPickerColor = vec3(1,0,0);
 
 		ms_pUiGotContext = 0;
@@ -730,6 +731,7 @@ public:
 	int m_SelectedImage;
 	
 	vec4 m_SelectedColor;
+	vec3 m_InitialPickerColor;
 	vec3 m_SelectedPickerColor;
 
 	IGraphics::CTextureHandle m_CheckerTexture;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -585,6 +585,8 @@ public:
 		m_ShowEnvelopePreview = SHOWENV_NONE;
 		m_SelectedQuadEnvelope = -1;
 		m_SelectedEnvelopePoint = -1;
+		
+		m_SelectedColor = vec4(0,0,0,0);
 
 		ms_pUiGotContext = 0;
 	}
@@ -725,6 +727,8 @@ public:
 	int m_SelectedEnvelopePoint;
     int m_SelectedQuadEnvelope;
 	int m_SelectedImage;
+	
+	vec4 m_SelectedColor;
 
 	IGraphics::CTextureHandle m_CheckerTexture;
 	IGraphics::CTextureHandle m_BackgroundTexture;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -532,7 +532,7 @@ public:
 		m_GridActive = false;
 		m_GridFactor = 1;
 		
-		m_PickColor = false;
+		m_MouseEdMode = MOUSE_EDIT;
 
 		m_aFileName[0] = 0;
 		m_aFileSaveName[0] = 0;
@@ -619,7 +619,13 @@ public:
 	bool m_GridActive;
 	int m_GridFactor;
 	
-	bool m_PickColor; // TODO: rename: pointer/mouse mode
+	enum
+	{
+		MOUSE_EDIT=0,
+		MOUSE_PIPETTE,
+	};
+	
+	int m_MouseEdMode;
 
 	char m_aFileName[512];
 	char m_aFileSaveName[512];

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -531,6 +531,8 @@ public:
 
 		m_GridActive = false;
 		m_GridFactor = 1;
+		
+		m_PickColor = false;
 
 		m_aFileName[0] = 0;
 		m_aFileSaveName[0] = 0;
@@ -616,6 +618,8 @@ public:
 
 	bool m_GridActive;
 	int m_GridFactor;
+	
+	bool m_PickColor; // TODO: rename: pointer/mouse mode
 
 	char m_aFileName[512];
 	char m_aFileSaveName[512];
@@ -705,7 +709,7 @@ public:
 		SHOWENV_ALL
 	};
 	int m_ShowEnvelopePreview;
-	bool m_ShowPicker;
+	bool m_ShowTilePicker;
 
 	int m_SelectedLayer;
 	int m_SelectedGroup;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -587,6 +587,7 @@ public:
 		m_SelectedEnvelopePoint = -1;
 		
 		m_SelectedColor = vec4(0,0,0,0);
+		m_SelectedPickerColor = vec3(1,0,0);
 
 		ms_pUiGotContext = 0;
 	}
@@ -729,6 +730,7 @@ public:
 	int m_SelectedImage;
 	
 	vec4 m_SelectedColor;
+	vec3 m_SelectedPickerColor;
 
 	IGraphics::CTextureHandle m_CheckerTexture;
 	IGraphics::CTextureHandle m_BackgroundTexture;
@@ -782,9 +784,9 @@ public:
 	static int PopupImage(CEditor *pEditor, CUIRect View);
 	static int PopupMenuFile(CEditor *pEditor, CUIRect View);
 	static int PopupSelectConfigAutoMap(CEditor *pEditor, CUIRect View);
-
 	static int PopupSelectDoodadRuleSet(CEditor *pEditor, CUIRect View);
 	static int PopupDoodadAutoMap(CEditor *pEditor, CUIRect View);
+	static int PopupColorPicker(CEditor *pEditor, CUIRect View);
 
 	static void CallbackOpenMap(const char *pFileName, int StorageType, void *pUser);
 	static void CallbackAppendMap(const char *pFileName, int StorageType, void *pUser);

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -135,7 +135,7 @@ void CLayerTiles::BrushSelecting(CUIRect Rect)
 	m_pEditor->Graphics()->QuadsEnd();
 	char aBuf[16];
 	str_format(aBuf, sizeof(aBuf), "%d,%d", ConvertX(Rect.w), ConvertY(Rect.h));
-	TextRender()->Text(0, Rect.x+3.0f, Rect.y+3.0f, m_pEditor->m_ShowPicker?15.0f:15.0f*m_pEditor->m_WorldZoom, aBuf, -1);
+	TextRender()->Text(0, Rect.x+3.0f, Rect.y+3.0f, m_pEditor->m_ShowTilePicker?15.0f:15.0f*m_pEditor->m_WorldZoom, aBuf, -1);
 }
 
 int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
@@ -253,13 +253,13 @@ void CLayerTiles::BrushFlipY()
 
 void CLayerTiles::BrushRotate(float Amount)
 {
-	int Rotation = (round_to_int(360.0f*Amount/(pi*2))/90)%4;	// 0=0°, 1=90°, 2=180°, 3=270°
+	int Rotation = (round_to_int(360.0f*Amount/(pi*2))/90)%4;	// 0=0ï¿½, 1=90ï¿½, 2=180ï¿½, 3=270ï¿½
 	if(Rotation < 0)
 		Rotation +=4;
 
 	if(Rotation == 1 || Rotation == 3)
 	{
-		// 90° rotation
+		// 90ï¿½ rotation
 		CTile *pTempData = new CTile[m_Width*m_Height];
 		mem_copy(pTempData, m_pTiles, m_Width*m_Height*sizeof(CTile));
 		CTile *pDst = m_pTiles;

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -253,13 +253,13 @@ void CLayerTiles::BrushFlipY()
 
 void CLayerTiles::BrushRotate(float Amount)
 {
-	int Rotation = (round_to_int(360.0f*Amount/(pi*2))/90)%4;	// 0=0�, 1=90�, 2=180�, 3=270�
+	int Rotation = (round_to_int(360.0f*Amount/(pi*2))/90)%4;	// 0=0°, 1=90°, 2=180°, 3=270°
 	if(Rotation < 0)
 		Rotation +=4;
 
 	if(Rotation == 1 || Rotation == 3)
 	{
-		// 90� rotation
+		// 90° rotation
 		CTile *pTempData = new CTile[m_Width*m_Height];
 		mem_copy(pTempData, m_pTiles, m_Width*m_Height*sizeof(CTile));
 		CTile *pDst = m_pTiles;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1034,9 +1034,11 @@ bool CEditor::PopupAutoMapProceedOrder()
 
 int CEditor::PopupColorPicker(CEditor *pEditor, CUIRect View)
 {
-	CUIRect SVPicker, HuePicker;
-	View.VSplitRight(20.0f, &SVPicker, &HuePicker);
+	CUIRect SVPicker, HuePicker, Palette;
+	View.HSplitBottom(20.0f, &SVPicker, &Palette);
+	SVPicker.VSplitRight(20.0f, &SVPicker, &HuePicker);
 	HuePicker.VSplitLeft(4.0f, 0x0, &HuePicker);
+	Palette.HSplitTop(4.0f, 0x0, &Palette);
 
 	pEditor->Graphics()->TextureClear();
 	pEditor->Graphics()->QuadsBegin();
@@ -1083,8 +1085,8 @@ int CEditor::PopupColorPicker(CEditor *pEditor, CUIRect View)
 
 	// logic
 	float X, Y;
-	static int ms_SVPicker = 0;
-	if(pEditor->UI()->DoPickerLogic(&ms_SVPicker, &SVPicker, &X, &Y))
+	static int s_SVPicker = 0;
+	if(pEditor->UI()->DoPickerLogic(&s_SVPicker, &SVPicker, &X, &Y))
 	{
 		hsv.y = X/SVPicker.w;
 		hsv.z = 1.0f - Y/SVPicker.h;	
@@ -1125,10 +1127,19 @@ int CEditor::PopupColorPicker(CEditor *pEditor, CUIRect View)
 
 	pEditor->Graphics()->QuadsEnd();
 
-	static int ms_HuePicker = 0;
-	if(pEditor->UI()->DoPickerLogic(&ms_HuePicker, &HuePicker, &X, &Y))
+	static int s_HuePicker = 0;
+	if(pEditor->UI()->DoPickerLogic(&s_HuePicker, &HuePicker, &X, &Y))
 	{
 		hsv.x = 1.0f - Y/HuePicker.h;	
+	}
+	
+	// palette
+	static int s_Palette = 0;
+	pEditor->RenderTools()->DrawUIRect(&Palette, pEditor->m_SelectedColor, 0, 0.0f);
+	if(pEditor->DoButton_Editor_Common(&s_Palette, 0x0, 0, &Palette, 0, 0x0))
+	{
+		if(pEditor->m_SelectedColor.a > 0.0f)
+			hsv = RgbToHsv(vec3(pEditor->m_SelectedColor.r, pEditor->m_SelectedColor.g, pEditor->m_SelectedColor.b));
 	}
 
 	pEditor->m_SelectedPickerColor = hsv;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include <base/color.h>
 #include <base/tl/array.h>
 
 #include <engine/console.h>
@@ -1029,4 +1030,108 @@ bool CEditor::PopupAutoMapProceedOrder()
 	}
 
 	return false;
+}
+
+int CEditor::PopupColorPicker(CEditor *pEditor, CUIRect View)
+{
+	CUIRect SVPicker, HuePicker;
+	View.VSplitRight(20.0f, &SVPicker, &HuePicker);
+	HuePicker.VSplitLeft(4.0f, 0x0, &HuePicker);
+
+	pEditor->Graphics()->TextureClear();
+	pEditor->Graphics()->QuadsBegin();
+
+	// base: white - hue
+	vec3 hsv = pEditor->m_SelectedPickerColor;
+	IGraphics::CColorVertex ColorArray[4];
+
+	vec3 c = HsvToRgb(vec3(hsv.x, 0.0f, 1.0f));
+	ColorArray[0] = IGraphics::CColorVertex(0, c.r, c.g, c.b, 1.0f);
+	c = HsvToRgb(vec3(hsv.x, 1.0f, 1.0f));
+	ColorArray[1] = IGraphics::CColorVertex(1, c.r, c.g, c.b, 1.0f);
+	c = HsvToRgb(vec3(hsv.x, 1.0f, 1.0f));
+	ColorArray[2] = IGraphics::CColorVertex(2, c.r, c.g, c.b, 1.0f);
+	c = HsvToRgb(vec3(hsv.x, 0.0f, 1.0f));
+	ColorArray[3] = IGraphics::CColorVertex(3, c.r, c.g, c.b, 1.0f);
+
+	pEditor->Graphics()->SetColorVertex(ColorArray, 4);
+
+	IGraphics::CQuadItem QuadItem(SVPicker.x, SVPicker.y, SVPicker.w, SVPicker.h);
+	pEditor->Graphics()->QuadsDrawTL(&QuadItem, 1);
+
+	// base: transparent - black
+	ColorArray[0] = IGraphics::CColorVertex(0, 0.0f, 0.0f, 0.0f, 0.0f);
+	ColorArray[1] = IGraphics::CColorVertex(1, 0.0f, 0.0f, 0.0f, 0.0f);
+	ColorArray[2] = IGraphics::CColorVertex(2, 0.0f, 0.0f, 0.0f, 1.0f);
+	ColorArray[3] = IGraphics::CColorVertex(3, 0.0f, 0.0f, 0.0f, 1.0f);
+
+	pEditor->Graphics()->SetColorVertex(ColorArray, 4);
+
+	pEditor->Graphics()->QuadsDrawTL(&QuadItem, 1);
+
+	pEditor->Graphics()->QuadsEnd();
+
+	// marker
+	vec2 Marker = vec2(hsv.y*pEditor->UI()->Scale(), (1.0f - hsv.z)*pEditor->UI()->Scale()) * vec2(SVPicker.w, SVPicker.h);
+	pEditor->Graphics()->QuadsBegin();
+	pEditor->Graphics()->SetColor(0.5f, 0.5f, 0.5f, 1.0f);
+	IGraphics::CQuadItem aMarker[2];
+	aMarker[0] = IGraphics::CQuadItem(SVPicker.x+Marker.x, SVPicker.y+Marker.y - 5.0f*pEditor->UI()->PixelSize(), pEditor->UI()->PixelSize(), 11.0f*pEditor->UI()->PixelSize());
+	aMarker[1] = IGraphics::CQuadItem(SVPicker.x+Marker.x - 5.0f*pEditor->UI()->PixelSize(), SVPicker.y+Marker.y, 11.0f*pEditor->UI()->PixelSize(), pEditor->UI()->PixelSize());
+	pEditor->Graphics()->QuadsDrawTL(aMarker, 2);
+	pEditor->Graphics()->QuadsEnd();
+
+	// logic
+	float X, Y;
+	static int ms_SVPicker = 0;
+	if(pEditor->UI()->DoPickerLogic(&ms_SVPicker, &SVPicker, &X, &Y))
+	{
+		hsv.y = X/SVPicker.w;
+		hsv.z = 1.0f - Y/SVPicker.h;	
+	}
+
+	// hue slider
+	static const float s_aColorIndices[7][3] = {
+		{1.0f, 0.0f, 0.0f}, // red
+		{1.0f, 0.0f, 1.0f},	// magenta
+		{0.0f, 0.0f, 1.0f}, // blue
+		{0.0f, 1.0f, 1.0f}, // cyan
+		{0.0f, 1.0f, 0.0f}, // green
+		{1.0f, 1.0f, 0.0f}, // yellow
+		{1.0f, 0.0f, 0.0f}  // red
+	};
+
+	pEditor->Graphics()->QuadsBegin();
+	vec4 ColorTop, ColorBottom;
+	float Offset = HuePicker.h/6.0f;
+	for(int j = 0; j < 6; j++)
+	{
+		ColorTop = vec4(s_aColorIndices[j][0], s_aColorIndices[j][1], s_aColorIndices[j][2], 1.0f);
+		ColorBottom = vec4(s_aColorIndices[j+1][0], s_aColorIndices[j+1][1], s_aColorIndices[j+1][2], 1.0f);
+
+		ColorArray[0] = IGraphics::CColorVertex(0, ColorTop.r, ColorTop.g, ColorTop.b, ColorTop.a);
+		ColorArray[1] = IGraphics::CColorVertex(1, ColorTop.r, ColorTop.g, ColorTop.b, ColorTop.a);
+		ColorArray[2] = IGraphics::CColorVertex(2, ColorBottom.r, ColorBottom.g, ColorBottom.b, ColorBottom.a);
+		ColorArray[3] = IGraphics::CColorVertex(3, ColorBottom.r, ColorBottom.g, ColorBottom.b, ColorBottom.a);
+		pEditor->Graphics()->SetColorVertex(ColorArray, 4);
+		IGraphics::CQuadItem QuadItem(HuePicker.x, HuePicker.y+Offset*j, HuePicker.w, Offset);
+		pEditor->Graphics()->QuadsDrawTL(&QuadItem, 1);
+	}
+
+	// marker
+	pEditor->Graphics()->SetColor(0.5f, 0.5f, 0.5f, 1.0f);
+	IGraphics::CQuadItem QuadItemMarker(HuePicker.x, HuePicker.y + (1.0f - hsv.x) * HuePicker.h * pEditor->UI()->Scale(), HuePicker.w, pEditor->UI()->PixelSize());
+	pEditor->Graphics()->QuadsDrawTL(&QuadItemMarker, 1);
+
+	pEditor->Graphics()->QuadsEnd();
+
+	static int ms_HuePicker = 0;
+	if(pEditor->UI()->DoPickerLogic(&ms_HuePicker, &HuePicker, &X, &Y))
+	{
+		hsv.x = 1.0f - Y/HuePicker.h;	
+	}
+
+	pEditor->m_SelectedPickerColor = hsv;
+
+	return 0;
 }


### PR DESCRIPTION
Added some color picking features for the editor: eyedropper/pipette and HSV color picker
(requested by @Sonix-).

Pipette is implemented by reading pixels from the current backbuffer, which involves CPU-GPU synchronization, but the performance penalty is neglectable.

(Includes cleanup and refactoring in some places)

Any feedback is welcome!
