### PR TITLE
Fix&improve the server browser (issue #1670)

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -63,6 +63,7 @@ CMenus::CMenus()
 
 	m_EscapePressed = false;
 	m_EnterPressed = false;
+	m_TabPressed = false;
 	m_DeletePressed = false;
 	m_UpArrowPressed = false;
 	m_DownArrowPressed = false;
@@ -2308,6 +2309,8 @@ bool CMenus::OnInput(IInput::CEvent e)
 			// special for popups
 			if(e.m_Key == KEY_RETURN || e.m_Key == KEY_KP_ENTER)
 				m_EnterPressed = true;
+			else if(e.m_Key == KEY_TAB)
+				m_TabPressed = true;
 			else if(e.m_Key == KEY_DELETE)
 				m_DeletePressed = true;
 			else if(e.m_Key == KEY_UP)
@@ -2429,6 +2432,7 @@ void CMenus::OnRender()
 	{
 		m_EscapePressed = false;
 		m_EnterPressed = false;
+		m_TabPressed = false;
 		m_DeletePressed = false;
 		m_UpArrowPressed = false;
 		m_DownArrowPressed = false;
@@ -2480,6 +2484,7 @@ void CMenus::OnRender()
 	UI()->FinishCheck();
 	m_EscapePressed = false;
 	m_EnterPressed = false;
+	m_TabPressed = false;
 	m_DeletePressed = false;
 	m_UpArrowPressed = false;
 	m_DownArrowPressed = false;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -238,6 +238,7 @@ private:
 	//
 	bool m_EscapePressed;
 	bool m_EnterPressed;
+	bool m_TabPressed;
 	bool m_DeletePressed;
 	bool m_UpArrowPressed;
 	bool m_DownArrowPressed;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -642,25 +642,17 @@ bool CMenus::RenderFilterHeader(CUIRect View, int FilterIndex)
 
 	float ButtonHeight = 20.0f;
 	float Spacing = 3.0f;
+	bool Switch = false;
 
 	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
 	CUIRect Button, EditButtons;
 	View.VSplitLeft(20.0f, &Button, &View);
 	Button.Margin(2.0f, &Button);
-	if(DoButton_SpriteClean(IMAGE_MENUICONS, pFilter->Extended() ? SPRITE_MENU_EXPANDED : SPRITE_MENU_COLLAPSED, &Button))
+	if(DoButton_SpriteClean(IMAGE_MENUICONS, pFilter->Extended() ? SPRITE_MENU_EXPANDED : SPRITE_MENU_COLLAPSED, &Button)
+		|| (UI()->MouseInside(&View) && Input()->KeyPress(KEY_MOUSE_1)))
 	{
-		pFilter->Switch();
-		
-		// retract the other filters
-		if(pFilter->Extended())
-		{
-			for(int i = 0; i < m_lFilters.size(); ++i)
-			{
-				if(i != FilterIndex && m_lFilters[i].Extended())
-					m_lFilters[i].Switch();
-			}
-		}
+		Switch = true; // switch later, to make sure we haven't clicked one of the filter buttons (edit...)
 	}
 
 	// split buttons from label
@@ -714,6 +706,7 @@ bool CMenus::RenderFilterHeader(CUIRect View, int FilterIndex)
 		static int s_EditPopupID = 0;
 		m_SelectedFilter = FilterIndex;
 		InvokePopupMenu(&s_EditPopupID, 0, UI()->MouseX(), UI()->MouseY(), 200.0f, 310.0f, PopupFilter);
+		Switch = false;
 	}
 
 	EditButtons.VSplitRight(Spacing, &EditButtons, 0);
@@ -722,7 +715,10 @@ bool CMenus::RenderFilterHeader(CUIRect View, int FilterIndex)
 	if(FilterIndex > 0 && (pFilter->Custom() > CBrowserFilter::FILTER_ALL || m_lFilters[FilterIndex-1].Custom() != CBrowserFilter::FILTER_STANDARD))
 	{
 		if(DoButton_SpriteClean(IMAGE_TOOLICONS, SPRITE_TOOL_UP_A, &Button))
+		{
 			Move(true, FilterIndex);
+			Switch = false;
+		}
 	}
 	else
 		DoIcon(IMAGE_TOOLICONS, SPRITE_TOOL_UP_B, &Button);
@@ -733,10 +729,27 @@ bool CMenus::RenderFilterHeader(CUIRect View, int FilterIndex)
 	if(FilterIndex >= 0 && FilterIndex < m_lFilters.size()-1 && (pFilter->Custom() != CBrowserFilter::FILTER_STANDARD || m_lFilters[FilterIndex+1].Custom() > CBrowserFilter::FILTER_ALL))
 	{
 		if(DoButton_SpriteClean(IMAGE_TOOLICONS, SPRITE_TOOL_DOWN_A, &Button))
+		{
 			Move(false, FilterIndex);
+			Switch = false;
+		}
 	}
 	else
 		DoIcon(IMAGE_TOOLICONS, SPRITE_TOOL_DOWN_B, &Button);
+
+	if(Switch)
+	{
+		pFilter->Switch();
+		// retract the other filters
+		if(pFilter->Extended())
+		{
+			for(int i = 0; i < m_lFilters.size(); ++i)
+			{
+				if(i != FilterIndex && m_lFilters[i].Extended())
+					m_lFilters[i].Switch();
+			}
+		}
+	}
 
 	return false;
 }

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1341,20 +1341,21 @@ void CMenus::RenderServerbrowserSidebar(CUIRect View)
 
 	// header
 	View.HSplitTop(ms_ListheaderHeight, &Header, &View);
-	Header.VSplitLeft(Header.w/2, &Button, &Header);
-	static CButtonContainer s_TabFriends;
-	if(DoButton_SpriteID(&s_TabFriends, IMAGE_SIDEBARICONS, m_SidebarTab!=0?SPRITE_SIDEBAR_FRIEND_A:SPRITE_SIDEBAR_FRIEND_B, m_SidebarTab==0 , &Button, CUI::CORNER_TL, 5.0f, true))
+	float Width = Header.w;
+	Header.VSplitLeft(Width*0.30f, &Button, &Header);
+	static CButtonContainer s_TabInfo;
+	if(DoButton_SpriteID(&s_TabInfo, IMAGE_SIDEBARICONS, m_SidebarTab!=0?SPRITE_SIDEBAR_INFO_A: SPRITE_SIDEBAR_INFO_B, m_SidebarTab==0 , &Button, CUI::CORNER_TL, 5.0f, true))
 	{
 		m_SidebarTab = 0;
 	}
-	Header.VSplitLeft(Header.w/2, &Button, &Header);
+	Header.VSplitLeft(Width*0.30f, &Button, &Header);
 	static CButtonContainer s_TabFilter;
 	if(DoButton_SpriteID(&s_TabFilter, IMAGE_SIDEBARICONS, m_SidebarTab!=1?SPRITE_SIDEBAR_FILTER_A: SPRITE_SIDEBAR_FILTER_B, m_SidebarTab==1, &Button, 0, 0.0f, true))
 	{
 		m_SidebarTab = 1;
 	}
-	static CButtonContainer s_TabInfo;
-	if(DoButton_SpriteID(&s_TabInfo, IMAGE_SIDEBARICONS, m_SidebarTab!=2?SPRITE_SIDEBAR_INFO_A: SPRITE_SIDEBAR_INFO_B, m_SidebarTab == 2, &Header, CUI::CORNER_TR, 5.0f, true))
+	static CButtonContainer s_TabFriends;
+	if(DoButton_SpriteID(&s_TabFriends, IMAGE_SIDEBARICONS, m_SidebarTab!=2?SPRITE_SIDEBAR_FRIEND_A:SPRITE_SIDEBAR_FRIEND_B, m_SidebarTab == 2, &Header, CUI::CORNER_TR, 5.0f, true))
 	{
 		m_SidebarTab = 2;
 	}
@@ -1363,13 +1364,13 @@ void CMenus::RenderServerbrowserSidebar(CUIRect View)
 	switch(m_SidebarTab)
 	{
 	case 0:
-		RenderServerbrowserFriendTab(View);
+		RenderServerbrowserInfoTab(View);
 		break;
 	case 1:
 		RenderServerbrowserFilterTab(View);
 		break;
 	case 2:
-		RenderServerbrowserInfoTab(View);
+		RenderServerbrowserFriendTab(View);
 	}
 }
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1004,7 +1004,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	{
 		if(i == COL_BROWSER_FLAG)
 		{
-			CUIRect Rect = ms_aBrowserCols[i].m_Rect;
+			/*CUIRect Rect = ms_aBrowserCols[i].m_Rect;
 			CUIRect Icon;
 
 			Rect.VSplitLeft(Rect.h, &Icon, &Rect);
@@ -1021,7 +1021,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 			Rect.VSplitLeft(Rect.h, &Icon, &Rect);
 			Icon.Margin(2.0f, &Icon);
-			DoIcon(IMAGE_BROWSEICONS, SPRITE_BROWSE_HEART_A, &Icon);
+			DoIcon(IMAGE_BROWSEICONS, SPRITE_BROWSE_HEART_A, &Icon);*/
 		}
 		else if(DoButton_GridHeader(ms_aBrowserCols[i].m_Caption, ms_aBrowserCols[i].m_Caption, g_Config.m_BrSort == ms_aBrowserCols[i].m_Sort, &ms_aBrowserCols[i].m_Rect))
 		{

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1339,6 +1339,18 @@ void CMenus::RenderServerbrowserSidebar(CUIRect View)
 	// background
 	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
+	// handle Tab key
+	if(m_TabPressed)
+	{
+		if(Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT))
+		{
+			m_SidebarTab--;
+			if(m_SidebarTab < 0) m_SidebarTab = 2;
+		}
+		else
+			m_SidebarTab = (m_SidebarTab+1)%3;
+	}
+
 	// header
 	View.HSplitTop(ms_ListheaderHeight, &Header, &View);
 	float Width = Header.w;

--- a/src/game/client/components/menus_popups.cpp
+++ b/src/game/client/components/menus_popups.cpp
@@ -189,6 +189,7 @@ int CMenus::PopupFilter(CMenus *pMenus, CUIRect View)
 		}
 	}
 	static float s_ScrollValue = 0.0f;
+	bool NeedScrollbar = (Button.w - Length) < 0.0f;
 	Button.x += min(0.0f, Button.w - Length) * s_ScrollValue;
 	for(int i = 0; i < CServerFilterInfo::MAX_GAMETYPES; ++i)
 	{
@@ -219,10 +220,17 @@ int CMenus::PopupFilter(CMenus *pMenus, CUIRect View)
 
 	pMenus->UI()->ClipDisable();
 
+	if(NeedScrollbar)
+	{
+		ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
+		s_ScrollValue = pMenus->DoScrollbarH(&s_ScrollValue, &Button, s_ScrollValue);
+	}
+	else
+	{
+		ServerFilter.HSplitTop(5.f, &Button, &ServerFilter);
+	}
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
-	s_ScrollValue = pMenus->DoScrollbarH(&s_ScrollValue, &Button, s_ScrollValue);
 
-	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 	Button.VSplitLeft(60.0f, &Button, &Icon);
 	ServerFilter.HSplitTop(3.0f, 0, &ServerFilter);
 	static char s_aGametype[16] = {0};
@@ -255,6 +263,9 @@ int CMenus::PopupFilter(CMenus *pMenus, CUIRect View)
 		}
 		pFilter->SetFilter(&FilterInfo);
 	}
+
+	if(!NeedScrollbar)
+		ServerFilter.HSplitTop(LineSize-5.f, &Button, &ServerFilter);
 
 	{
 		ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);

--- a/src/game/client/components/menus_popups.cpp
+++ b/src/game/client/components/menus_popups.cpp
@@ -226,9 +226,7 @@ int CMenus::PopupFilter(CMenus *pMenus, CUIRect View)
 		s_ScrollValue = pMenus->DoScrollbarH(&s_ScrollValue, &Button, s_ScrollValue);
 	}
 	else
-	{
-		ServerFilter.HSplitTop(5.f, &Button, &ServerFilter);
-	}
+		ServerFilter.HSplitTop(4.f, &Button, &ServerFilter); // Leave some space in between edit boxes
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 
 	Button.VSplitLeft(60.0f, &Button, &Icon);
@@ -253,6 +251,7 @@ int CMenus::PopupFilter(CMenus *pMenus, CUIRect View)
 			}
 		}
 	}
+	Icon.VSplitLeft(10.0f, 0, &Icon);
 	Icon.VSplitLeft(40.0f, &Button, 0);
 	static CButtonContainer s_ClearGametypes;
 	if(pMenus->DoButton_MenuTabTop(&s_ClearGametypes, Localize("Clear"), false, &Button))
@@ -265,7 +264,7 @@ int CMenus::PopupFilter(CMenus *pMenus, CUIRect View)
 	}
 
 	if(!NeedScrollbar)
-		ServerFilter.HSplitTop(LineSize-5.f, &Button, &ServerFilter);
+		ServerFilter.HSplitTop(LineSize-4.f, &Button, &ServerFilter);
 
 	{
 		ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);


### PR DESCRIPTION
This fixes several points from issue #1670:

- make dropdown filters expandable by clicking on the line (instead of the [+]).

clicking on the buttons does not expand it

-  do not show the game types scrollbar when it's not necessary

still put some space so it doesn't move what's below while not looking too odd:

![image](https://user-images.githubusercontent.com/355114/48623295-8ed70080-e9a9-11e8-8eb7-4d40361f202c.png)

- add some space between the + and Clear

-  remove top left icons, not useful (and outdated for the /!\)

- change the order of the friends tab and info, resize a bit while keeping the friends tab the largest for now. make Tab and Shift+Tab toggle those tabs

![image](https://user-images.githubusercontent.com/355114/48623316-9e564980-e9a9-11e8-81f0-6278d2fd876d.png)

Each bullet point from the issue is a separate commit.