### PR TITLE
Improve chat look and feel part 1

### DIFF
--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -3,6 +3,8 @@
 #ifndef ENGINE_TEXTRENDER_H
 #define ENGINE_TEXTRENDER_H
 #include "kernel.h"
+#include <base/vmath.h>
+#include <engine/graphics.h>
 
 enum
 {
@@ -40,6 +42,11 @@ public:
 
 	//
 	virtual void TextEx(CTextCursor *pCursor, const char *pText, int Length) = 0;
+	virtual void TextDeferredRenderEx(CTextCursor *pCursor, const char *pText, int Length,
+		struct CQuadChar* aQuadChar, int QuadCharMaxCount, int* out_pQuadCharCount,
+		IGraphics::CTextureHandle* pFontTexture) = 0;
+	virtual void TextShadowed(CTextCursor *pCursor, const char *pText, int Length, vec2 ShadowOffset,
+		vec4 ShadowColor, vec4 TextColor_) = 0;
 
 	// old foolish interface
 	virtual void TextColor(float r, float g, float b, float a) = 0;

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -651,7 +651,7 @@ void CChat::OnRender()
 
 
 		const vec2 ShadowOffset(0.8f, 1.5f);
-		const vec4 ShadowColor(0, 0, 0, Blend * 0.75f);
+		const vec4 ShadowColor(0, 0, 0, Blend * 0.9f);
 
 		const vec4 ColorSystem(1.0f, 1.0f, 0.5f, Blend);
 		const vec4 ColorWhisper(1.0f, 0.5f, 0.9f, Blend);

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -12,7 +12,7 @@ class CChat : public CComponent
 
 	enum
 	{
-		MAX_LINES = 25,
+		MAX_LINES = 50,
 	};
 
 	struct CLine


### PR DESCRIPTION
Since we are improving the UI for 0.7.1, I thought I'd do a pass on the in-game chat.
The text is now rendered with a shadow instead of an outline, with minor tweaks to colors.
The category of chat is also displayed directly, making it easy to distinguish between them.
This should also fix #1582.

![image](https://user-images.githubusercontent.com/294603/47737863-2c27fa00-dc72-11e8-9ca2-faf06089ae78.png)

![image](https://user-images.githubusercontent.com/294603/47737916-4e217c80-dc72-11e8-8772-651ce7f9b029.png)
