### PR TITLE
Don't hash protocol header twice in bam.lua 

### DIFF
--- a/bam.lua
+++ b/bam.lua
@@ -112,7 +112,7 @@ AddDependency(network_source, network_header)
 AddDependency(client_content_source, client_content_header)
 AddDependency(server_content_source, server_content_header)
 
-nethash = CHash("src/game/generated/nethash.cpp", "src/engine/shared/protocol.h", "src/game/generated/protocol.h", "src/game/tuning.h", "src/game/gamecore.cpp", network_header)
+nethash = CHash("src/game/generated/nethash.cpp", "src/engine/shared/protocol.h", "src/game/generated/protocol.h", "src/game/tuning.h", "src/game/gamecore.cpp")
 
 client_link_other = {}
 client_depends = {}

--- a/scripts/cmd5.py
+++ b/scripts/cmd5.py
@@ -30,6 +30,6 @@ for filename in sys.argv[1:]:
 
 hash = hashlib.md5(f).hexdigest().lower()[16:]
 #TODO 0.7: improve nethash creation
-if hash == "e42d81cd67b8c7bc":
+if hash == "fc9dffd45c6d100a":
 	hash = "626fce9a778df4d4"
 print('#define GAME_NETVERSION_HASH "%s"' % hash)


### PR DESCRIPTION
This was only fixed in CMake, resulting in differing nethashes.