### PR TITLE
Introduce cl_dynamic_camera option to toggle between camera modes

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -52,7 +52,7 @@ void CCamera::OnRender()
 			vec2 CameraOffset(0, 0);
 
 			float l = length(m_pClient->m_pControls->m_MousePos);
-			if(l > 0.0001f) // make sure that this isn't 0
+			if(g_Config.m_ClDynamicCamera && l > 0.0001f) // make sure that this isn't 0
 			{
 				float DeadZone = g_Config.m_ClMouseDeadzone;
 				float FollowFactor = g_Config.m_ClMouseFollowfactor/100.0f;

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -227,9 +227,15 @@ void CControls::ClampMousePos()
 	}
 	else
 	{
-		float CameraMaxDistance = 200.0f;
-		float FollowFactor = g_Config.m_ClMouseFollowfactor/100.0f;
-		float MouseMax = min(CameraMaxDistance/FollowFactor + g_Config.m_ClMouseDeadzone, (float)g_Config.m_ClMouseMaxDistance);
+		float MouseMax;
+		if(g_Config.m_ClDynamicCamera)
+		{
+			float CameraMaxDistance = 200.0f;
+			float FollowFactor = g_Config.m_ClMouseFollowfactor/100.0f;
+			MouseMax = min(CameraMaxDistance/FollowFactor + g_Config.m_ClMouseDeadzone, (float)g_Config.m_ClMouseMaxDistanceDynamic);
+		}
+		else
+			MouseMax = (float)g_Config.m_ClMouseMaxDistanceStatic;
 
 		if(length(m_MousePos) > MouseMax)
 			m_MousePos = normalize(m_MousePos)*MouseMax;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -706,18 +706,22 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	Game.HSplitTop(Spacing, 0, &Game);
 	Game.HSplitTop(ButtonHeight, &Button, &Game);
 	static int s_DynamicCameraButton = 0;
-	if(DoButton_CheckBox(&s_DynamicCameraButton, Localize("Dynamic Camera"), g_Config.m_ClMouseDeadzone != 0, &Button))
+	if(DoButton_CheckBox(&s_DynamicCameraButton, Localize("Dynamic Camera"), g_Config.m_ClDynamicCamera, &Button))
 	{
-		if(g_Config.m_ClMouseDeadzone)
+		if(g_Config.m_ClDynamicCamera)
 		{
-			g_Config.m_ClMouseFollowfactor = 0;
-			g_Config.m_ClMouseMaxDistance = 400;
-			g_Config.m_ClMouseDeadzone = 0;
+			g_Config.m_ClDynamicCamera = 0;
+			// force to defaults when using the GUI
+			g_Config.m_ClMouseMaxDistanceStatic = 400;
+			// g_Config.m_ClMouseFollowfactor = 0;
+			// g_Config.m_ClMouseDeadzone = 0;
 		}
 		else
 		{
+			g_Config.m_ClDynamicCamera = 1;
+			// force to defaults when using the GUI
+			g_Config.m_ClMouseMaxDistanceDynamic = 1000;
 			g_Config.m_ClMouseFollowfactor = 60;
-			g_Config.m_ClMouseMaxDistance = 1000;
 			g_Config.m_ClMouseDeadzone = 300;
 		}
 	}
@@ -850,8 +854,9 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	static CButtonContainer s_ResetButton;
 	if(DoButton_Menu(&s_ResetButton, Localize("Reset"), 0, &Button))
 	{
+		g_Config.m_ClDynamicCamera = 1;
+		g_Config.m_ClMouseMaxDistanceDynamic = 1000;
 		g_Config.m_ClMouseFollowfactor = 60;
-		g_Config.m_ClMouseMaxDistance = 1000;
 		g_Config.m_ClMouseDeadzone = 300;
 		g_Config.m_ClAutoswitchWeapons = 1;
 		g_Config.m_ClShowhud = 1;

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -23,9 +23,11 @@ MACRO_CONFIG_INT(ClThreadsoundloading, cl_threadsoundloading, 0, 0, 1, CFGFLAG_C
 
 MACRO_CONFIG_INT(ClWarningTeambalance, cl_warning_teambalance, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Warn about team balance")
 
+MACRO_CONFIG_INT(ClDynamicCamera, cl_dynamic_camera, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Switches camera mode. If set to 0, forces mouse deadzone to 0.")
 MACRO_CONFIG_INT(ClMouseDeadzone, cl_mouse_deadzone, 300, 0, 0, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")
 MACRO_CONFIG_INT(ClMouseFollowfactor, cl_mouse_followfactor, 60, 0, 200, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")
-MACRO_CONFIG_INT(ClMouseMaxDistance, cl_mouse_max_distance, 800, 0, 0, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")
+MACRO_CONFIG_INT(ClMouseMaxDistanceDynamic, cl_mouse_max_distance_dynamic, 1000, 0, 0, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Mouse max distance, in dynamic camera mode")
+MACRO_CONFIG_INT(ClMouseMaxDistanceStatic, cl_mouse_max_distance_static, 400, 0, 0, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Mouse max distance, in static camera mode")
 
 MACRO_CONFIG_INT(ClCustomizeSkin, cl_customize_skin, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")
 


### PR DESCRIPTION
Working on #1565. There is a new `cl_dynamic_camera` option that allows things like

`bind tab +toggle cl_dynamic camera 1 0`

holding `tab` then expands the view range of the tee.
Maybe it could even be a default, actually.

I ran into a bit of a problem with the `cl_mouse_max_distance`, as you definitely want to have a different one for static camera and dynamic camera. At first, I thought of forcing it to `400`, the default, but this would make the bind unusable by players who wish to change the default mouse radius (it would force defaults).

So I split `cl_mouse_max_distance` into `cl_mouse_max_distance_static` and `cl_mouse_max_distance_dynamic`

What `cl_dynamic_camera does now is a switch between:
* `cl_mouse_max_distance_dynamic` / `cl_mouse_follow_factor` / `cl_mouse_dead_zone`
* `cl_mouse_max_distance_static` / 0 / 0

Settings menus have been adapted to this behavior. The Dynamic Camera button resets the mouse settings to default when switching from a mode to another, according to what was decided in #1565.

Note: I didn't change the defaults. It still defaults to dynamic.