### PR TITLE
Fix toggling the up-to-date filter

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -275,8 +275,8 @@ int CServerBrowser::SortHash() const
 	i |= g_Config.m_BrFilterPureMap<<12;
 	i |= g_Config.m_BrFilterGametypeStrict<<13;
 	i |= g_Config.m_BrFilterCountry<<14;
-	i |= g_Config.m_BrFilterPing<<15;
-	i |= g_Config.m_BrFilterUptodate<<16;
+	i |= g_Config.m_BrFilterUptodate<<15;
+	i |= g_Config.m_BrFilterPing<<16;
 	return i;
 }
 


### PR DESCRIPTION
Toggling the up-to-date filter (without a refresh) does not work because the corresponding bit in the sort-hash is overwritten by the ping value.