### PR TITLE
Pre-multiplied alpha fix

### DIFF
--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -67,7 +67,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 						Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "countryflags", aBuf);
 						continue;
 					}
-					
+
 					// add entry
 					const char *pCountryName = rStart[i]["id"];
 					CCountryFlag CountryFlag;
@@ -89,7 +89,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 						mem_free(Info.m_pData);
 					}
 					m_aCountryFlags.add_unsorted(CountryFlag);
-		
+
 					// print message
 					if(g_Config.m_Debug)
 					{
@@ -113,7 +113,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 			DefaultIndex = Index;
 			break;
 		}
-	
+
 	// init LUT
 	if(DefaultIndex != 0)
 		for(int i = 0; i < CODE_RANGE; ++i)
@@ -161,7 +161,7 @@ void CCountryFlags::Render(int CountryCode, const vec4 *pColor, float x, float y
 	{
 		Graphics()->TextureSet(pFlag->m_Texture);
 		Graphics()->QuadsBegin();
-		Graphics()->SetColor(pColor->r, pColor->g, pColor->b, pColor->a);
+		Graphics()->SetColor(pColor->r*pColor->a, pColor->g*pColor->a, pColor->b*pColor->a, pColor->a);
 		IGraphics::CQuadItem QuadItem(x, y, w, h);
 		Graphics()->QuadsDrawTL(&QuadItem, 1);
 		Graphics()->QuadsEnd();

--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -70,7 +70,8 @@ void CDamageInd::OnRender()
 		else
 		{
 			vec2 Pos = mix(m_aItems[i].m_Pos+m_aItems[i].m_Dir*75.0f, m_aItems[i].m_Pos, clamp((Life-0.60f)/0.15f, 0.0f, 1.0f));
-			Graphics()->SetColor(1.0f,1.0f,1.0f, Life/0.1f);
+			const float Alpha = clamp(Life * 10.0f, 0.0f, 1.0f); // 0.1 -> 0.0 == 1.0 -> 0.0
+			Graphics()->SetColor(1.0f*Alpha, 1.0f*Alpha, 1.0f*Alpha, Alpha);
 			Graphics()->QuadsSetRotation(m_aItems[i].m_StartAngle + Life * 2.0f);
 			RenderTools()->SelectSprite(SPRITE_STAR1);
 			RenderTools()->DrawSprite(Pos.x, Pos.y, 48.0f);

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -472,7 +472,7 @@ void CPlayers::RenderPlayer(
 
 		Graphics()->QuadsSetRotation(pi/6*WiggleAngle);
 
-		Graphics()->SetColor(1.0f,1.0f,1.0f,a);
+		Graphics()->SetColor(1.0f * a, 1.0f * a, 1.0f * a, a);
 		// client_datas::emoticon is an offset from the first emoticon
 		RenderTools()->SelectSprite(SPRITE_OOP + m_pClient->m_aClients[ClientID].m_Emoticon);
 		IGraphics::CQuadItem QuadItem(Position.x, Position.y - 23 - 32*h, 64, 64*h);

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -83,7 +83,7 @@ float SolveBezier(float x, float p0, float p1, float p2, float p3)
 		// cardano's method
 		double p = b/3 - a*a/9;
 		double q = (2*a*a*a/27 - a*b/3 + c)/2;
-		
+
 		double D = q*q + p*p*p;
 
 		if(D > 0.0)
@@ -97,7 +97,7 @@ float SolveBezier(float x, float p0, float p1, float p2, float p3)
 			// one single, one double solution or triple solution
 			double s = CubicRoot(-q);
 			t = 2*s - sub;
-			
+
 			if(0.0 <= t && t <= 1.0001f)
 				return t;
 			else
@@ -180,7 +180,7 @@ void CRenderTools::RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Cha
 					p3 = vec2(pPoints[i+1].m_Time/1000.0f, fx2f(pPoints[i+1].m_aValues[c]));
 
 					outTang = vec2(pPoints[i].m_aOutTangentdx[c]/1000.0f, fx2f(pPoints[i].m_aOutTangentdy[c]));
-					inTang = -vec2(pPoints[i+1].m_aInTangentdx[c]/1000.0f, fx2f(pPoints[i+1].m_aInTangentdy[c]));					
+					inTang = -vec2(pPoints[i+1].m_aInTangentdx[c]/1000.0f, fx2f(pPoints[i+1].m_aInTangentdy[c]));
 					p1 = p0 + outTang;
 					p2 = p3 - inTang;
 
@@ -197,7 +197,7 @@ void CRenderTools::RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Cha
 			case CURVETYPE_LINEAR:
 				break;
 			}
-			
+
 			for(int c = 0; c < Channels; c++)
 			{
 				float v0 = fx2f(pPoints[i].m_aValues[c]);
@@ -248,7 +248,7 @@ void CRenderTools::RenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, ENV
 		 TODO: Analyze quadtexture
 		if(a < 0.01f || (q->m_aColors[0].a < 0.01f && q->m_aColors[1].a < 0.01f && q->m_aColors[2].a < 0.01f && q->m_aColors[3].a < 0.01f))
 			Opaque = true;
-		
+
 		if(Opaque && !(RenderFlags&LAYERRENDERFLAG_OPAQUE))
 			continue;
 		if(!Opaque && !(RenderFlags&LAYERRENDERFLAG_TRANSPARENT))
@@ -348,7 +348,8 @@ void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 
 	}
 
 	Graphics()->QuadsBegin();
-	Graphics()->SetColor(Color.r*r, Color.g*g, Color.b*b, Color.a*a);
+	const float Alpha = Color.a*a;
+	Graphics()->SetColor(Color.r*r*Alpha, Color.g*g*Alpha, Color.b*b*Alpha, Alpha);
 
 	int StartY = (int)(ScreenY0/Scale)-1;
 	int StartX = (int)(ScreenX0/Scale)-1;
@@ -442,7 +443,7 @@ void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 
 						y3 = y2;
 						y2 = y1;
 						y1 = Tmp;
- 					}
+					}
 
 					Graphics()->QuadsSetSubsetFree(x0, y0, x1, y1, x2, y2, x3, y3, Index);
 					IGraphics::CQuadItem QuadItem(x*Scale, y*Scale, Scale, Scale);


### PR DESCRIPTION
Fixed pre-multiplied alpha for flags, damage indicators, emotes and tile layers.
Fixes #1530.

*this is a modified dm8 for illustration purposes*
Before:
![screenshot_2018-11-14_18-08-11](https://user-images.githubusercontent.com/294603/48554111-cd06ee00-e8dd-11e8-80d9-b73636135991.png)

After:
![screenshot_2018-11-14_18-08-42](https://user-images.githubusercontent.com/294603/48554117-d2643880-e8dd-11e8-9bea-a66faf130483.png)
