### PR TITLE
Remove outdated console chain code for browser filters

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2400,8 +2400,6 @@ void CClient::RegisterCommands()
 
 	// used for server browser update
 	m_pConsole->Chain("br_filter_string", ConchainServerBrowserUpdate, this);
-	m_pConsole->Chain("br_filter_gametype", ConchainServerBrowserUpdate, this);
-	m_pConsole->Chain("br_filter_serveraddress", ConchainServerBrowserUpdate, this);
 
 	m_pConsole->Chain("gfx_screen", ConchainWindowScreen, this);
 	m_pConsole->Chain("gfx_fullscreen", ConchainFullscreen, this);


### PR DESCRIPTION
Commit a5f585357039620361b071cc9f15b6f71c103b26 left out console chains:

https://github.com/teeworlds/teeworlds/blob/e2c6ce81eb9e084ceced500363790d3f079271fb/src/engine/client/client.cpp#L2401-L2404