### PR TITLE
Update of token cache missing in Client

### DIFF
--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -46,6 +46,7 @@ int CNetClient::Update()
 	if(m_Connection.State() == NET_CONNSTATE_ERROR)
 		Disconnect(m_Connection.ErrorString());
 	m_TokenManager.Update();
+	m_TokenCache.Update();
 	return 0;
 }
 


### PR DESCRIPTION
Has been done in CNetServer but is missing in CNetClient. Expired tokens won't get dropped which leads to info requests using an expired token (That's the reason why the serverlist cannot be refreshed after a few seconds). 