### PR TITLE
Added Linux desktop shortcuts and appstore metadata

### DIFF
--- a/other/teeworlds.appdata.xml
+++ b/other/teeworlds.appdata.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+  <id type="desktop">teeworlds.desktop</id>
+  <license>Zlib and CC-BY-SA-3.0</license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <summary>Online multiplayer shooter game</summary>
+  <description>
+    <p>
+      Teeworlds is a free online multiplayer game. Battle with up to 16 players
+      in a variety of game modes, including Team Deathmatch and Capture The Flag.
+      You can even design your own maps! 
+    </p>
+  </description>
+  <url type="homepage">https://www.teeworlds.com/</url>
+  <screenshots>
+    <screenshot>https://www.teeworlds.com/images/screens/screenshot_desert.png</screenshot>
+    <screenshot>https://www.teeworlds.com/images/screens/screenshot_grass.png</screenshot>
+    <screenshot>https://www.teeworlds.com/images/screens/screenshot_winter.png</screenshot>
+    <screenshot>https://www.teeworlds.com/images/screens/screenshot_jungle.png</screenshot>
+  </screenshots>
+</application>

--- a/other/teeworlds.desktop
+++ b/other/teeworlds.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Teeworlds
+GenericName=Online multi-player 2D platform shooter
+Type=Application
+Terminal=false
+Exec=teeworlds
+Icon=teeworlds
+Comment=Teeworlds: Jumping the Gun
+Categories=Game;ArcadeGame;


### PR DESCRIPTION
This adds metadata for Linux software stores. See https://people.freedesktop.org/~hughsient/appdata/ for reference. Also a shortcut for launching it from the applications menu was missing. Each distribution patched it in on their own. This contains a consolidated version with typos fixed and descriptions from your homepage. Closes https://github.com/teeworlds/teeworlds/issues/1228.