### PR TITLE
Make client launchable from the browser given a special link

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2325,6 +2325,24 @@ static CClient *CreateClient()
 	return new(pClient) CClient;
 }
 
+static bool IsTeeworldsConnectLink(const char *str)
+{
+	const char *starter = "teeworlds:";
+
+	while(*str && *starter && *str == *starter)
+	{
+		str++;
+		starter++;
+	}
+
+	return *starter == '\0';
+}
+
+void CClient::HandleTeeworldsConnectLink(const char *clink)
+{
+	str_copy(m_aCmdConnect, clink + sizeof("teeworlds:") - 1, sizeof(m_aCmdConnect));
+}
+
 /*
 	Server Time
 	Client Mirror Time
@@ -2429,7 +2447,9 @@ int main(int argc, const char **argv) // ignore_convention
 		pConsole->ExecuteFile("autoexec.cfg");
 
 		// parse the command line arguments
-		if(argc > 1) // ignore_convention
+		if(argc == 2 && IsTeeworldsConnectLink(argv[1]))
+			pClient->HandleTeeworldsConnectLink(argv[1]);
+		else if(argc > 1) // ignore_convention
 			pConsole->ParseArguments(argc-1, &argv[1]); // ignore_convention
 	}
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -315,5 +315,8 @@ public:
 	void ToggleFullscreen();
 	void ToggleWindowBordered();
 	void ToggleWindowVSync();
+
+	// Teeworlds connect link
+	void HandleTeeworldsConnectLink(const char *clink);
 };
 #endif


### PR DESCRIPTION
It's the exact same mechanism than mailto:foo@bar.com links, adapted to
teeworlds.  Such links looks like:

```
teeworlds:1.2.3.4:8300
teeworlds:localhost
```

Browsers may require [extra configuration](http://kb.mozillazine.org/Register_protocol) to be able to open them.

Once everything is set up, clicking on a link in any webpage will prompt
the user to pick an application to open it.  Choosing (a compatible) 
teeworlds client will launch it and automatically connect it to the given
address.

Behind the scene, the browser will run the client with only one
argument: the full address.  Hence it is the same than running the
teeworlds client with the following command line:

```
teeworlds "teeworlds:1.2.3.4:8300"
```

The rational for this change is to allow websites like teerank.com,
teeworlds-stats.info, and others to provide a link to directly connect
to a server.  Users or webpages could also link a server.
