### PR TITLE
Fix kicking afk spectators joining the game

### DIFF
--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -1113,6 +1113,8 @@ void IGameController::DoTeamChange(CPlayer *pPlayer, int Team, bool DoChatMsg)
 	}
 	OnPlayerInfoChange(pPlayer);
 	GameServer()->OnClientTeamChange(ClientID);
+
+	pPlayer->m_InactivityTickCounter = 0;
 }
 
 int IGameController::GetStartTeam()


### PR DESCRIPTION
Currently, a client gets kicked for being inactive when joining the game from the spectator mode if the client was afk during that time.