### PR TITLE
Show motd unless we actively wanna look the scoreboard

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -412,6 +412,10 @@ bool CScoreboard::Active()
 	if(m_Active)
 		return true;
 
+	// skip if motd is present
+	if(m_pClient->m_pMotd->IsActive())
+		return false;
+
 	if(m_pClient->m_LocalClientID != -1 && m_pClient->m_aClients[m_pClient->m_LocalClientID].m_Team != TEAM_SPECTATORS)
 	{
 		// we are not a spectator, check if we are dead, don't follow a player and the game isn't paused


### PR DESCRIPTION
Should fix #1543 
The scoreboard was rendered shortly between enter and joining a team, clearing the motd. 