### PR TITLE
Fixed text white outline

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -754,7 +754,7 @@ void CChat::OnRender()
 	}
 
 	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
-	TextRender()->TextOutlineColor(1.0f, 1.0f, 1.0f, 0.25f);
+	TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.3f);
 }
 
 void CChat::Say(int Mode, const char *pLine)


### PR DESCRIPTION
That was a bad copy and paste, my bad.
We should probably specify the TextOutline state in more places though, so this would not happen.