### PR TITLE
 More accurate ping estimation in the scoreboard

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -387,6 +387,12 @@ void CClient::DirectInput(int *pInput, int Size)
 	for(int i = 0; i < Size/4; i++)
 		Msg.AddInt(pInput[i]);
 
+	int PingCorrection = 0;
+	int64 TagTime;
+	if(m_SnapshotStorage.Get(m_AckGameTick, &TagTime, 0, 0) >= 0)
+		PingCorrection = (int)(((time_get()-TagTime)*1000)/time_freq());
+	Msg.AddInt(PingCorrection);
+
 	SendMsg(&Msg, 0);
 }
 
@@ -417,6 +423,12 @@ void CClient::SendInput()
 	// pack it
 	for(int i = 0; i < Size/4; i++)
 		Msg.AddInt(m_aInputs[m_CurrentInput].m_aData[i]);
+
+	int PingCorrection = 0;
+	int64 TagTime;
+	if(m_SnapshotStorage.Get(m_AckGameTick, &TagTime, 0, 0) >= 0)
+		PingCorrection = (int)(((Now-TagTime)*1000)/time_freq());
+	Msg.AddInt(PingCorrection);
 
 	m_CurrentInput++;
 	m_CurrentInput%=200;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -377,26 +377,6 @@ bool CClient::ConnectionProblems() const
 	return m_NetClient.GotProblems() != 0;
 }
 
-void CClient::DirectInput(int *pInput, int Size)
-{
-	CMsgPacker Msg(NETMSG_INPUT, true);
-	Msg.AddInt(m_AckGameTick);
-	Msg.AddInt(m_PredTick);
-	Msg.AddInt(Size);
-
-	for(int i = 0; i < Size/4; i++)
-		Msg.AddInt(pInput[i]);
-
-	int PingCorrection = 0;
-	int64 TagTime;
-	if(m_SnapshotStorage.Get(m_AckGameTick, &TagTime, 0, 0) >= 0)
-		PingCorrection = (int)(((time_get()-TagTime)*1000)/time_freq());
-	Msg.AddInt(PingCorrection);
-
-	SendMsg(&Msg, 0);
-}
-
-
 void CClient::SendInput()
 {
 	int64 Now = time_get();

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -212,7 +212,6 @@ public:
 
 	virtual IGraphics::CTextureHandle GetDebugFont() const { return m_DebugFont; }
 
-	void DirectInput(int *pInput, int Size);
 	void SendInput();
 
 	// TODO: OPT: do this alot smarter!


### PR DESCRIPTION
This adds the delay between `NETMSG_SNAP` and `NETMSG_INPUT` to the `NETMSG_INPUT` packet, so the server can use it to calculate a more accurate latency value.

This allows ping faking to some extent, but it was already possible by modifying the first value in `NETMSG_INPUT`.