### PR TITLE
Add Damage net event

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -5,7 +5,6 @@ Emotes = Enum("EMOTE", ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
 Emoticons = Enum("EMOTICON", ["OOP", "EXCLAMATION", "HEARTS", "DROP", "DOTDOT", "MUSIC", "SORRY", "GHOST", "SUSHI", "SPLATTEE", "DEVILTEE", "ZOMG", "ZZZ", "WTF", "EYES", "QUESTION"])
 Votes = Enum("VOTE", ["UNKNOWN", "START_OP", "START_KICK", "START_SPEC", "END_ABORT", "END_PASS", "END_FAIL"])
 ChatModes = Enum("CHAT", ["NONE", "ALL", "TEAM", "WHISPER"])
-DamageType = Enum("DAMAGE", ["NORMAL", "ARMOR", "SELF", "SELF_ARMOR"])
 
 PlayerFlags = Flags("PLAYERFLAG", ["ADMIN", "CHATTING", "SCOREBOARD", "READY", "DEAD", "WATCHING"])
 GameFlags = Flags("GAMEFLAG", ["TEAMS", "FLAGS", "SURVIVAL"])
@@ -58,7 +57,6 @@ Enums = [
 	Emoticons,
 	Votes,
 	ChatModes,
-	DamageType,
 	GameMsgIDs,
 ]
 
@@ -233,15 +231,12 @@ Objects = [
 		NetIntRange("m_SoundID", 0, 'NUM_SOUNDS-1'),
 	]),
 
-	NetEvent("DamageInd:Common", [
-		NetIntAny("m_Angle"),
-	]),
-
 	NetEvent("Damage:Common", [ # Unused yet
 		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
 		NetIntAny("m_Angle"),
-		NetIntRange("m_Amount", 1, 9),
-		NetEnum("m_Type", DamageType),
+		NetIntRange("m_HealthAmount", 1, 9),
+		NetIntRange("m_ArmorAmount", 1, 9),
+		NetBool("m_Self"),
 	]),
 ]
 

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -5,6 +5,7 @@ Emotes = Enum("EMOTE", ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
 Emoticons = Enum("EMOTICON", ["OOP", "EXCLAMATION", "HEARTS", "DROP", "DOTDOT", "MUSIC", "SORRY", "GHOST", "SUSHI", "SPLATTEE", "DEVILTEE", "ZOMG", "ZZZ", "WTF", "EYES", "QUESTION"])
 Votes = Enum("VOTE", ["UNKNOWN", "START_OP", "START_KICK", "START_SPEC", "END_ABORT", "END_PASS", "END_FAIL"])
 ChatModes = Enum("CHAT", ["NONE", "ALL", "TEAM", "WHISPER"])
+DamageType = Enum("DAMAGE", ["NORMAL", "ARMOR", "SELF", "SELF_ARMOR"])
 
 PlayerFlags = Flags("PLAYERFLAG", ["ADMIN", "CHATTING", "SCOREBOARD", "READY", "DEAD", "WATCHING"])
 GameFlags = Flags("GAMEFLAG", ["TEAMS", "FLAGS", "SURVIVAL"])
@@ -57,6 +58,7 @@ Enums = [
 	Emoticons,
 	Votes,
 	ChatModes,
+	DamageType,
 	GameMsgIDs,
 ]
 
@@ -233,14 +235,13 @@ Objects = [
 
 	NetEvent("DamageInd:Common", [
 		NetIntAny("m_Angle"),
-		NetBool("m_Armored"),
 	]),
 
 	NetEvent("Damage:Common", [ # Unused yet
 		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
 		NetIntAny("m_Angle"),
 		NetIntRange("m_Amount", 1, 9),
-		NetBool("m_Armored"),
+		NetEnum("m_Type", DamageType),
 	]),
 ]
 

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -233,6 +233,14 @@ Objects = [
 
 	NetEvent("DamageInd:Common", [
 		NetIntAny("m_Angle"),
+		NetBool("m_Armored"),
+	]),
+
+	NetEvent("Damage:Common", [ # Unused yet
+		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+		NetIntAny("m_Angle"),
+		NetIntRange("m_Amount", 1, 9),
+		NetBool("m_Armored"),
 	]),
 ]
 

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -22,6 +22,8 @@ CEffects::CEffects()
 {
 	m_Add50hz = false;
 	m_Add100hz = false;
+	m_DamageTaken = 0;
+	m_DamageTakenTick = 0;
 }
 
 void CEffects::AirJump(vec2 Pos)
@@ -47,9 +49,32 @@ void CEffects::AirJump(vec2 Pos)
 	m_pClient->m_pSounds->PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_AIRJUMP, 1.0f, Pos);
 }
 
-void CEffects::DamageIndicator(vec2 Pos, vec2 Dir)
+void CEffects::DamageIndicator(vec2 Pos, int Amount)
 {
-	m_pClient->m_pDamageind->Create(Pos, Dir);
+	m_DamageTaken++;
+	int Angle;
+	// create healthmod indicator
+	if(Client()->LocalTime() < m_DamageTakenTick+0.5f)
+	{
+		// make sure that the damage indicators don't group together
+		Angle = m_DamageTaken*0.25f;
+	}
+	else
+	{
+		m_DamageTaken = 0;
+		Angle = 0;
+	}
+
+	float a = 3*pi/2 + Angle;
+	float s = a-pi/3;
+	float e = a+pi/3;
+	for(int i = 0; i < Amount; i++)
+	{
+		float f = mix(s, e, float(i+1)/float(Amount+2));
+		m_pClient->m_pDamageind->Create(vec2(Pos.x, Pos.y), direction(f));
+	}
+
+	m_DamageTakenTick = Client()->LocalTime();
 }
 
 void CEffects::PowerupShine(vec2 Pos, vec2 size)

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -8,6 +8,9 @@ class CEffects : public CComponent
 {
 	bool m_Add50hz;
 	bool m_Add100hz;
+
+	int m_DamageTaken;
+	float m_DamageTakenTick;
 public:
 	CEffects();
 
@@ -19,7 +22,7 @@ public:
 	void Explosion(vec2 Pos);
 	void HammerHit(vec2 Pos);
 	void AirJump(vec2 Pos);
-	void DamageIndicator(vec2 Pos, vec2 Dir);
+	void DamageIndicator(vec2 Pos, int Amount);
 	void PlayerSpawn(vec2 Pos);
 	void PlayerDeath(vec2 Pos, int ClientID);
 	void PowerupShine(vec2 Pos, vec2 Size);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -819,10 +819,10 @@ void CGameClient::ProcessEvents()
 		IClient::CSnapItem Item;
 		const void *pData = Client()->SnapGetItem(SnapType, Index, &Item);
 
-		if(Item.m_Type == NETEVENTTYPE_DAMAGEIND)
+		if(Item.m_Type == NETEVENTTYPE_DAMAGE)
 		{
-			CNetEvent_DamageInd *ev = (CNetEvent_DamageInd *)pData;
-			m_pEffects->DamageIndicator(vec2(ev->m_X, ev->m_Y), direction(ev->m_Angle/256.0f));
+			CNetEvent_Damage *ev = (CNetEvent_Damage *)pData;
+			m_pEffects->DamageIndicator(vec2(ev->m_X, ev->m_Y), ev->m_HealthAmount + ev->m_ArmorAmount);
 		}
 		else if(Item.m_Type == NETEVENTTYPE_EXPLOSION)
 		{

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -722,14 +722,14 @@ bool CCharacter::TakeDamage(vec2 Force, vec2 Source, int Dmg, int From, int Weap
 	if(Server()->Tick() < m_DamageTakenTick+25)
 	{
 		// make sure that the damage indicators doesn't group together
-		GameServer()->CreateDamageInd(m_Pos, m_DamageTaken*0.25f, OldHealth-m_Health, OldArmor-m_Armor);
+		GameServer()->CreateDamageInd(m_Pos, m_DamageTaken*0.25f, Dmg);
 	}
 	else
 	{
 		m_DamageTaken = 0;
-		GameServer()->CreateDamageInd(m_Pos, 0, OldHealth-m_Health, OldArmor-m_Armor);
+		GameServer()->CreateDamageInd(m_Pos, 0, Dmg);
 	}	
-	GameServer()->CreateDamage(m_Pos, m_pPlayer->GetCID(), Source, OldHealth-m_Health, OldArmor-m_Armor);
+	GameServer()->CreateDamage(m_Pos, m_pPlayer->GetCID(), Source, OldHealth-m_Health, OldArmor-m_Armor, From == m_pPlayer->GetCID());
 
 	m_DamageTakenTick = Server()->Tick();
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -620,7 +620,6 @@ void CCharacter::TickDefered()
 void CCharacter::TickPaused()
 {
 	++m_AttackTick;
-	++m_DamageTakenTick;
 	++m_Ninja.m_ActivationTick;
 	++m_ReckoningTick;
 	if(m_LastAction != -1)
@@ -690,8 +689,6 @@ bool CCharacter::TakeDamage(vec2 Force, vec2 Source, int Dmg, int From, int Weap
 	if(From == m_pPlayer->GetCID())
 		Dmg = max(1, Dmg/2);
 
-	m_DamageTaken++;
-
 	int OldHealth = m_Health, OldArmor = m_Armor;
 	if(Dmg)
 	{
@@ -719,19 +716,7 @@ bool CCharacter::TakeDamage(vec2 Force, vec2 Source, int Dmg, int From, int Weap
 	}
 
 	// create healthmod indicator
-	if(Server()->Tick() < m_DamageTakenTick+25)
-	{
-		// make sure that the damage indicators doesn't group together
-		GameServer()->CreateDamageInd(m_Pos, m_DamageTaken*0.25f, Dmg);
-	}
-	else
-	{
-		m_DamageTaken = 0;
-		GameServer()->CreateDamageInd(m_Pos, 0, Dmg);
-	}	
 	GameServer()->CreateDamage(m_Pos, m_pPlayer->GetCID(), Source, OldHealth-m_Health, OldArmor-m_Armor, From == m_pPlayer->GetCID());
-
-	m_DamageTakenTick = Server()->Tick();
 
 	// do damage Hit sound
 	if(From >= 0 && From != m_pPlayer->GetCID() && GameServer()->m_apPlayers[From])

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -42,7 +42,7 @@ public:
 	void FireWeapon();
 
 	void Die(int Killer, int Weapon);
-	bool TakeDamage(vec2 Force, int Dmg, int From, int Weapon);
+	bool TakeDamage(vec2 Force, vec2 Source, int Dmg, int From, int Weapon);
 
 	bool Spawn(class CPlayer *pPlayer, vec2 Pos);
 	bool Remove();

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -83,8 +83,6 @@ private:
 	int m_ReloadTimer;
 	int m_AttackTick;
 
-	int m_DamageTaken;
-
 	int m_EmoteType;
 	int m_EmoteStop;
 
@@ -100,8 +98,6 @@ private:
 	CNetObj_PlayerInput m_Input;
 	int m_NumInputs;
 	int m_Jumped;
-
-	int m_DamageTakenTick;
 
 	int m_Health;
 	int m_Armor;

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -30,7 +30,7 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 	m_From = From;
 	m_Pos = At;
 	m_Energy = -1;
-	pHit->TakeDamage(vec2(0.f, 0.f), g_pData->m_Weapons.m_aId[WEAPON_LASER].m_Damage, m_Owner, WEAPON_LASER);
+	pHit->TakeDamage(vec2(0.f, 0.f), normalize(To-From), g_pData->m_Weapons.m_aId[WEAPON_LASER].m_Damage, m_Owner, WEAPON_LASER);
 	return true;
 }
 

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -76,7 +76,7 @@ void CProjectile::Tick()
 			GameServer()->CreateExplosion(CurPos, m_Owner, m_Weapon, m_Damage);
 
 		else if(TargetChr)
-			TargetChr->TakeDamage(m_Direction * max(0.001f, m_Force), m_Damage, m_Owner, m_Weapon);
+			TargetChr->TakeDamage(m_Direction * max(0.001f, m_Force), m_Direction*-1, m_Damage, m_Owner, m_Weapon);
 
 		GameServer()->m_World.DestroyEntity(this);
 	}

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -93,46 +93,19 @@ class CCharacter *CGameContext::GetPlayerChar(int ClientID)
 	return m_apPlayers[ClientID]->GetCharacter();
 }
 
-void CGameContext::CreateDamageInd(vec2 Pos, float Angle, int Amount)
-{
-	float a = 3*pi/2 + Angle;
-	//float a = get_angle(dir);
-	float s = a-pi/3;
-	float e = a+pi/3;
-	for(int i = 0; i < Amount; i++)
-	{
-		float f = mix(s, e, float(i+1)/float(Amount+2));
-		CNetEvent_DamageInd *pEvent = (CNetEvent_DamageInd *)m_Events.Create(NETEVENTTYPE_DAMAGEIND, sizeof(CNetEvent_DamageInd));
-		if(pEvent)
-		{
-			pEvent->m_X = (int)Pos.x;
-			pEvent->m_Y = (int)Pos.y;
-			pEvent->m_Angle = (int)(f*256.0f);
-		}
-	}
-}
-
 void CGameContext::CreateDamage(vec2 Pos, int Id, vec2 Source, int HealthAmount, int ArmorAmount, bool Self)
 {
-	for(int ArmorType = 0; ArmorType < 2; ArmorType++)
+	float f = angle(Source);
+	CNetEvent_Damage *pEvent = (CNetEvent_Damage *)m_Events.Create(NETEVENTTYPE_DAMAGE, sizeof(CNetEvent_Damage));
+	if(pEvent)
 	{
-		if((ArmorType && ArmorAmount) || (!ArmorType && HealthAmount))
-		{
-			float f = angle(Source);
-			CNetEvent_Damage *pEvent = (CNetEvent_Damage *)m_Events.Create(NETEVENTTYPE_DAMAGE, sizeof(CNetEvent_Damage));
-			if(pEvent)
-			{
-				pEvent->m_X = (int)Pos.x;
-				pEvent->m_Y = (int)Pos.y;
-				pEvent->m_ClientID = Id;
-				pEvent->m_Angle = (int)(f*256.0f);
-				pEvent->m_Amount = ArmorType ? ArmorAmount : HealthAmount;
-				if(!Self)
-					pEvent->m_Type = ArmorType ? DAMAGE_ARMOR : DAMAGE_NORMAL;
-				else
-					pEvent->m_Type = ArmorType ? DAMAGE_SELF_ARMOR : DAMAGE_SELF;
-			}
-		}
+		pEvent->m_X = (int)Pos.x;
+		pEvent->m_Y = (int)Pos.y;
+		pEvent->m_ClientID = Id;
+		pEvent->m_Angle = (int)(f*256.0f);
+		pEvent->m_HealthAmount = HealthAmount;
+		pEvent->m_ArmorAmount = HealthAmount;
+		pEvent->m_Self = Self;
 	}
 }
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -93,35 +93,26 @@ class CCharacter *CGameContext::GetPlayerChar(int ClientID)
 	return m_apPlayers[ClientID]->GetCharacter();
 }
 
-void CGameContext::CreateDamageInd(vec2 Pos, float Angle, int HealthAmount, int ArmorAmount)
+void CGameContext::CreateDamageInd(vec2 Pos, float Angle, int Amount)
 {
-	int TotalAmount = HealthAmount+ArmorAmount;
 	float a = 3*pi/2 + Angle;
 	//float a = get_angle(dir);
 	float s = a-pi/3;
 	float e = a+pi/3;
-	for(int i = 0; i < TotalAmount; i++)
+	for(int i = 0; i < Amount; i++)
 	{
-		float f = mix(s, e, float(i+1)/float(TotalAmount+2));
+		float f = mix(s, e, float(i+1)/float(Amount+2));
 		CNetEvent_DamageInd *pEvent = (CNetEvent_DamageInd *)m_Events.Create(NETEVENTTYPE_DAMAGEIND, sizeof(CNetEvent_DamageInd));
 		if(pEvent)
 		{
 			pEvent->m_X = (int)Pos.x;
 			pEvent->m_Y = (int)Pos.y;
 			pEvent->m_Angle = (int)(f*256.0f);
-			if(ArmorAmount)
-			{
-				pEvent->m_Armored = true;
-				ArmorAmount--;
-			}
-			else
-				pEvent->m_Armored = false;
-
 		}
 	}
 }
 
-void CGameContext::CreateDamage(vec2 Pos, int Id, vec2 Source, int HealthAmount, int ArmorAmount)
+void CGameContext::CreateDamage(vec2 Pos, int Id, vec2 Source, int HealthAmount, int ArmorAmount, bool Self)
 {
 	for(int ArmorType = 0; ArmorType < 2; ArmorType++)
 	{
@@ -136,7 +127,10 @@ void CGameContext::CreateDamage(vec2 Pos, int Id, vec2 Source, int HealthAmount,
 				pEvent->m_ClientID = Id;
 				pEvent->m_Angle = (int)(f*256.0f);
 				pEvent->m_Amount = ArmorType ? ArmorAmount : HealthAmount;
-				pEvent->m_Armored = ArmorType;
+				if(!Self)
+					pEvent->m_Type = ArmorType ? DAMAGE_ARMOR : DAMAGE_NORMAL;
+				else
+					pEvent->m_Type = ArmorType ? DAMAGE_SELF_ARMOR : DAMAGE_SELF;
 			}
 		}
 	}

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -104,7 +104,7 @@ void CGameContext::CreateDamage(vec2 Pos, int Id, vec2 Source, int HealthAmount,
 		pEvent->m_ClientID = Id;
 		pEvent->m_Angle = (int)(f*256.0f);
 		pEvent->m_HealthAmount = HealthAmount;
-		pEvent->m_ArmorAmount = HealthAmount;
+		pEvent->m_ArmorAmount = ArmorAmount;
 		pEvent->m_Self = Self;
 	}
 }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -123,7 +123,8 @@ public:
 	CVoteOptionServer *m_pVoteOptionLast;
 
 	// helper functions
-	void CreateDamageInd(vec2 Pos, float AngleMod, int Amount);
+	void CreateDamageInd(vec2 Pos, float AngleMod, int HealthAmount, int ArmorAmount);
+	void CreateDamage(vec2 Pos, int Id, vec2 Source, int HealthAmount, int ArmorAmount);
 	void CreateExplosion(vec2 Pos, int Owner, int Weapon, int MaxDamage);
 	void CreateHammerHit(vec2 Pos);
 	void CreatePlayerSpawn(vec2 Pos);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -123,8 +123,8 @@ public:
 	CVoteOptionServer *m_pVoteOptionLast;
 
 	// helper functions
-	void CreateDamageInd(vec2 Pos, float AngleMod, int HealthAmount, int ArmorAmount);
-	void CreateDamage(vec2 Pos, int Id, vec2 Source, int HealthAmount, int ArmorAmount);
+	void CreateDamageInd(vec2 Pos, float AngleMod, int Amount);
+	void CreateDamage(vec2 Pos, int Id, vec2 Source, int HealthAmount, int ArmorAmount, bool Self);
 	void CreateExplosion(vec2 Pos, int Owner, int Weapon, int MaxDamage);
 	void CreateHammerHit(vec2 Pos);
 	void CreatePlayerSpawn(vec2 Pos);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -123,7 +123,6 @@ public:
 	CVoteOptionServer *m_pVoteOptionLast;
 
 	// helper functions
-	void CreateDamageInd(vec2 Pos, float AngleMod, int Amount);
 	void CreateDamage(vec2 Pos, int Id, vec2 Source, int HealthAmount, int ArmorAmount, bool Self);
 	void CreateExplosion(vec2 Pos, int Owner, int Weapon, int MaxDamage);
 	void CreateHammerHit(vec2 Pos);


### PR DESCRIPTION
So this is a proposal to include a `Damage` net event.
This event contains the following:

- `m_ClientID`: ID of damaged tee
- `m_Amount`: amount of damage taken, from 1 to 9
- `m_Angle`: angle from which damage was taken
- `m_Armored`: type of damage (armor damage or health damage) 

This would allow for some later potential graphical improvements that would need to take into account the affected tee, and the angle from which the damage came.

I also added the boolean `m_Armored` flag to `DamageInd`, in case we want to keep server-side damage indicators for health-only.

This is related to #1715, which is only a foretaste of what could be done ;-)
Adding the pre-feature of #1715 is completely optional, I have it done and ready though.

Note: Actually, it should also be possible to completely remove the `DamageInd` packet and generate the damage indicators from the client. I'm not sure if this has any unwanted side-effects. 
PS: the `m_Angle` flag was tested with all weapons/particles.