### PR TITLE
Fix button fading

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -176,7 +176,9 @@ int CMenus::DoButton_Menu(const void *pID, const char *pText, int Checked, const
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 		TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.3f);
 	}
-	return UI()->DoButtonLogic(pID, pText, Checked, pRect);
+	int ret = UI()->DoButtonLogic(pID, pText, Checked, pRect);
+	if(ret) *const_cast<float*>(reinterpret_cast<const float*>(pID)) = 0;
+	return ret;
 }
 
 void CMenus::DoButton_KeySelect(const void *pID, const char *pText, int Checked, const CUIRect *pRect)


### PR DESCRIPTION
When pressing a button, it's FadeVal will be set to zero. It only works for the button which is pressed, and I see no possibility to reset the FadeVal of all buttons on the screen whenever pressing one of them. So it fixes #1337 as far as possible, but not entirely. You may also call the realization hacky, but it works :stuck_out_tongue_winking_eye: