### PR TITLE
include stddef.h in system.h so size_t is available

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -8,6 +8,8 @@
 #ifndef BASE_SYSTEM_H
 #define BASE_SYSTEM_H
 
+#include <stddef.h>
+
 #include "detect.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Without this include teeworlds does not compile with clang on macOS.