### PR TITLE
Display user IDs

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -445,6 +445,10 @@ void CChat::AddLine(int ClientID, int Mode, const char *pLine, int TargetID)
 
 		m_aLines[m_CurrentLine].m_Highlighted =  Highlighted;
 
+		int NameCID = ClientID;
+		if(Mode == CHAT_WHISPER && ClientID == m_pClient->m_LocalClientID && TargetID >= 0)
+			NameCID = TargetID;
+
 		if(ClientID == -1) // server message
 		{
 			m_aLines[m_CurrentLine].m_aName[0] = 0;
@@ -463,10 +467,6 @@ void CChat::AddLine(int ClientID, int Mode, const char *pLine, int TargetID)
 					m_aLines[m_CurrentLine].m_NameColor = TEAM_BLUE;
 			}
 
-			int NameCID = ClientID;
-			if(Mode == CHAT_WHISPER && ClientID == m_pClient->m_LocalClientID && TargetID >= 0)
-				NameCID = TargetID;
-
 			str_format(m_aLines[m_CurrentLine].m_aName, sizeof(m_aLines[m_CurrentLine].m_aName), "%s", m_pClient->m_aClients[NameCID].m_aName);
 			str_format(m_aLines[m_CurrentLine].m_aText, sizeof(m_aLines[m_CurrentLine].m_aText), "%s", pLine);
 		}
@@ -479,7 +479,8 @@ void CChat::AddLine(int ClientID, int Mode, const char *pLine, int TargetID)
 			str_copy(aBufMode, "teamchat", sizeof(aBufMode));
 		else
 			str_copy(aBufMode, "chat", sizeof(aBufMode));
-		str_format(aBuf, sizeof(aBuf), "%s: %s", m_aLines[m_CurrentLine].m_aName, m_aLines[m_CurrentLine].m_aText);
+
+		str_format(aBuf, sizeof(aBuf), "%2d: %s: %s", NameCID, m_aLines[m_CurrentLine].m_aName, m_aLines[m_CurrentLine].m_aText);
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, aBufMode, aBuf, Highlighted || Mode == CHAT_WHISPER);
 	}
 
@@ -565,7 +566,7 @@ void CChat::OnRender()
 			}
 			else if(m_Mode == CHAT_WHISPER)
 			{
-				CategoryWidth += Cursor.m_FontSize;
+				CategoryWidth += RenderTools()->GetClientIdRectSize(CategoryFontSize);
 				str_format(aCatText, sizeof(aCatText), "%s",m_pClient->m_aClients[m_WhisperTarget].m_aName);
 			}
 			else
@@ -705,6 +706,7 @@ void CChat::OnRender()
 
 			if(Line.m_ClientID != -1)
 			{
+				Cursor.m_X += RenderTools()->GetClientIdRectSize(Cursor.m_FontSize);
 				str_append(aBuf, Line.m_aName, sizeof(aBuf));
 				str_append(aBuf, ": ", sizeof(aBuf));
 			}
@@ -715,7 +717,6 @@ void CChat::OnRender()
 			// FIXME: sometimes an empty line will pop here when the cursor reaches the end of line
 			Line.m_Size[OffsetType].y = Cursor.m_LineCount * Cursor.m_FontSize;
 			Line.m_Size[OffsetType].x = Cursor.m_LineCount == 1 ? Cursor.m_X - Cursor.m_StartX : LineWidth;
-			Line.m_Size[OffsetType].x += RenderTools()->GetClientIdRectSize(Cursor.m_FontSize);
 		}
 	}
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -715,6 +715,7 @@ void CChat::OnRender()
 			// FIXME: sometimes an empty line will pop here when the cursor reaches the end of line
 			Line.m_Size[OffsetType].y = Cursor.m_LineCount * Cursor.m_FontSize;
 			Line.m_Size[OffsetType].x = Cursor.m_LineCount == 1 ? Cursor.m_X - Cursor.m_StartX : LineWidth;
+			Line.m_Size[OffsetType].x += RenderTools()->GetClientIdRectSize(Cursor.m_FontSize);
 		}
 	}
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -869,7 +869,9 @@ void CChat::OnRender()
 
 		if(Line.m_ClientID != -1)
 		{
-			RenderTools()->DrawClientID(TextRender(), &Cursor, Line.m_ClientID);
+			vec4 BgIdColor = TextColor;
+			BgIdColor.a = 0.5f;
+			RenderTools()->DrawClientID(TextRender(), &Cursor, Line.m_ClientID, BgIdColor);
 			str_format(aBuf, sizeof(aBuf), "%s: ", Line.m_aName);
 			TextRender()->TextShadowed(&Cursor, aBuf, -1, ShadowOffset, ShadowColor, TextColor);
 		}

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -467,7 +467,7 @@ void CChat::AddLine(int ClientID, int Mode, const char *pLine, int TargetID)
 			if(Mode == CHAT_WHISPER && ClientID == m_pClient->m_LocalClientID && TargetID >= 0)
 				NameCID = TargetID;
 
-			str_format(m_aLines[m_CurrentLine].m_aName, sizeof(m_aLines[m_CurrentLine].m_aName), "%2d: %s", NameCID, m_pClient->m_aClients[NameCID].m_aName);
+			str_format(m_aLines[m_CurrentLine].m_aName, sizeof(m_aLines[m_CurrentLine].m_aName), "%s", m_pClient->m_aClients[NameCID].m_aName);
 			str_format(m_aLines[m_CurrentLine].m_aText, sizeof(m_aLines[m_CurrentLine].m_aText), "%s", pLine);
 		}
 
@@ -544,7 +544,7 @@ void CChat::OnRender()
 	{
 		// calculate category text size
 		// TODO: rework TextRender. Writing the same code twice to calculate a simple thing as width is ridiculus
-		float CategoryWidth;
+		float CategoryWidth = 0;
 		float CategoryHeight;
 		const float CategoryFontSize = 8.0f;
 		const float InputFontSize = 8.0f;
@@ -564,14 +564,16 @@ void CChat::OnRender()
 					str_copy(aCatText, Localize("Team"), sizeof(aCatText));
 			}
 			else if(m_Mode == CHAT_WHISPER)
-				str_format(aCatText, sizeof(aCatText), "%2d: %s",
-						   m_WhisperTarget, m_pClient->m_aClients[m_WhisperTarget].m_aName);
+			{
+				CategoryWidth += Cursor.m_FontSize;
+				str_format(aCatText, sizeof(aCatText), "%s",m_pClient->m_aClients[m_WhisperTarget].m_aName);
+			}
 			else
 				str_copy(aCatText, Localize("Chat"), sizeof(aCatText));
 
 			TextRender()->TextEx(&Cursor, aCatText, -1);
 
-			CategoryWidth = Cursor.m_X - Cursor.m_StartX;
+			CategoryWidth += Cursor.m_X - Cursor.m_StartX;
 			CategoryHeight = Cursor.m_FontSize;
 		}
 
@@ -625,6 +627,8 @@ void CChat::OnRender()
 		Cursor.m_LineWidth = Width-190.0f;
 		Cursor.m_MaxLines = 2;
 
+		if(m_Mode == CHAT_WHISPER)
+			RenderTools()->DrawClientID(TextRender(), &Cursor, m_WhisperTarget);
 		TextRender()->TextEx(&Cursor, aCatText, -1);
 
 		Cursor.m_X += 4.0f;
@@ -865,6 +869,7 @@ void CChat::OnRender()
 
 		if(Line.m_ClientID != -1)
 		{
+			RenderTools()->DrawClientID(TextRender(), &Cursor, Line.m_ClientID);
 			str_format(aBuf, sizeof(aBuf), "%s: ", Line.m_aName);
 			TextRender()->TextShadowed(&Cursor, aBuf, -1, ShadowOffset, ShadowColor, TextColor);
 		}

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -871,9 +871,13 @@ void CChat::OnRender()
 
 		if(Line.m_ClientID != -1)
 		{
+			int NameCID = Line.m_ClientID;
+			if(Line.m_Mode == CHAT_WHISPER && Line.m_ClientID == m_pClient->m_LocalClientID && Line.m_TargetID >= 0)
+				NameCID = Line.m_TargetID;
+
 			vec4 BgIdColor = TextColor;
 			BgIdColor.a = 0.5f;
-			RenderTools()->DrawClientID(TextRender(), &Cursor, Line.m_ClientID, BgIdColor);
+			RenderTools()->DrawClientID(TextRender(), &Cursor, NameCID, BgIdColor);
 			str_format(aBuf, sizeof(aBuf), "%s: ", Line.m_aName);
 			TextRender()->TextShadowed(&Cursor, aBuf, -1, ShadowOffset, ShadowColor, TextColor);
 		}

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -209,9 +209,16 @@ void CHud::RenderScoreHud()
 						// draw name of the flag holder
 						int ID = FlagCarrier[t]%MAX_CLIENTS;
 						char aName[64];
-						str_format(aName, sizeof(aName), "%2d: %s", ID, g_Config.m_ClShowsocial ? m_pClient->m_aClients[ID].m_aName : "");
+						str_format(aName, sizeof(aName), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[ID].m_aName : "");
 						float w = TextRender()->TextWidth(0, 8.0f, aName, -1);
-						TextRender()->Text(0, min(Whole-w-1.0f, Whole-ScoreWidthMax-ImageSize-2*Split), StartY+(t+1)*20.0f-3.0f, 8.0f, aName, -1);
+
+						CTextCursor Cursor;
+						float x = min(Whole-w-1.0f, Whole-ScoreWidthMax-ImageSize-2*Split);
+						float y = StartY+(t+1)*20.0f-3.0f;
+						TextRender()->SetCursor(&Cursor, x, y, 8.0f, TEXTFLAG_RENDER);
+
+						RenderTools()->DrawClientID(TextRender(), &Cursor, ID);
+						TextRender()->TextEx(&Cursor, aName, -1);
 
 						// draw tee of the flag holder
 						CTeeRenderInfo Info = m_pClient->m_aClients[ID].m_RenderInfo;
@@ -283,9 +290,16 @@ void CHud::RenderScoreHud()
 					// draw name
 					int ID = aPlayerInfo[t].m_ClientID;
 					char aName[64];
-					str_format(aName, sizeof(aName), "%2d: %s", ID, g_Config.m_ClShowsocial ? m_pClient->m_aClients[ID].m_aName : "");
+					str_format(aName, sizeof(aName), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[ID].m_aName : "");
 					float w = TextRender()->TextWidth(0, 8.0f, aName, -1);
-					TextRender()->Text(0, min(Whole-w-1.0f, Whole-ScoreWidthMax-ImageSize-2*Split-PosSize), StartY+(t+1)*20.0f-3.0f, 8.0f, aName, -1);
+
+					CTextCursor Cursor;
+					float x = min(Whole-w-1.0f, Whole-ScoreWidthMax-ImageSize-2*Split-PosSize);
+					float y = StartY+(t+1)*20.0f-3.0f;
+					TextRender()->SetCursor(&Cursor, x, y, 8.0f, TEXTFLAG_RENDER);
+
+					RenderTools()->DrawClientID(TextRender(), &Cursor, ID);
+					TextRender()->TextEx(&Cursor, aName, -1);
 
 					// draw tee
 					CTeeRenderInfo Info = m_pClient->m_aClients[ID].m_RenderInfo;
@@ -609,28 +623,41 @@ void CHud::RenderSpectatorHud()
 
 	// draw the text
 	char aName[64];
-	str_format(aName, sizeof(aName), "%2d: %s", m_pClient->m_Snap.m_SpecInfo.m_SpectatorID, g_Config.m_ClShowsocial ? m_pClient->m_aClients[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID].m_aName : "");
+	const int SpecID = m_pClient->m_Snap.m_SpecInfo.m_SpectatorID;
+	const int SpecMode = m_pClient->m_Snap.m_SpecInfo.m_SpecMode;
+	str_format(aName, sizeof(aName), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID].m_aName : "");
 	char aBuf[128];
-	switch(m_pClient->m_Snap.m_SpecInfo.m_SpecMode)
+
+	CTextCursor Cursor;
+	TextRender()->SetCursor(&Cursor, m_Width-174.0f, m_Height-13.0f, 8.0f, TEXTFLAG_RENDER);
+
+	str_format(aBuf, sizeof(aBuf), "%s: ", Localize("Spectate"));
+	TextRender()->TextEx(&Cursor, aBuf, -1);
+
+	switch(SpecMode)
 	{
 	case SPEC_FREEVIEW:
-		str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Spectate"), Localize("Free-View"));
+		str_format(aBuf, sizeof(aBuf), "%s", Localize("Free-View"));
 		break;
 	case SPEC_PLAYER:
-		str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Spectate"), aName);
+		str_format(aBuf, sizeof(aBuf), "%s", aName);
 		break;
 	case SPEC_FLAGRED:
 	case SPEC_FLAGBLUE:
 		char aFlag[64];
-		str_format(aFlag, sizeof(aFlag), m_pClient->m_Snap.m_SpecInfo.m_SpecMode == SPEC_FLAGRED ? Localize("red flag") : Localize("blue flag"));
+		str_format(aFlag, sizeof(aFlag), SpecMode == SPEC_FLAGRED ? Localize("red flag") : Localize("blue flag"));
 
-		if(m_pClient->m_Snap.m_SpecInfo.m_SpectatorID != -1)
-			str_format(aBuf, sizeof(aBuf), "%s: %s (%s)", Localize("Spectate"), aFlag, aName);
+		if(SpecID != -1)
+			str_format(aBuf, sizeof(aBuf), "%s (%s)", aFlag, aName);
 		else
-			str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Spectate"), aFlag);
+			str_format(aBuf, sizeof(aBuf), "%s", aFlag);
 		break;
 	}
-	TextRender()->Text(0, m_Width-174.0f, m_Height-13.0f, 8.0f, aBuf, -1);
+
+	if(SpecMode == SPEC_PLAYER || SpecID != -1)
+		RenderTools()->DrawClientID(TextRender(), &Cursor, SpecID);
+
+	TextRender()->TextEx(&Cursor, aBuf, -1);
 }
 
 void CHud::OnRender()

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -210,7 +210,7 @@ void CHud::RenderScoreHud()
 						int ID = FlagCarrier[t]%MAX_CLIENTS;
 						char aName[64];
 						str_format(aName, sizeof(aName), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[ID].m_aName : "");
-						float w = TextRender()->TextWidth(0, 8.0f, aName, -1);
+						float w = TextRender()->TextWidth(0, 8.0f, aName, -1) + RenderTools()->GetClientIdRectSize(8.0f);
 
 						CTextCursor Cursor;
 						float x = min(Whole-w-1.0f, Whole-ScoreWidthMax-ImageSize-2*Split);

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -27,11 +27,11 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 		CKillMsg Kill;
 		Kill.m_VictimID = pMsg->m_Victim;
 		Kill.m_VictimTeam = m_pClient->m_aClients[Kill.m_VictimID].m_Team;
-		str_format(Kill.m_aVictimName, sizeof(Kill.m_aVictimName), "%2d: %s", pMsg->m_Victim, g_Config.m_ClShowsocial ? m_pClient->m_aClients[Kill.m_VictimID].m_aName : "");
+		str_format(Kill.m_aVictimName, sizeof(Kill.m_aVictimName), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[Kill.m_VictimID].m_aName : "");
 		Kill.m_VictimRenderInfo = m_pClient->m_aClients[Kill.m_VictimID].m_RenderInfo;
 		Kill.m_KillerID = pMsg->m_Killer;
 		Kill.m_KillerTeam = m_pClient->m_aClients[Kill.m_KillerID].m_Team;
-		str_format(Kill.m_aKillerName, sizeof(Kill.m_aKillerName), "%2d: %s", pMsg->m_Killer, g_Config.m_ClShowsocial ? m_pClient->m_aClients[Kill.m_KillerID].m_aName : "");
+		str_format(Kill.m_aKillerName, sizeof(Kill.m_aKillerName), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[Kill.m_KillerID].m_aName : "");
 		Kill.m_KillerRenderInfo = m_pClient->m_aClients[Kill.m_KillerID].m_RenderInfo;
 		Kill.m_Weapon = pMsg->m_Weapon;
 		Kill.m_ModeSpecial = pMsg->m_ModeSpecial;
@@ -66,7 +66,11 @@ void CKillMessages::OnRender()
 
 		// render victim name
 		x -= VictimNameW;
-		TextRender()->Text(0, x, y, FontSize, m_aKillmsgs[r].m_aVictimName, -1);
+		CTextCursor Cursor;
+		TextRender()->SetCursor(&Cursor, x, y, FontSize, TEXTFLAG_RENDER);
+
+		RenderTools()->DrawClientID(TextRender(), &Cursor, m_aKillmsgs[r].m_VictimID);
+		TextRender()->TextEx(&Cursor, m_aKillmsgs[r].m_aVictimName, -1);
 
 		// render victim tee
 		x -= 24.0f;
@@ -135,7 +139,10 @@ void CKillMessages::OnRender()
 
 			// render killer name
 			x -= KillerNameW;
-			TextRender()->Text(0, x, y, FontSize, m_aKillmsgs[r].m_aKillerName, -1);
+			TextRender()->SetCursor(&Cursor, x, y, FontSize, TEXTFLAG_RENDER);
+
+			RenderTools()->DrawClientID(TextRender(), &Cursor, m_aKillmsgs[r].m_KillerID);
+			TextRender()->TextEx(&Cursor, m_aKillmsgs[r].m_aKillerName, -1);
 		}
 
 		y += 46.0f;

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -59,8 +59,8 @@ void CKillMessages::OnRender()
 			continue;
 
 		float FontSize = 36.0f;
-		float KillerNameW = TextRender()->TextWidth(0, FontSize, m_aKillmsgs[r].m_aKillerName, -1);
-		float VictimNameW = TextRender()->TextWidth(0, FontSize, m_aKillmsgs[r].m_aVictimName, -1);
+		float KillerNameW = TextRender()->TextWidth(0, FontSize, m_aKillmsgs[r].m_aKillerName, -1) + RenderTools()->GetClientIdRectSize(FontSize);
+		float VictimNameW = TextRender()->TextWidth(0, FontSize, m_aKillmsgs[r].m_aVictimName, -1) + RenderTools()->GetClientIdRectSize(FontSize);
 
 		float x = StartX;
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -953,6 +953,12 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	if(DoButton_CheckBox(&s_Showsocial, Localize("Show social"), g_Config.m_ClShowsocial, &Button))
 		g_Config.m_ClShowsocial ^= 1;
 
+	GameRight.HSplitTop(Spacing, 0, &GameRight);
+	GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
+	static int s_ShowUserId = 0;
+	if(DoButton_CheckBox(&s_ShowUserId, Localize("Show user IDs"), g_Config.m_ClShowUserId, &Button))
+		g_Config.m_ClShowUserId ^= 1;
+
 	// show chat messages button
 	if(g_Config.m_ClShowsocial)
 	{

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -32,8 +32,11 @@ void CNamePlates::RenderNameplate(
 
 
 		char aName[64];
-		str_format(aName, sizeof(aName), "%2d: %s", ClientID, g_Config.m_ClShowsocial ? m_pClient->m_aClients[ClientID].m_aName: "");
+		str_format(aName, sizeof(aName), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[ClientID].m_aName: "");
 		float tw = TextRender()->TextWidth(0, FontSize, aName, -1);
+
+		CTextCursor Cursor;
+		TextRender()->SetCursor(&Cursor, Position.x-tw/2.0f, Position.y-FontSize-38.0f, FontSize, TEXTFLAG_RENDER);
 
 		TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.5f*a);
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, a);
@@ -45,7 +48,8 @@ void CNamePlates::RenderNameplate(
 				TextRender()->TextColor(0.7f, 0.7f, 1.0f, a);
 		}
 
-		TextRender()->Text(0, Position.x-tw/2.0f, Position.y-FontSize-38.0f, FontSize, aName, -1);
+		RenderTools()->DrawClientID(TextRender(), &Cursor, ClientID);
+		TextRender()->TextEx(&Cursor, aName, -1);
 
 		TextRender()->TextColor(1,1,1,1);
 		TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.3f);

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -48,8 +48,16 @@ void CNamePlates::RenderNameplate(
 				TextRender()->TextColor(0.7f, 0.7f, 1.0f, a);
 		}
 
-		RenderTools()->DrawClientID(TextRender(), &Cursor, ClientID);
-		TextRender()->TextEx(&Cursor, aName, -1);
+		const vec4 IdTextColor(0.1f, 0.1f, 0.1f, a);
+		vec4 BgIdColor(1.0f, 0.5f, 0.5f, a * 0.5f);
+		if(m_pClient->m_aClients[ClientID].m_Team == TEAM_BLUE)
+			BgIdColor = vec4(0.7f, 0.7f, 1.0f, a * 0.5f);
+
+		if(a > 0.001f)
+		{
+			RenderTools()->DrawClientID(TextRender(), &Cursor, ClientID, BgIdColor, IdTextColor);
+			TextRender()->TextEx(&Cursor, aName, -1);
+		}
 
 		TextRender()->TextColor(1,1,1,1);
 		TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.3f);

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -33,9 +33,9 @@ void CNamePlates::RenderNameplate(
 
 		char aName[64];
 		str_format(aName, sizeof(aName), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[ClientID].m_aName: "");
-		float tw = TextRender()->TextWidth(0, FontSize, aName, -1);
 
 		CTextCursor Cursor;
+		float tw = TextRender()->TextWidth(0, FontSize, aName, -1) + RenderTools()->GetClientIdRectSize(FontSize);
 		TextRender()->SetCursor(&Cursor, Position.x-tw/2.0f, Position.y-FontSize-38.0f, FontSize, TEXTFLAG_RENDER);
 
 		TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.5f*a);

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -107,7 +107,8 @@ void CScoreboard::RenderSpectators(float x, float y, float w)
 		if(pInfo->m_PlayerFlags&PLAYERFLAG_WATCHING)
 			TextRender()->TextColor(1.0f, 1.0f, 0.0f, 1.0f);
 		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), "%2d: %s", i, g_Config.m_ClShowsocial ? m_pClient->m_aClients[i].m_aName : "");
+		str_format(aBuf, sizeof(aBuf), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[i].m_aName : "");
+		RenderTools()->DrawClientID(TextRender(), &Cursor, i);
 		TextRender()->TextEx(&Cursor, aBuf, -1);
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 		Multiple = true;
@@ -285,7 +286,8 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 			TextRender()->SetCursor(&Cursor, NameOffset, y+Spacing, FontSize, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
 			Cursor.m_LineWidth = NameLength;
 			char aBuf[64];
-			str_format(aBuf, sizeof(aBuf), "%2d: %s", pInfo->m_ClientID, g_Config.m_ClShowsocial ? m_pClient->m_aClients[pInfo->m_ClientID].m_aName : "");
+			str_format(aBuf, sizeof(aBuf), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[pInfo->m_ClientID].m_aName : "");
+			RenderTools()->DrawClientID(TextRender(), &Cursor, pInfo->m_ClientID);
 			TextRender()->TextEx(&Cursor, aBuf, -1);
 			TextRender()->TextColor(1.0f, 1.0f, 1.0f, ColorAlpha);
 

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -343,8 +343,13 @@ void CSpectator::OnRender()
 		}
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, Selected?1.0f:0.5f);
 		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), "%2d: %s", i, g_Config.m_ClShowsocial ? m_pClient->m_aClients[i].m_aName : "");
-		TextRender()->Text(0, Width/2.0f+x+50.0f, Height/2.0f+y+5.0f, FontSize, aBuf, 220.0f);
+		str_format(aBuf, sizeof(aBuf), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[i].m_aName : "");
+
+		CTextCursor Cursor;
+		TextRender()->SetCursor(&Cursor, Width/2.0f+x+50.0f, Height/2.0f+y+5.0f, FontSize, TEXTFLAG_RENDER);
+
+		RenderTools()->DrawClientID(TextRender(), &Cursor, i);
+		TextRender()->TextEx(&Cursor, aBuf, -1);
 
 		// flag
 		if(m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS &&

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -624,3 +624,8 @@ void CRenderTools::DrawClientID(ITextRender* pTextRender, CTextCursor* pCursor, 
 
 	pCursor->m_X = PrevX + Rect.w + 0.2f * FontSize;
 }
+
+float CRenderTools::GetClientIdRectSize(float FontSize)
+{
+	return 1.4f * FontSize + 0.2f * FontSize;
+}

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -595,25 +595,32 @@ void CRenderTools::RenderTilemapGenerateSkip(class CLayers *pLayers)
 	}
 }
 
-void CRenderTools::DrawClientID(ITextRender* pTextRender, CTextCursor* pCursor, int ID)
+void CRenderTools::DrawClientID(ITextRender* pTextRender, CTextCursor* pCursor, int ID,
+								const vec4& BgColor, const vec4& TextColor)
 {
 	char aBuff[4];
 	str_format(aBuff, sizeof(aBuff), "%2d ", ID);
 
 	const float LinebaseY = pTextRender->TextGetLineBaseY(pCursor);
 
+	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
+	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	float FakeToScreenY = (Graphics()->ScreenHeight()/(ScreenY1-ScreenY0));
+	float FontSize = (int)(pCursor->m_FontSize * FakeToScreenY)/FakeToScreenY;
+
 	CUIRect Rect;
 	Rect.x = pCursor->m_X;
-	Rect.y = LinebaseY - pCursor->m_FontSize + 0.2f;
-	Rect.w = 1.4f * pCursor->m_FontSize;
-	Rect.h = pCursor->m_FontSize;
-	DrawRoundRect(&Rect, vec4(1, 1, 1, 0.5f), 0.25f * pCursor->m_FontSize);
+	Rect.y = LinebaseY - FontSize + 0.025f * FontSize;
+	Rect.w = 1.4f * FontSize;
+	Rect.h = FontSize;
+	DrawRoundRect(&Rect, BgColor, 0.25f * FontSize);
 
 	const float PrevX = pCursor->m_X;
+	pCursor->m_X += (ID < 10 ? 0.04f: 0.0f) * FontSize;
 
-	pTextRender->TextColor(1, 1, 1, 1);
-	pTextRender->TextOutlineColor(0, 0, 0, 0.3f);
-	pTextRender->TextEx(pCursor, aBuff, -1);
+	// TODO: make a simple text one (no shadow)
+	pTextRender->TextShadowed(pCursor, aBuff, -1, vec2(0,0), vec4(0,0,0,0),
+							  vec4(0.1f, 0.1f, 0.1f, 1.0f));
 
-	pCursor->m_X = PrevX + Rect.w + 1.0f;
+	pCursor->m_X = PrevX + Rect.w + 0.2f * FontSize;
 }

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -598,6 +598,8 @@ void CRenderTools::RenderTilemapGenerateSkip(class CLayers *pLayers)
 void CRenderTools::DrawClientID(ITextRender* pTextRender, CTextCursor* pCursor, int ID,
 								const vec4& BgColor, const vec4& TextColor)
 {
+	if(!g_Config.m_ClShowUserId) return;
+
 	char aBuff[4];
 	str_format(aBuff, sizeof(aBuff), "%2d ", ID);
 
@@ -627,5 +629,6 @@ void CRenderTools::DrawClientID(ITextRender* pTextRender, CTextCursor* pCursor, 
 
 float CRenderTools::GetClientIdRectSize(float FontSize)
 {
+	if(!g_Config.m_ClShowUserId) return 0;
 	return 1.4f * FontSize + 0.2f * FontSize;
 }

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -7,6 +7,7 @@
 #include <engine/shared/config.h>
 #include <engine/graphics.h>
 #include <engine/map.h>
+#include <engine/textrender.h>
 #include <generated/client_data.h>
 #include <generated/protocol.h>
 #include <game/layers.h>
@@ -592,4 +593,27 @@ void CRenderTools::RenderTilemapGenerateSkip(class CLayers *pLayers)
 			}
 		}
 	}
+}
+
+void CRenderTools::DrawClientID(ITextRender* pTextRender, CTextCursor* pCursor, int ID)
+{
+	char aBuff[4];
+	str_format(aBuff, sizeof(aBuff), "%2d ", ID);
+
+	const float LinebaseY = pTextRender->TextGetLineBaseY(pCursor);
+
+	CUIRect Rect;
+	Rect.x = pCursor->m_X;
+	Rect.y = LinebaseY - pCursor->m_FontSize + 0.2f;
+	Rect.w = 1.4f * pCursor->m_FontSize;
+	Rect.h = pCursor->m_FontSize;
+	DrawRoundRect(&Rect, vec4(1, 1, 1, 0.5f), 0.25f * pCursor->m_FontSize);
+
+	const float PrevX = pCursor->m_X;
+
+	pTextRender->TextColor(1, 1, 1, 1);
+	pTextRender->TextOutlineColor(0, 0, 0, 0.3f);
+	pTextRender->TextEx(pCursor, aBuff, -1);
+
+	pCursor->m_X = PrevX + Rect.w + 1.0f;
 }

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -92,7 +92,7 @@ public:
 
 	void DrawClientID(ITextRender* pTextRender, CTextCursor* pCursor, int ID,
 					  const vec4& BgColor = vec4(1, 1, 1, 0.5f), const vec4& TextColor = vec4(0.1f, 0.1f, 0.1f, 1.0f));
-
+	float GetClientIdRectSize(float FontSize);
 };
 
 #endif

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -47,6 +47,7 @@ public:
 };
 
 typedef void (*ENVELOPE_EVAL)(float TimeOffset, int Env, float *pChannels, void *pUser);
+class CTextCursor;
 
 class CRenderTools
 {
@@ -88,6 +89,8 @@ public:
 	void MapScreenToWorld(float CenterX, float CenterY, float ParallaxX, float ParallaxY,
 		float OffsetX, float OffsetY, float Aspect, float Zoom, float aPoints[4]);
 	void MapScreenToGroup(float CenterX, float CenterY, CMapItemGroup *pGroup, float Zoom);
+
+	void DrawClientID(ITextRender* pTextRender, CTextCursor* pCursor, int ID);
 
 };
 

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -90,7 +90,8 @@ public:
 		float OffsetX, float OffsetY, float Aspect, float Zoom, float aPoints[4]);
 	void MapScreenToGroup(float CenterX, float CenterY, CMapItemGroup *pGroup, float Zoom);
 
-	void DrawClientID(ITextRender* pTextRender, CTextCursor* pCursor, int ID);
+	void DrawClientID(ITextRender* pTextRender, CTextCursor* pCursor, int ID,
+					  const vec4& BgColor = vec4(1, 1, 1, 0.5f), const vec4& TextColor = vec4(0.1f, 0.1f, 0.1f, 1.0f));
 
 };
 

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -31,6 +31,8 @@ MACRO_CONFIG_INT(ClMouseMaxDistanceStatic, cl_mouse_max_distance_static, 400, 0,
 
 MACRO_CONFIG_INT(ClCustomizeSkin, cl_customize_skin, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")
 
+MACRO_CONFIG_INT(ClShowUserId, cl_show_user_id, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")
+
 MACRO_CONFIG_INT(EdZoomTarget, ed_zoom_target, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Zoom to the current mouse target")
 MACRO_CONFIG_INT(EdShowkeys, ed_showkeys, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")
 MACRO_CONFIG_INT(EdColorGridInner, ed_color_grid_inner, 0xFFFFFF26, 0, 0, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/294603/48957279-db957b00-ef57-11e8-8cf7-f52248a5d2d7.png)

This display an ID box mostly everywhere there used to be a 'ID: '.
It's not a perfect solution, the rect can be somewhat misaligned, but this could be improved if we get perfect bounds for text rendering.

I've also added an option to turn it on/off, off by default. Most users won't ever need this feature thus having it disabled by default seems to be the correct choice.

A few hard coded text IDs still persist however, in system messages. As they are deeply connected to translations, I wasn't sure what the right approach for them would be.

Closes #1591.