### PR TITLE
Added CircleCI automated building

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,18 @@
+dependencies:
+  pre:
+    - |
+        sudo apt-get install libsdl2-dev libfreetype6-dev
+
+        if [ ! -d ~/bam ]; then
+          git clone https://github.com/matricks/bam.git ~/bam
+          cd ~/bam/
+          git reset --hard f012dd9a3e38295b8a45af5a101d29573381f169
+          ./make_unix.sh
+        fi
+
+  cache_directories:
+    - "~/bam/"
+
+test:
+  override:
+    - ~/bam/bam conf=release all

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-Teeworlds
+Teeworlds [![CircleCI](https://circleci.com/gh/teeworlds/teeworlds.svg?style=svg)](https://circleci.com/gh/teeworlds/teeworlds)
 =========
 
 A retro multiplayer shooter


### PR DESCRIPTION
Automatically tries to build Teeworlds on commits (but does not try to run it). The readme has a badge indicating whether the last build on master succeeded or not.
Stuff on CircleCI is already set up. Note to anyone wanting to set this up for their fork that CircleCI must be configured (on the their site) to use Ubuntu 14.04 instead of 12.04 for SDL2 to be available.

Based on [DDNet's](https://github.com/ddnet/ddnet/blob/master/circle.yml) CircleCI configuration.