### PR TITLE
Add an 'up-to-date' server browser filter, filters out previous server versions

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1713,7 +1713,7 @@ void CClient::InitInterfaces()
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 
 	//
-	m_ServerBrowser.SetBaseInfo(&m_ContactClient, m_pGameClient->NetVersion());
+	m_ServerBrowser.SetBaseInfo(&m_ContactClient, m_pGameClient->NetVersion(), m_pGameClient->Version());
 	m_Friends.Init();
 }
 

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -61,10 +61,11 @@ CServerBrowser::CServerBrowser()
 	m_BroadcastTime = 0;
 }
 
-void CServerBrowser::SetBaseInfo(class CNetClient *pClient, const char *pNetVersion)
+void CServerBrowser::SetBaseInfo(class CNetClient *pClient, const char *pNetVersion, const char *pGameVersion)
 {
 	m_pNetClient = pClient;
 	str_copy(m_aNetVersion, pNetVersion, sizeof(m_aNetVersion));
+	str_copy(m_aGameVersion, pGameVersion, sizeof(m_aGameVersion));
 	m_pMasterServer = Kernel()->RequestInterface<IMasterServer>();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pFriends = Kernel()->RequestInterface<IFriends>();
@@ -180,6 +181,10 @@ void CServerBrowser::Filter()
 			Filtered = 1;
 		else if(g_Config.m_BrFilterCompatversion && str_comp_num(m_ppServerlist[i]->m_Info.m_aVersion, m_aNetVersion, 3) != 0)
 			Filtered = 1;
+		else if((g_Config.m_BrFilterUptodate && str_comp_num(m_ppServerlist[i]->m_Info.m_aVersion, m_aGameVersion, 5) != 0)
+			&& !(str_comp_num(m_ppServerlist[i]->m_Info.m_aVersion, m_aGameVersion, 4) == 0 
+			&& m_ppServerlist[i]->m_Info.m_aVersion[4] >= m_aGameVersion[4] && m_ppServerlist[i]->m_Info.m_aVersion[4] <= '9'))
+			Filtered = 1;
 		else if(g_Config.m_BrFilterServerAddress[0] && !str_find_nocase(m_ppServerlist[i]->m_Info.m_aAddress, g_Config.m_BrFilterServerAddress))
 			Filtered = 1;
 		else if(g_Config.m_BrFilterGametypeStrict && g_Config.m_BrFilterGametype[0] && str_comp_nocase(m_ppServerlist[i]->m_Info.m_aGameType, g_Config.m_BrFilterGametype))
@@ -271,6 +276,7 @@ int CServerBrowser::SortHash() const
 	i |= g_Config.m_BrFilterGametypeStrict<<13;
 	i |= g_Config.m_BrFilterCountry<<14;
 	i |= g_Config.m_BrFilterPing<<15;
+	i |= g_Config.m_BrFilterUptodate<<16;
 	return i;
 }
 

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -58,7 +58,7 @@ public:
 	void Set(const NETADDR &Addr, int Type, int Token, const CServerInfo *pInfo);
 	void Request(const NETADDR &Addr) const;
 
-	void SetBaseInfo(class CNetClient *pClient, const char *pNetVersion);
+	void SetBaseInfo(class CNetClient *pClient, const char *pNetVersion, const char *pGameVersion);
 
 private:
 	CNetClient *m_pNetClient;
@@ -66,6 +66,7 @@ private:
 	class IConsole *m_pConsole;
 	class IFriends *m_pFriends;
 	char m_aNetVersion[128];
+	char m_aGameVersion[128];
 
 	CHeap m_ServerlistHeap;
 	CServerEntry **m_ppServerlist;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -44,6 +44,7 @@ MACRO_CONFIG_STR(BrFilterServerAddress, br_filter_serveraddress, 128, "", CFGFLA
 MACRO_CONFIG_INT(BrFilterPure, br_filter_pure, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Filter out non-standard servers in browser")
 MACRO_CONFIG_INT(BrFilterPureMap, br_filter_pure_map, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Filter out non-standard maps in browser")
 MACRO_CONFIG_INT(BrFilterCompatversion, br_filter_compatversion, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Filter out non-compatible servers in browser")
+MACRO_CONFIG_INT(BrFilterUptodate, br_filter_uptodate, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Filter out servers not up-to-date (>= client version)")
 
 MACRO_CONFIG_INT(BrSort, br_sort, 4, 0, 256, CFGFLAG_SAVE|CFGFLAG_CLIENT, "")
 MACRO_CONFIG_INT(BrSortOrder, br_sort_order, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "")

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -510,6 +510,10 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 		g_Config.m_BrFilterCompatversion ^= 1;
 
 	ServerFilter.HSplitTop(20.0f, &Button, &ServerFilter);
+	if (DoButton_CheckBox((char *)&g_Config.m_BrFilterUptodate, Localize("Up-to-date only"), g_Config.m_BrFilterUptodate, &Button))
+		g_Config.m_BrFilterUptodate ^= 1;
+
+	ServerFilter.HSplitTop(20.0f, &Button, &ServerFilter);
 	if (DoButton_CheckBox((char *)&g_Config.m_BrFilterPure, Localize("Standard gametype"), g_Config.m_BrFilterPure, &Button))
 		g_Config.m_BrFilterPure ^= 1;
 
@@ -594,6 +598,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 		g_Config.m_BrFilterPure = 1;
 		g_Config.m_BrFilterPureMap = 1;
 		g_Config.m_BrFilterCompatversion = 1;
+		g_Config.m_BrFilterUptodate = 1;
 		Client()->ServerBrowserUpdate();
 	}
 }


### PR DESCRIPTION
This is a proposal to close #1644 and help players see servers that are free of spoofed clients.

This is for the 0.6 branch.