### PR TITLE
Fetch favorite info without relying on masterserver

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -95,17 +95,18 @@ void CServerBrowser::Set(const NETADDR &Addr, int SetType, int Token, const CSer
 			}
 		}
 		break;
-	/*else if(Type == SET_FAV_ADD)
-	{
-		if(m_ServerlistType != IServerBrowser::TYPE_FAVORITES)
-			return;
-
-		if(!Find(Addr))
+	case SET_FAV_ADD:
 		{
-			pEntry = Add(Addr);
-			QueueRequest(pEntry);
+			if(!(m_RefreshFlags&IServerBrowser::REFRESHFLAG_INTERNET))
+				return;
+
+			if(!Find(IServerBrowser::TYPE_INTERNET, Addr))
+			{
+				pEntry = Add(IServerBrowser::TYPE_INTERNET, Addr);
+				QueueRequest(pEntry);
+			}
 		}
-	}*/
+		break;
 	case SET_TOKEN:
 		{
 			int Type;
@@ -116,7 +117,7 @@ void CServerBrowser::Set(const NETADDR &Addr, int SetType, int Token, const CSer
 				Type = IServerBrowser::TYPE_INTERNET;
 				pEntry = Find(Type, Addr);
 				if(pEntry && (pEntry->m_InfoState != CServerEntry::STATE_PENDING || Token != pEntry->m_CurrentToken))
-					pEntry = 0;					
+					pEntry = 0;
 			}
 
 			// lan entry
@@ -125,7 +126,7 @@ void CServerBrowser::Set(const NETADDR &Addr, int SetType, int Token, const CSer
 				Type = IServerBrowser::TYPE_LAN;
 				pEntry = Add(Type, Addr);
 			}
-			
+
 			// set info
 			if(pEntry)
 			{
@@ -291,13 +292,10 @@ void CServerBrowser::Refresh(int RefreshFlags)
 		m_NumRequests = 0;
 
 		m_NeedRefresh = 1;
+		for(int i = 0; i < m_ServerBrowserFavorites.m_NumFavoriteServers; i++)
+			if(m_ServerBrowserFavorites.m_aFavoriteServers[i].m_State >= CServerBrowserFavorites::FAVSTATE_ADDR)
+				Set(m_ServerBrowserFavorites.m_aFavoriteServers[i].m_Addr, SET_FAV_ADD, -1, 0);
 	}
-	/*else if(Type == IServerBrowser::TYPE_FAVORITES)
-	{
-		for(int i = 0; i < m_NumFavoriteServers; i++)
-			if(m_aFavoriteServers[i].m_State >= FAVSTATE_ADDR)
-				Set(m_aFavoriteServers[i].m_Addr, SET_FAV_ADD, -1, 0);
-	}*/
 }
 
 int CServerBrowser::LoadingProgression() const
@@ -330,7 +328,7 @@ void CServerBrowser::AddFavorite(const CServerInfo *pInfo)
 }
 
 void CServerBrowser::RemoveFavorite(const CServerInfo *pInfo)
-{ 
+{
 	if(m_ServerBrowserFavorites.RemoveFavoriteEx(pInfo->m_aHostname, &pInfo->m_NetAddr))
 	{
 		for(int i = 0; i < NUM_TYPES; ++i)
@@ -460,7 +458,7 @@ void CServerBrowser::RequestImpl(const NETADDR &Addr, CServerEntry *pEntry) cons
 	Packer.Reset();
 	Packer.AddRaw(SERVERBROWSE_GETINFO, sizeof(SERVERBROWSE_GETINFO));
 	Packer.AddInt(pEntry ? pEntry->m_CurrentToken : m_CurrentLanToken);
-	
+
 	CNetChunk Packet;
 	Packet.m_ClientID = -1;
 	Packet.m_Address = Addr;
@@ -495,7 +493,7 @@ void CServerBrowser::SetInfo(int ServerlistType, CServerEntry *pEntry, const CSe
 		pEntry->m_Info.m_Flags |= FLAG_PUREMAP;
 	pEntry->m_Info.m_Favorite = Fav;
 	pEntry->m_Info.m_NetAddr = pEntry->m_Addr;
- 
+
 	m_aServerlist[ServerlistType].m_NumPlayers += pEntry->m_Info.m_NumPlayers;
 
 	pEntry->m_InfoState = CServerEntry::STATE_READY;


### PR DESCRIPTION
This is an attempt to solve #1542 
I reintroduced commented code, the useful part might not be at the right place since there is a special class for serverbrowser_fav. 