### PR TITLE
Disable scoreboard when on menu and hide motd when on menu

### DIFF
--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -9,6 +9,7 @@
 #include <generated/client_data.h>
 #include <game/client/gameclient.h>
 
+#include "menus.h"
 #include "motd.h"
 
 void CMotd::Clear()
@@ -18,6 +19,9 @@ void CMotd::Clear()
 
 bool CMotd::IsActive()
 {
+	// dont render modt if the menu is active
+	if(m_pClient->m_pMenus->IsActive())
+		return false;
 	return time_get() < m_ServerMotdTime;
 }
 

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -410,8 +410,10 @@ void CScoreboard::OnRender()
 bool CScoreboard::Active()
 {
 	// disable scoreboard if the menu is active
-	if(m_pClient->m_pMenus->IsActive())
+	if(m_pClient->m_pMenus->IsActive()) {
 		m_Active = false;
+		return false;
+	}
 
 	// if we activly wanna look on the scoreboard
 	if(m_Active)

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -16,6 +16,7 @@
 #include <game/client/components/motd.h>
 #include <game/client/components/skins.h>
 
+#include "menus.h"
 #include "scoreboard.h"
 
 
@@ -408,6 +409,10 @@ void CScoreboard::OnRender()
 
 bool CScoreboard::Active()
 {
+	// disable scoreboard if the menu is active
+	if(m_pClient->m_pMenus->IsActive())
+		m_Active = false;
+
 	// if we activly wanna look on the scoreboard
 	if(m_Active)
 		return true;

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -410,10 +410,8 @@ void CScoreboard::OnRender()
 bool CScoreboard::Active()
 {
 	// disable scoreboard if the menu is active
-	if(m_pClient->m_pMenus->IsActive()) {
-		m_Active = false;
+	if(m_pClient->m_pMenus->IsActive())
 		return false;
-	}
 
 	// if we activly wanna look on the scoreboard
 	if(m_Active)


### PR DESCRIPTION
Fix #1610 
NB: the scoreboard was stuck if pressing TAB and going to menu because controls are disabled on menu
MotD is preserved if entering and leaving menu in the ClMotdTime. 
This can be discussed.