### PR TITLE
Server browser adjustments: autoswitch to info tab, fix graying out joinable servers

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -390,7 +390,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 		TextRender()->TextOutlineColor(1.0f, 1.0f, 1.0f, 0.25f);
 	}
 
-	float TextAplpha = (pEntry->m_NumPlayers == pEntry->m_MaxPlayers || pEntry->m_NumClients == pEntry->m_MaxClients) ? 0.5f : 1.0f;
+	float TextAlpha = (pEntry->m_NumClients == pEntry->m_MaxClients) ? 0.5f : 1.0f;
 	for(int c = 0; c < NUM_BROWSER_COLS; c++)
 	{
 		CUIRect Button = ms_aBrowserCols[c].m_Rect;
@@ -448,7 +448,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 				Cursor.m_LineWidth = Button.w;
 			}
 			
-			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAplpha);
+			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
 
 			if(g_Config.m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_SERVERNAME))
 			{
@@ -457,9 +457,9 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 				if(pStr)
 				{
 					TextRender()->TextEx(&Cursor, pEntry->m_aName, (int)(pStr-pEntry->m_aName));
-					TextRender()->TextColor(0.4f, 0.4f, 1.0f, TextAplpha);
+					TextRender()->TextColor(0.4f, 0.4f, 1.0f, TextAlpha);
 					TextRender()->TextEx(&Cursor, pStr, str_length(g_Config.m_BrFilterString));
-					TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAplpha);
+					TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
 					TextRender()->TextEx(&Cursor, pStr+str_length(g_Config.m_BrFilterString), -1);
 				}
 				else
@@ -480,7 +480,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 				Cursor.m_LineWidth = Button.w;
 			}
 
-			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAplpha);
+			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
 
 			if(g_Config.m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_MAPNAME))
 			{
@@ -489,9 +489,9 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 				if(pStr)
 				{
 					TextRender()->TextEx(&Cursor, pEntry->m_aMap, (int)(pStr-pEntry->m_aMap));
-					TextRender()->TextColor(0.4f, 0.4f, 1.0f, TextAplpha);
+					TextRender()->TextColor(0.4f, 0.4f, 1.0f, TextAlpha);
 					TextRender()->TextEx(&Cursor, pStr, str_length(g_Config.m_BrFilterString));
-					TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAplpha);
+					TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
 					TextRender()->TextEx(&Cursor, pStr+str_length(g_Config.m_BrFilterString), -1);
 				}
 				else
@@ -502,7 +502,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 		}
 		else if(ID == COL_BROWSER_PLAYERS)
 		{
-			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAplpha);
+			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
 			CServerFilterInfo FilterInfo;
 			pFilter->GetFilter(&FilterInfo);
 
@@ -511,7 +511,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 			else
 				str_format(aTemp, sizeof(aTemp), "%d/%d", pEntry->m_NumClients, pEntry->m_MaxClients);
 			if(g_Config.m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_PLAYER))
-				TextRender()->TextColor(0.4f, 0.4f, 1.0f, TextAplpha);
+				TextRender()->TextColor(0.4f, 0.4f, 1.0f, TextAlpha);
 			Button.y += 2.0f;
 			UI()->DoLabel(&Button, aTemp, 12.0f, CUI::ALIGN_CENTER);
 		}
@@ -522,7 +522,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 			vec4 Color;
 			if(Selected || Inside)
 			{
-				Color = vec4(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAplpha);
+				Color = vec4(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
 			}
 			else
 			{
@@ -531,15 +531,15 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 				float MixVal;
 				if(Ping <= 125)
 				{
-					StartColor = vec4(0.0f, 1.0f, 0.0f, TextAplpha);
-					EndColor = vec4(1.0f, 1.0f, 0.0f, TextAplpha);
+					StartColor = vec4(0.0f, 1.0f, 0.0f, TextAlpha);
+					EndColor = vec4(1.0f, 1.0f, 0.0f, TextAlpha);
 					
 					MixVal = (Ping-50.0f)/75.0f;
 				}
 				else
 				{
-					StartColor = vec4(1.0f, 1.0f, 0.0f, TextAplpha);
-					EndColor = vec4(1.0f, 0.0f, 0.0f, TextAplpha);
+					StartColor = vec4(1.0f, 1.0f, 0.0f, TextAlpha);
+					EndColor = vec4(1.0f, 0.0f, 0.0f, TextAlpha);
 					
 					MixVal = (Ping-125.0f)/75.0f;
 				}
@@ -573,7 +573,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 				Cursor.m_LineWidth = Button.w;
 			}
 
-			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAplpha);
+			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
 			TextRender()->TextEx(&Cursor, pEntry->m_aGameType, -1);
 		}
 	}

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1189,6 +1189,8 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 				{
 					m_SelectedServer.m_Filter = s;
 					m_SelectedServer.m_Index = i;
+					if(g_Config.m_UiAutoswitchInfotab)
+						m_SidebarTab = 0;
 					str_copy(g_Config.m_UiServerAddress, pItem->m_aAddress, sizeof(g_Config.m_UiServerAddress));
 					if(Input()->MouseDoubleClick())
 						Client()->Connect(g_Config.m_UiServerAddress);

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -80,6 +80,7 @@ MACRO_CONFIG_INT(UiSettingsPage, ui_settings_page, 0, 0, 5, CFGFLAG_CLIENT|CFGFL
 //MACRO_CONFIG_INT(UiToolboxPage, ui_toolbox_page, 0, 0, 2, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Toolbox page")
 MACRO_CONFIG_STR(UiServerAddress, ui_server_address, 64, "localhost:8303", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface server address")
 MACRO_CONFIG_INT(UiMousesens, ui_mousesens, 100, 5, 100000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Mouse sensitivity for menus/editor")
+MACRO_CONFIG_INT(UiAutoswitchInfotab, ui_autoswitch_infotab, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Switch to the info tab when clicking on a server")
 
 MACRO_CONFIG_INT(GfxNoclip, gfx_noclip, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Disable clipping")
 


### PR DESCRIPTION
Two commits:

- Now only gray out servers that cannot be joined. Closes #1605

- @LordSk's suggestion at https://github.com/teeworlds/teeworlds/issues/1670#issuecomment-439391159: 

> Can clicking on a server switch to the server info tab?

Added a console option for mouse maniacs that enjoy clicking everywhere without side effects.