### PR TITLE
Highlighting is now also triggered by empty messages, and is disabled for the user's own messages. Fix #1559.

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -422,17 +422,20 @@ void CChat::AddLine(int ClientID, int Mode, const char *pLine)
 		m_aLines[m_CurrentLine].m_Mode = Mode;
 		m_aLines[m_CurrentLine].m_NameColor = -2;
 
-		// check for highlighted name
-		const char *pHL = str_find_nocase(pLine, m_pClient->m_aClients[m_pClient->m_LocalClientID].m_aName);
-		if(pHL)
+		if(ClientID != m_pClient->m_LocalClientID) // do not highlight our own messages
 		{
-			int Length = str_length(m_pClient->m_aClients[m_pClient->m_LocalClientID].m_aName);
-			if((pLine == pHL || pHL[-1] == ' ') // space or nothing before
-				&& ((pHL[Length] == 0 || pHL[Length] == ' ') || pHL[Length] == ':' && (pHL[Length+1] == 0) || pHL[Length+1] == ' ')) // space or nothing after, allowing a colon
+			// check for highlighted name
+			const char *pHL = str_find_nocase(pLine, m_pClient->m_aClients[m_pClient->m_LocalClientID].m_aName);
+			if(pHL)
 			{
-				Highlighted = true;
+				int Length = str_length(m_pClient->m_aClients[m_pClient->m_LocalClientID].m_aName);
+				if((pLine == pHL || pHL[-1] == ' ') // space or nothing before
+					&& ((pHL[Length] == 0 || pHL[Length] == ' ') || pHL[Length] == ':' && (pHL[Length+1] == 0) || pHL[Length+1] == ' ')) // space or nothing after, allowing a colon
+				{
+					Highlighted = true;
+				}
+				m_CompletionFav = ClientID;
 			}
-			m_CompletionFav = ClientID;
 		}
 
 		m_aLines[m_CurrentLine].m_Highlighted =  Highlighted || Mode == CHAT_WHISPER;


### PR DESCRIPTION
- `<username>:` now triggers highlighting
- typing your own name in a message no longer triggers highlighting
Fixes proposed issue #1559.