### PR TITLE
In release builds, disable Windows console by default. Closes #1583

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2431,18 +2431,25 @@ void CClient::HandleTeeworldsConnectLink(const char *pConLink)
 int main(int argc, const char **argv) // ignore_convention
 {
 #if defined(CONF_FAMILY_WINDOWS)
+	bool UseDefaultConsoleSettings = true;
 	for(int i = 1; i < argc; i++) // ignore_convention
 	{
 #ifdef CONF_RELEASE
-		if(!(str_comp("-c", argv[i]) == 0 || str_comp("--console", argv[i]) == 0)) // ignore_convention
+		if(str_comp("-c", argv[i]) == 0 || str_comp("--console", argv[i]) == 0) // ignore_convention
 #else
 		if(str_comp("-s", argv[i]) == 0 || str_comp("--silent", argv[i]) == 0) // ignore_convention
 #endif
 		{
-			FreeConsole();
+			UseDefaultConsoleSettings = false;
 			break;
 		}
 	}
+#ifdef CONF_RELEASE
+	if(!UseDefaultConsoleSettings)
+#else
+	if(UseDefaultConsoleSettings)
+#endif
+		FreeConsole();
 #endif
 
 	bool UseDefaultConfig = false;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2433,7 +2433,11 @@ int main(int argc, const char **argv) // ignore_convention
 #if defined(CONF_FAMILY_WINDOWS)
 	for(int i = 1; i < argc; i++) // ignore_convention
 	{
+#ifdef CONF_RELEASE
 		if(str_comp("-s", argv[i]) == 0 || str_comp("--silent", argv[i]) == 0) // ignore_convention
+#else
+		if(!(str_comp("-c", argv[i]) == 0 || str_comp("--console", argv[i]) == 0)) // ignore_convention
+#endif
 		{
 			FreeConsole();
 			break;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2434,9 +2434,9 @@ int main(int argc, const char **argv) // ignore_convention
 	for(int i = 1; i < argc; i++) // ignore_convention
 	{
 #ifdef CONF_RELEASE
-		if(str_comp("-s", argv[i]) == 0 || str_comp("--silent", argv[i]) == 0) // ignore_convention
-#else
 		if(!(str_comp("-c", argv[i]) == 0 || str_comp("--console", argv[i]) == 0)) // ignore_convention
+#else
+		if(str_comp("-s", argv[i]) == 0 || str_comp("--silent", argv[i]) == 0) // ignore_convention
 #endif
 		{
 			FreeConsole();


### PR DESCRIPTION
It can be enabled again with a `-c` or `--console` option.
Leaving it for debug builds is a design choice, so feel free to discuss.

#1583 