### PR TITLE
Server broadcast

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -242,8 +242,8 @@ Messages = [
 	NetMessage("Sv_Motd", [
 		NetString("m_pMessage"),
 	]),
-    
-    NetMessage("Sv_Broadcast", [
+
+	NetMessage("Sv_Broadcast", [
 		NetString("m_pMessage"),
 	]),
 

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -242,6 +242,10 @@ Messages = [
 	NetMessage("Sv_Motd", [
 		NetString("m_pMessage"),
 	]),
+    
+    NetMessage("Sv_Broadcast", [
+		NetString("m_pMessage"),
+	]),
 
 	NetMessage("Sv_Chat", [
 		NetIntRange("m_Mode", 0, 'NUM_CHATS-1'),

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -700,6 +700,7 @@ public:
 			int NextCharacter = str_utf8_decode(&pTmp);
 			while(pCurrent < pBatchEnd)
 			{
+				pCursor->m_CharCount += pTmp-pCurrent;
 				int Character = NextCharacter;
 				pCurrent = pTmp;
 				NextCharacter = str_utf8_decode(&pTmp);
@@ -744,7 +745,6 @@ public:
 
 					DrawX += Advance*Size;
 					pCursor->m_GlyphCount++;
-					pCursor->m_CharCount += pTmp-pCurrent;
 				}
 			}
 
@@ -889,6 +889,7 @@ public:
 				int NextCharacter = str_utf8_decode(&pTmp);
 				while(pCurrent < pBatchEnd)
 				{
+					pCursor->m_CharCount += pTmp-pCurrent;
 					int Character = NextCharacter;
 					pCurrent = pTmp;
 					NextCharacter = str_utf8_decode(&pTmp);
@@ -925,7 +926,6 @@ public:
 
 						DrawX += Advance*Size;
 						pCursor->m_GlyphCount++;
-						pCursor->m_CharCount += pTmp-pCurrent;
 					}
 				}
 

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -498,6 +498,7 @@ public:
 		pCursor->m_LineCount = 1;
 		pCursor->m_LineWidth = -1;
 		pCursor->m_Flags = Flags;
+		pCursor->m_GlyphCount = 0;
 		pCursor->m_CharCount = 0;
 	}
 
@@ -672,7 +673,7 @@ public:
 				{
 					// word can't be fitted in one line, cut it
 					CTextCursor Cutter = *pCursor;
-					Cutter.m_CharCount = 0;
+					Cutter.m_GlyphCount = 0;
 					Cutter.m_X = DrawX;
 					Cutter.m_Y = DrawY;
 					Cutter.m_Flags &= ~TEXTFLAG_RENDER;
@@ -680,7 +681,7 @@ public:
 
 					TextDeferredRenderEx(&Cutter, (const char *)pCurrent, Wlen, aQuadChar, QuadCharMaxCount,
 										 pQuadCharCount, pFontTexture);
-					Wlen = Cutter.m_CharCount;
+					Wlen = Cutter.m_GlyphCount;
 					NewLine = 1;
 
 					if(Wlen <= 3) // if we can't place 3 chars of the word on this line, take the next
@@ -742,7 +743,8 @@ public:
 					}
 
 					DrawX += Advance*Size;
-					pCursor->m_CharCount++;
+					pCursor->m_GlyphCount++;
+					pCursor->m_CharCount += pTmp-pCurrent;
 				}
 			}
 
@@ -861,14 +863,14 @@ public:
 					{
 						// word can't be fitted in one line, cut it
 						CTextCursor Cutter = *pCursor;
-						Cutter.m_CharCount = 0;
+						Cutter.m_GlyphCount = 0;
 						Cutter.m_X = DrawX;
 						Cutter.m_Y = DrawY;
 						Cutter.m_Flags &= ~TEXTFLAG_RENDER;
 						Cutter.m_Flags |= TEXTFLAG_STOP_AT_END;
 
 						TextEx(&Cutter, (const char *)pCurrent, Wlen);
-						Wlen = Cutter.m_CharCount;
+						Wlen = Cutter.m_GlyphCount;
 						NewLine = 1;
 
 						if(Wlen <= 3) // if we can't place 3 chars of the word on this line, take the next
@@ -922,7 +924,8 @@ public:
 						}
 
 						DrawX += Advance*Size;
-						pCursor->m_CharCount++;
+						pCursor->m_GlyphCount++;
+						pCursor->m_CharCount += pTmp-pCurrent;
 					}
 				}
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -25,6 +25,7 @@ MACRO_CONFIG_INT(ClAutoScreenshot, cl_auto_screenshot, 0, 0, 1, CFGFLAG_SAVE|CFG
 MACRO_CONFIG_INT(ClAutoScreenshotMax, cl_auto_screenshot_max, 10, 0, 1000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Maximum number of automatically created screenshots (0 = no limit)")
 
 MACRO_CONFIG_INT(ClShowServerBroadcast, cl_show_server_broadcast, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Show server broadcast")
+MACRO_CONFIG_INT(ClEnableColoredBroadcast, cl_enable_colored_broadcast, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Eanble colored server broadcasts")
 
 MACRO_CONFIG_STR(BrFilterString, br_filter_string, 25, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Server browser filtering string")
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -25,7 +25,7 @@ MACRO_CONFIG_INT(ClAutoScreenshot, cl_auto_screenshot, 0, 0, 1, CFGFLAG_SAVE|CFG
 MACRO_CONFIG_INT(ClAutoScreenshotMax, cl_auto_screenshot_max, 10, 0, 1000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Maximum number of automatically created screenshots (0 = no limit)")
 
 MACRO_CONFIG_INT(ClShowServerBroadcast, cl_show_server_broadcast, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Show server broadcast")
-MACRO_CONFIG_INT(ClEnableColoredBroadcast, cl_enable_colored_broadcast, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Eanble colored server broadcasts")
+MACRO_CONFIG_INT(ClColoredBroadcast, cl_colored_broadcast, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Enable colored server broadcasts")
 
 MACRO_CONFIG_STR(BrFilterString, br_filter_string, 25, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Server browser filtering string")
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -24,6 +24,8 @@ MACRO_CONFIG_INT(ClAutoDemoMax, cl_auto_demo_max, 10, 0, 1000, CFGFLAG_SAVE|CFGF
 MACRO_CONFIG_INT(ClAutoScreenshot, cl_auto_screenshot, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Automatically take game over screenshot")
 MACRO_CONFIG_INT(ClAutoScreenshotMax, cl_auto_screenshot_max, 10, 0, 1000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Maximum number of automatically created screenshots (0 = no limit)")
 
+MACRO_CONFIG_INT(ClShowServerBroadcast, cl_show_server_broadcast, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Show server broadcast")
+
 MACRO_CONFIG_STR(BrFilterString, br_filter_string, 25, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Server browser filtering string")
 
 MACRO_CONFIG_INT(BrSort, br_sort, 0, 0, 256, CFGFLAG_SAVE|CFGFLAG_CLIENT, "")

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -20,6 +20,7 @@ class CTextCursor
 public:
 	int m_Flags;
 	int m_LineCount;
+	int m_GlyphCount;
 	int m_CharCount;
 	int m_MaxLines;
 

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -8,11 +8,214 @@
 
 #include <game/client/gameclient.h>
 
-#include <game/client/components/motd.h>
-#include <game/client/components/scoreboard.h>
-
 #include "broadcast.h"
+#include "chat.h"
+#include "scoreboard.h"
+#include "motd.h"
 
+inline bool IsCharANum(char c)
+{
+	return c >= '0' && c <= '9';
+}
+
+inline int WordLengthBack(const char *pText, int MaxChars)
+{
+	int s = 0;
+	while(MaxChars--)
+	{
+		if((*pText == '\n' || *pText == '\t' || *pText == ' '))
+			return s;
+		pText--;
+		s++;
+	}
+	return 0;
+}
+
+inline bool IsCharWhitespace(char c)
+{
+	return c == '\n' || c == '\t' || c == ' ';
+}
+
+void CBroadcast::RenderServerBroadcast()
+{
+	if(!g_Config.m_ClShowServerBroadcast || m_pClient->m_MuteServerBroadcast)
+		return;
+
+	const bool ColoredBroadcastEnabled = g_Config.m_ClEnableColoredBroadcast;
+	const float Height = 300;
+	const float Width = Height*Graphics()->ScreenAspect();
+
+	const float DisplayDuration = 10.0f;
+	const float DisplayStartFade = 9.0f;
+	const float DeltaTime = Client()->LocalTime() - m_SrvBroadcastReceivedTime;
+
+	if(m_aSrvBroadcastMsg[0] == 0 || DeltaTime > DisplayDuration)
+		return;
+
+	if(m_pClient->m_pChat->IsActive())
+			return;
+
+	const float Fade = 1.0f - max(0.0f, (DeltaTime - DisplayStartFade) / (DisplayDuration - DisplayStartFade));
+
+	CUIRect ScreenRect = {0, 0, Width, Height};
+
+	CUIRect BcView = ScreenRect;
+	BcView.x += Width * 0.25f;
+	BcView.y += Height * 0.8f;
+	BcView.w *= 0.5f;
+	BcView.h *= 0.2f;
+
+	float FontSize = 11.0f;
+
+	vec4 ColorTop(0, 0, 0, 0);
+	vec4 ColorBot(0, 0, 0, 0.4f * Fade);
+	CUIRect BgRect;
+	BcView.HSplitBottom(10.0f, 0, &BgRect);
+
+	RenderTools()->DrawUIRect4(&BgRect, ColorTop, ColorTop,
+							   ColorBot, ColorBot, 0, 0);
+
+	// server broadcast line
+	CUIRect TitleRect;
+	BcView.HSplitBottom(10.0f, &BcView, &TitleRect);
+	TitleRect.y += 1.5f;
+	TextRender()->TextColor(1, 1, 1, 0.6f * Fade);
+	UI()->DoLabel(&TitleRect, Localize("Server broadcast"), 5.5f, CUI::ALIGN_CENTER);
+
+	BcView.VMargin(5.0f, &BcView);
+	BcView.HSplitBottom(2.0f, &BcView, 0);
+
+	const char* pBroadcastMsg = m_aSrvBroadcastMsg;
+	const int MsgLen = m_aSrvBroadcastMsgLen;
+
+	// broadcast message
+	// one line == big font
+	// > one line == small font
+
+	CTextCursor Cursor;
+	TextRender()->SetCursor(&Cursor, BcView.x, BcView.y, FontSize, 0);
+	Cursor.m_LineWidth = BcView.w;
+	TextRender()->TextEx(&Cursor, pBroadcastMsg, -1);
+
+	// can't fit on one line, reduce size
+	if(Cursor.m_LineCount > 1)
+	{
+		FontSize = 6.5f; // smaller font
+		TextRender()->SetCursor(&Cursor, BcView.x, BcView.y, FontSize, 0);
+		Cursor.m_LineWidth = BcView.w;
+		TextRender()->TextEx(&Cursor, pBroadcastMsg, -1);
+	}
+
+	// make lines
+	struct CLineInfo
+	{
+		const char* m_pStrStart;
+		int m_StrLen;
+		float m_Width;
+	};
+
+	CLineInfo aLines[10];
+	int CurCharCount = 0;
+	int LineCount = 0;
+
+	while(CurCharCount < MsgLen)
+	{
+		const char* RemainingMsg = pBroadcastMsg + CurCharCount;
+
+		TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_STOP_AT_END);
+		Cursor.m_LineWidth = BcView.w;
+
+		TextRender()->TextEx(&Cursor, RemainingMsg, -1);
+		int StrLen = Cursor.m_CharCount;
+
+		// don't cut words
+		if(CurCharCount + StrLen < MsgLen)
+		{
+			const int WorldLen = WordLengthBack(RemainingMsg + StrLen, StrLen);
+			if(WorldLen > 0 && WorldLen < StrLen)
+			{
+				StrLen -= WorldLen;
+				TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_STOP_AT_END);
+				Cursor.m_LineWidth = BcView.w;
+				TextRender()->TextEx(&Cursor, RemainingMsg, StrLen);
+			}
+		}
+
+		const float TextWidth = Cursor.m_X-Cursor.m_StartX;
+
+		CLineInfo Line = { RemainingMsg, StrLen, TextWidth };
+		aLines[LineCount++] = Line;
+		CurCharCount += StrLen;
+	}
+
+	// draw lines
+	TextRender()->TextColor(1, 1, 1, 1);
+	TextRender()->TextOutlineColor(0, 0, 0, 0.3f);
+	float y = BcView.y + BcView.h - LineCount * FontSize;
+
+	for(int l = 0; l < LineCount; l++)
+	{
+		const CLineInfo& Line = aLines[l];
+		TextRender()->SetCursor(&Cursor, BcView.x + (BcView.w - Line.m_Width) * 0.5f, y,
+								FontSize, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
+		Cursor.m_LineWidth = BcView.w;
+
+		// draw colored text
+		if(ColoredBroadcastEnabled)
+		{
+			int DrawnStrLen = 0;
+			int ThisCharPos = Line.m_pStrStart - pBroadcastMsg;
+			while(DrawnStrLen < Line.m_StrLen)
+			{
+				int StartColorID = -1;
+				int ColorStrLen = -1;
+
+				for(int j = 0; j < m_SrvBroadcastColorCount; j++)
+				{
+					if((ThisCharPos+DrawnStrLen) >= m_aSrvBroadcastColorList[j].m_CharPos)
+					{
+						StartColorID = j;
+					}
+					else if(StartColorID >= 0)
+					{
+						ColorStrLen = m_aSrvBroadcastColorList[j].m_CharPos - m_aSrvBroadcastColorList[StartColorID].m_CharPos;
+						break;
+					}
+				}
+
+				dbg_assert(StartColorID >= 0, "This should not be -1, color not found");
+
+				if(ColorStrLen == -1)
+					ColorStrLen = Line.m_StrLen-DrawnStrLen;
+
+				const CBcColor& TextColor = m_aSrvBroadcastColorList[StartColorID];
+				float r = TextColor.m_R/255.f;
+				float g = TextColor.m_G/255.f;
+				float b = TextColor.m_B/255.f;
+				float AvgLum = 0.2126*r + 0.7152*g + 0.0722*b;
+
+				if(AvgLum < 0.25f)
+					TextRender()->TextOutlineColor(1, 1, 1, 0.6f);
+				else
+					TextRender()->TextOutlineColor(0, 0, 0, 0.3f);
+
+				TextRender()->TextColor(r, g, b, Fade);
+
+				TextRender()->TextEx(&Cursor, Line.m_pStrStart+DrawnStrLen, ColorStrLen);
+				DrawnStrLen += ColorStrLen;
+			}
+		}
+		else
+		{
+			TextRender()->TextEx(&Cursor, Line.m_pStrStart, Line.m_StrLen);
+		}
+
+		y += FontSize;
+	}
+
+	TextRender()->TextColor(1, 1, 1, 1);
+	TextRender()->TextOutlineColor(0, 0, 0, 0.3f);
+}
 
 CBroadcast::CBroadcast()
 {
@@ -27,12 +230,59 @@ void CBroadcast::DoBroadcast(const char *pText)
 	Cursor.m_LineWidth = 300*Graphics()->ScreenAspect();
 	TextRender()->TextEx(&Cursor, m_aBroadcastText, -1);
 	m_BroadcastRenderOffset = 150*Graphics()->ScreenAspect()-Cursor.m_X/2;
-	m_BroadcastTime = time_get()+time_freq()*10;
+	m_BroadcastTime = Client()->LocalTime() + 10.0f;
 }
 
 void CBroadcast::OnReset()
 {
 	m_BroadcastTime = 0;
+}
+
+void CBroadcast::OnMessage(int MsgType, void* pRawMsg)
+{
+	// process server broadcast message
+	if(MsgType == NETMSGTYPE_SV_BROADCAST && g_Config.m_ClShowServerBroadcast &&
+	   !m_pClient->m_MuteServerBroadcast)
+	{
+		CNetMsg_Sv_Broadcast *pMsg = (CNetMsg_Sv_Broadcast *)pRawMsg;
+
+		// new broadcast message
+		int MsgLen = str_length(pMsg->m_pMessage);
+		mem_zero(m_aSrvBroadcastMsg, sizeof(m_aSrvBroadcastMsg));
+		m_aSrvBroadcastMsgLen = 0;
+		m_SrvBroadcastReceivedTime = Client()->LocalTime();
+
+		const CBcColor White = { 255, 255, 255, 0 };
+		m_aSrvBroadcastColorList[0] = White;
+		m_SrvBroadcastColorCount = 1;
+
+		// parse colors
+		for(int i = 0; i < MsgLen; i++)
+		{
+			const char* c = pMsg->m_pMessage + i;
+			const char* pTmp = c;
+			int CharUtf8 = str_utf8_decode(&pTmp);
+			const int Utf8Len = pTmp-c;
+
+			if(*c == CharUtf8 && *c == '^')
+			{
+				if(i+3 < MsgLen && IsCharANum(c[1]) && IsCharANum(c[2])  && IsCharANum(c[3]))
+				{
+					u8 r = (c[1] - '0') * 24 + 39;
+					u8 g = (c[2] - '0') * 24 + 39;
+					u8 b = (c[3] - '0') * 24 + 39;
+					CBcColor Color = { r, g, b, m_aSrvBroadcastMsgLen };
+					if(m_SrvBroadcastColorCount < MAX_BROADCAST_COLORS)
+						m_aSrvBroadcastColorList[m_SrvBroadcastColorCount++] = Color;
+					i += 3;
+					continue;
+				}
+			}
+
+			if(m_aSrvBroadcastMsgLen+Utf8Len < MAX_BROADCAST_MSG_LENGTH)
+				m_aSrvBroadcastMsg[m_aSrvBroadcastMsgLen++] = *c;
+		}
+	}
 }
 
 void CBroadcast::OnRender()
@@ -42,12 +292,16 @@ void CBroadcast::OnRender()
 
 	Graphics()->MapScreen(0, 0, 300*Graphics()->ScreenAspect(), 300);
 
-	if(time_get() < m_BroadcastTime)
+	// client broadcast
+	if(Client()->LocalTime() < m_BroadcastTime)
 	{
 		CTextCursor Cursor;
 		TextRender()->SetCursor(&Cursor, m_BroadcastRenderOffset, 40.0f, 12.0f, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = 300*Graphics()->ScreenAspect()-m_BroadcastRenderOffset;
 		TextRender()->TextEx(&Cursor, m_aBroadcastText, -1);
 	}
+
+	// server broadcast
+	RenderServerBroadcast();
 }
 

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -44,7 +44,7 @@ void CBroadcast::RenderServerBroadcast()
 	if(!g_Config.m_ClShowServerBroadcast || m_pClient->m_MuteServerBroadcast)
 		return;
 
-	const bool ColoredBroadcastEnabled = g_Config.m_ClEnableColoredBroadcast;
+	const bool ColoredBroadcastEnabled = g_Config.m_ClColoredBroadcast;
 	const float Height = 300;
 	const float Width = Height*Graphics()->ScreenAspect();
 
@@ -72,16 +72,42 @@ void CBroadcast::RenderServerBroadcast()
 	vec4 ColorBot(0, 0, 0, 0.4f * Fade);
 	CUIRect BgRect;
 	BcView.HSplitBottom(10.0f, 0, &BgRect);
+	BcView.HSplitBottom(8.0f, &BcView, 0);
+
+	// draw bottom bar
+	const float CornerWidth = 12.0f;
+	BgRect.VMargin(CornerWidth, &BgRect);
+
+	Graphics()->TextureClear();
+	Graphics()->QuadsBegin();
+	IGraphics::CFreeformItem LeftCorner(
+		BgRect.x - CornerWidth, BgRect.y + BgRect.h,
+		BgRect.x, BgRect.y,
+		BgRect.x, BgRect.y + BgRect.h,
+		BgRect.x, BgRect.y + BgRect.h
+	);
+	IGraphics::CColorVertex aColorVert[4] = {
+		IGraphics::CColorVertex(0, 0,0,0, 0.0f),
+		IGraphics::CColorVertex(1, 0,0,0, 0.0f),
+		IGraphics::CColorVertex(2, 0,0,0, 0.4f * Fade),
+		IGraphics::CColorVertex(3, 0,0,0, 0.4f * Fade)};
+	Graphics()->SetColorVertex(aColorVert, 4);
+	Graphics()->QuadsDrawFreeform(&LeftCorner, 1);
+
+	IGraphics::CFreeformItem RightCorner(
+		BgRect.x+BgRect.w + CornerWidth, BgRect.y + BgRect.h,
+		BgRect.x+BgRect.w, BgRect.y,
+		BgRect.x+BgRect.w, BgRect.y + BgRect.h,
+		BgRect.x+BgRect.w, BgRect.y + BgRect.h
+	);
+	Graphics()->SetColorVertex(aColorVert, 4);
+	Graphics()->QuadsDrawFreeform(&RightCorner, 1);
+
+	Graphics()->QuadsEnd();
 
 	RenderTools()->DrawUIRect4(&BgRect, ColorTop, ColorTop,
 							   ColorBot, ColorBot, 0, 0);
 
-	// server broadcast line
-	CUIRect TitleRect;
-	BcView.HSplitBottom(10.0f, &BcView, &TitleRect);
-	TitleRect.y += 1.5f;
-	TextRender()->TextColor(1, 1, 1, 0.6f * Fade);
-	UI()->DoLabel(&TitleRect, Localize("Server broadcast"), 5.5f, CUI::ALIGN_CENTER);
 
 	BcView.VMargin(5.0f, &BcView);
 	BcView.HSplitBottom(2.0f, &BcView, 0);
@@ -187,11 +213,10 @@ void CBroadcast::OnReset()
 void CBroadcast::OnMessage(int MsgType, void* pRawMsg)
 {
 	// process server broadcast message
-	if(MsgType == NETMSGTYPE_SV_CHAT && g_Config.m_ClShowServerBroadcast &&
+	if(MsgType == NETMSGTYPE_SV_BROADCAST && g_Config.m_ClShowServerBroadcast &&
 	   !m_pClient->m_MuteServerBroadcast)
 	{
-		//CNetMsg_Sv_Broadcast *pMsg = (CNetMsg_Sv_Broadcast *)pRawMsg;
-		CNetMsg_Sv_Chat *pMsg = (CNetMsg_Sv_Chat *)pRawMsg;
+		CNetMsg_Sv_Broadcast *pMsg = (CNetMsg_Sv_Broadcast *)pRawMsg;
 
 		// new broadcast message
 		int RcvMsgLen = str_length(pMsg->m_pMessage);

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -228,7 +228,7 @@ void CBroadcast::OnMessage(int MsgType, void* pRawMsg)
 		m_aSrvBroadcastColorList[0] = White;
 		m_SrvBroadcastColorCount = 1;
 
-		CBcLineInfo UserLines[3];
+		CBcLineInfo UserLines[MAX_BROADCAST_LINES];
 		int UserLineCount = 0;
 		int LastUserLineStartPoint = 0;
 
@@ -257,7 +257,7 @@ void CBroadcast::OnMessage(int MsgType, void* pRawMsg)
 
 			if(*c == CharUtf8 && *c == '\\')
 			{
-				if(i+1 < RcvMsgLen && c[1] == 'n' && UserLineCount < 3)
+				if(i+1 < RcvMsgLen && c[1] == 'n' && UserLineCount < MAX_BROADCAST_LINES)
 				{
 					CBcLineInfo Line = { m_aSrvBroadcastMsg+LastUserLineStartPoint,
 										 m_aSrvBroadcastMsgLen-LastUserLineStartPoint, 0 };
@@ -310,7 +310,7 @@ void CBroadcast::OnMessage(int MsgType, void* pRawMsg)
 
 			// make lines
 			int CurCharCount = 0;
-			while(CurCharCount < MsgLen && m_SrvBroadcastLineCount < 3)
+			while(CurCharCount < MsgLen && m_SrvBroadcastLineCount < MAX_BROADCAST_LINES)
 			{
 				const char* RemainingMsg = pBroadcastMsg + CurCharCount;
 
@@ -344,7 +344,7 @@ void CBroadcast::OnMessage(int MsgType, void* pRawMsg)
 		{
 			FontSize = BROADCAST_FONTSIZE_SMALL;
 
-			for(int i = 0; i < UserLineCount && m_SrvBroadcastLineCount < 3; i++)
+			for(int i = 0; i < UserLineCount && m_SrvBroadcastLineCount < MAX_BROADCAST_LINES; i++)
 			{
 				TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_STOP_AT_END);
 				Cursor.m_LineWidth = LineMaxWidth;

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -31,7 +31,7 @@ class CBroadcast : public CComponent
 	};
 
 	CBcColor m_aSrvBroadcastColorList[MAX_BROADCAST_COLORS];
-	CBcLineInfo m_aSrvBroadcastLines[10];
+	CBcLineInfo m_aSrvBroadcastLines[3];
 	char m_aSrvBroadcastMsg[MAX_BROADCAST_MSG_LENGTH+1];
 	int m_aSrvBroadcastMsgLen;
 	int m_SrvBroadcastColorCount;

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -7,8 +7,29 @@
 class CBroadcast : public CComponent
 {
 	char m_aBroadcastText[128];
-	int64 m_BroadcastTime;
+	float m_BroadcastTime;
 	float m_BroadcastRenderOffset;
+
+	// server broadcast
+	typedef unsigned char u8;
+	struct CBcColor
+	{
+		u8 m_R, m_G, m_B;
+		int m_CharPos;
+	};
+
+	enum {
+		MAX_BROADCAST_COLORS = 128,
+		MAX_BROADCAST_MSG_LENGTH = 127
+	};
+
+	CBcColor m_aSrvBroadcastColorList[MAX_BROADCAST_COLORS];
+	char m_aSrvBroadcastMsg[MAX_BROADCAST_MSG_LENGTH+1];
+	int m_aSrvBroadcastMsgLen;
+	int m_SrvBroadcastColorCount;
+	float m_SrvBroadcastReceivedTime;
+
+	void RenderServerBroadcast();
 
 public:
 	CBroadcast();
@@ -16,6 +37,7 @@ public:
 	void DoBroadcast(const char *pText);
 
 	virtual void OnReset();
+	virtual void OnMessage(int MsgType, void *pRawMsg);
 	virtual void OnRender();
 };
 

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -27,11 +27,12 @@ class CBroadcast : public CComponent
 
 	enum {
 		MAX_BROADCAST_COLORS = 128,
-		MAX_BROADCAST_MSG_LENGTH = 127
+		MAX_BROADCAST_MSG_LENGTH = 127,
+		MAX_BROADCAST_LINES = 3,
 	};
 
 	CBcColor m_aSrvBroadcastColorList[MAX_BROADCAST_COLORS];
-	CBcLineInfo m_aSrvBroadcastLines[3];
+	CBcLineInfo m_aSrvBroadcastLines[MAX_BROADCAST_LINES];
 	char m_aSrvBroadcastMsg[MAX_BROADCAST_MSG_LENGTH+1];
 	int m_aSrvBroadcastMsgLen;
 	int m_SrvBroadcastColorCount;

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -18,16 +18,26 @@ class CBroadcast : public CComponent
 		int m_CharPos;
 	};
 
+	struct CBcLineInfo
+	{
+		const char* m_pStrStart;
+		int m_StrLen;
+		float m_Width;
+	};
+
 	enum {
 		MAX_BROADCAST_COLORS = 128,
 		MAX_BROADCAST_MSG_LENGTH = 127
 	};
 
 	CBcColor m_aSrvBroadcastColorList[MAX_BROADCAST_COLORS];
+	CBcLineInfo m_aSrvBroadcastLines[10];
 	char m_aSrvBroadcastMsg[MAX_BROADCAST_MSG_LENGTH+1];
 	int m_aSrvBroadcastMsgLen;
 	int m_SrvBroadcastColorCount;
+	int m_SrvBroadcastLineCount;
 	float m_SrvBroadcastReceivedTime;
+	float m_SrvBroadcastFontSize;
 
 	void RenderServerBroadcast();
 

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -13,7 +13,7 @@ class CHud : public CComponent
 
 	// broadcast
 	typedef unsigned char u8;
-	struct BcColor
+	struct CBcColor
 	{
 		u8 m_R,m_G,m_B;
 		int m_CharPos;
@@ -24,7 +24,7 @@ class CHud : public CComponent
 		MAX_BROADCAST_MSG_LENGTH = 127
 	};
 
-	BcColor m_aBroadcastColorList[MAX_BROADCAST_COLORS];
+	CBcColor m_aBroadcastColorList[MAX_BROADCAST_COLORS];
 	char m_aBroadcastMsg[MAX_BROADCAST_MSG_LENGTH+1];
 	int m_aBroadcastMsgLen;
 	int m_BroadcastColorCount;

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -15,16 +15,18 @@ class CHud : public CComponent
 	typedef unsigned char u8;
 	struct BcColor
 	{
-		u8 r,g,b;
+		u8 m_R,m_G,m_B;
+		int m_CharPos;
 	};
 
 	enum {
-		MAX_BROADCAST_COLORS = 256,
-		MAX_BROADCAST_MSG_LENGTH = 256
+		MAX_BROADCAST_COLORS = 128,
+		MAX_BROADCAST_MSG_LENGTH = 127
 	};
 
 	BcColor m_aBroadcastColorList[MAX_BROADCAST_COLORS];
-	char m_aBroadcastMsg[MAX_BROADCAST_MSG_LENGTH];
+	char m_aBroadcastMsg[MAX_BROADCAST_MSG_LENGTH+1];
+	int m_aBroadcastMsgLen;
 	int m_BroadcastColorCount;
 	float m_BroadcastReceivedTime;
 

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -3,12 +3,30 @@
 #ifndef GAME_CLIENT_COMPONENTS_HUD_H
 #define GAME_CLIENT_COMPONENTS_HUD_H
 #include <game/client/component.h>
+#include <base/tl/array.h>
 
 class CHud : public CComponent
 {
 	float m_Width, m_Height;
 	float m_AverageFPS;
 	int64 m_WarmupHideTick;
+
+	// broadcast
+	typedef unsigned char u8;
+	struct BcColor
+	{
+		u8 r,g,b;
+	};
+
+	enum {
+		MAX_BROADCAST_COLORS = 256,
+		MAX_BROADCAST_MSG_LENGTH = 256
+	};
+
+	BcColor m_aBroadcastColorList[MAX_BROADCAST_COLORS];
+	char m_aBroadcastMsg[MAX_BROADCAST_MSG_LENGTH];
+	int m_BroadcastColorCount;
+	float m_BroadcastReceivedTime;
 
 	void RenderCursor();
 
@@ -26,10 +44,12 @@ class CHud : public CComponent
 	void RenderScoreHud();
 	void RenderSpectatorHud();
 	void RenderWarmupTimer();
+	void RenderBroadcast();
 public:
 	CHud();
 
 	virtual void OnReset();
+	virtual void OnMessage(int MsgType, void *pRawMsg);
 	virtual void OnRender();
 };
 

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -3,7 +3,6 @@
 #ifndef GAME_CLIENT_COMPONENTS_HUD_H
 #define GAME_CLIENT_COMPONENTS_HUD_H
 #include <game/client/component.h>
-#include <base/tl/array.h>
 
 class CHud : public CComponent
 {
@@ -27,7 +26,6 @@ class CHud : public CComponent
 	void RenderScoreHud();
 	void RenderSpectatorHud();
 	void RenderWarmupTimer();
-
 public:
 	CHud();
 

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -11,11 +11,11 @@ class CHud : public CComponent
 	float m_AverageFPS;
 	int64 m_WarmupHideTick;
 
-	// broadcast
+	// server broadcast
 	typedef unsigned char u8;
 	struct CBcColor
 	{
-		u8 m_R,m_G,m_B;
+		u8 m_R, m_G, m_B;
 		int m_CharPos;
 	};
 

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -11,25 +11,6 @@ class CHud : public CComponent
 	float m_AverageFPS;
 	int64 m_WarmupHideTick;
 
-	// server broadcast
-	typedef unsigned char u8;
-	struct CBcColor
-	{
-		u8 m_R, m_G, m_B;
-		int m_CharPos;
-	};
-
-	enum {
-		MAX_BROADCAST_COLORS = 128,
-		MAX_BROADCAST_MSG_LENGTH = 127
-	};
-
-	CBcColor m_aBroadcastColorList[MAX_BROADCAST_COLORS];
-	char m_aBroadcastMsg[MAX_BROADCAST_MSG_LENGTH+1];
-	int m_aBroadcastMsgLen;
-	int m_BroadcastColorCount;
-	float m_BroadcastReceivedTime;
-
 	void RenderCursor();
 
 	void RenderFps();
@@ -46,12 +27,11 @@ class CHud : public CComponent
 	void RenderScoreHud();
 	void RenderSpectatorHud();
 	void RenderWarmupTimer();
-	void RenderBroadcast();
+
 public:
 	CHud();
 
 	virtual void OnReset();
-	virtual void OnMessage(int MsgType, void *pRawMsg);
 	virtual void OnRender();
 };
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -367,7 +367,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 		CUIRect Button;
 		ServerInfo.HSplitBottom(20.0f, &ServerInfo, &Button);
 		static int s_MuteBroadcast = 0;
-		if(DoButton_CheckBox(&s_MuteBroadcast, Localize("Mute broadcast"),
+		if(DoButton_CheckBox(&s_MuteBroadcast, Localize("Mute broadcasts"),
 							 m_pClient->m_MuteServerBroadcast, &Button))
 		{
 			m_pClient->m_MuteServerBroadcast ^= 1;

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -363,6 +363,17 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 			ServerBrowser()->AddFavorite(&CurrentServerInfo);
 	}
 
+	{
+		CUIRect Button;
+		ServerInfo.HSplitBottom(20.0f, &ServerInfo, &Button);
+		static int s_MuteBroadcast = 0;
+		if(DoButton_CheckBox(&s_MuteBroadcast, Localize("Mute broadcast"),
+							 m_pClient->m_MuteServerBroadcast, &Button))
+		{
+			m_pClient->m_MuteServerBroadcast ^= 1;
+		}
+	}
+
 	// gameinfo
 	GameInfo.VSplitLeft(1.0f, 0, &GameInfo);
 	RenderTools()->DrawUIRect(&GameInfo, vec4(0.0, 0.0, 0.0, 0.25f), CUI::CORNER_ALL, 5.0f);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -596,7 +596,7 @@ int CMenus::ThemeScan(const char *pName, int IsDir, int DirType, void *pUser)
 
 	if(str_comp(aThemeName, "none") == 0) // "none" is reserved, disallowed for maps
 		return 0;
-	
+
 	// try to edit an existing theme
 	for(int i = 0; i < pSelf->m_lThemes.size(); i++)
 	{
@@ -628,7 +628,7 @@ int CMenus::ThemeIconScan(const char *pName, int IsDir, int DirType, void *pUser
 		return 0;
 	char aThemeName[128];
 	str_copy(aThemeName, pName, min((int)sizeof(aThemeName),l-3));
-	
+
 	// save icon for an existing theme
 	for(sorted_array<CTheme>::range r = pSelf->m_lThemes.all(); !r.empty(); r.pop_front()) // bit slow but whatever
 	{
@@ -804,7 +804,7 @@ void CMenus::RenderThemeSelection(CUIRect MainView, bool Header)
 				Graphics()->QuadsDrawTL(&QuadItem, 1);
 				Graphics()->QuadsEnd();
 			}
-			
+
 			Item.m_Rect.y += 2.0f;
 			char aName[128];
 			if(r.front().m_Name[0])
@@ -994,6 +994,13 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		if(DoButton_Menu(&s_ButtonFilterchat, aBuf, 0, &Button))
 			g_Config.m_ClFilterchat = (g_Config.m_ClFilterchat + 1) % 3;
 	}
+
+	GameRight.HSplitTop(Spacing, 0, &GameRight);
+	GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
+	static int s_EnableColoredBroadcasts = 0;
+	if(DoButton_CheckBox(&s_EnableColoredBroadcasts, Localize("Enable colored server broadcasts"),
+						 g_Config.m_ClColoredBroadcast, &Button))
+		g_Config.m_ClColoredBroadcast ^= 1;
 
 	// render client menu
 	Client.HSplitTop(ButtonHeight, &Label, &Client);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -249,7 +249,7 @@ void CGameClient::OnInit()
 	m_UI.SetGraphics(Graphics(), TextRender());
 	m_RenderTools.m_pGraphics = Graphics();
 	m_RenderTools.m_pUI = UI();
-	
+
 	int64 Start = time_get();
 
 	// set the language
@@ -369,6 +369,7 @@ void CGameClient::OnReset()
 	m_DemoSpecMode = SPEC_FREEVIEW;
 	m_DemoSpecID = -1;
 	m_Tuning = CTuningParams();
+	m_MuteServerBroadcast = false;
 }
 
 
@@ -633,7 +634,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 			if(m_LocalClientID != -1 && !pMsg->m_Silent)
 			{
 				DoEnterMessage(pMsg->m_pName, pMsg->m_ClientID, pMsg->m_Team);
-				
+
 				if(m_pDemoRecorder->IsRecording())
 				{
 					CNetMsg_De_ClientEnter Msg;
@@ -746,7 +747,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 		if(pMsg->m_Silent == 0)
 		{
 			DoTeamChangeMessage(m_aClients[pMsg->m_ClientID].m_aName, pMsg->m_ClientID, pMsg->m_Team);
-		}		
+		}
 	}
 	else if(MsgId == NETMSGTYPE_SV_READYTOENTER)
 	{
@@ -983,7 +984,7 @@ void CGameClient::OnNewSnapshot()
 					m_ServerMode = SERVERMODE_PURE;
 				}
 			}
-			
+
 			// network items
 			if(Item.m_Type == NETOBJTYPE_PLAYERINFO)
 			{
@@ -1018,7 +1019,7 @@ void CGameClient::OnNewSnapshot()
 					// clamp ammo count for non ninja weapon
 					if(m_Snap.m_aCharacters[Item.m_ID].m_Cur.m_Weapon != WEAPON_NINJA)
 						m_Snap.m_aCharacters[Item.m_ID].m_Cur.m_AmmoCount = clamp(m_Snap.m_aCharacters[Item.m_ID].m_Cur.m_AmmoCount, 0, 10);
-					
+
 					if(pOld)
 					{
 						m_Snap.m_aCharacters[Item.m_ID].m_Active = true;
@@ -1199,7 +1200,7 @@ void CGameClient::OnDemoRecSnap()
 	CNetObj_De_GameInfo *pGameInfo = static_cast<CNetObj_De_GameInfo *>(Client()->SnapNewItem(NETOBJTYPE_DE_GAMEINFO, 0, sizeof(CNetObj_De_GameInfo)));
 	if(!pGameInfo)
 		return;
-	
+
 	pGameInfo->m_GameFlags = m_GameInfo.m_GameFlags;
 	pGameInfo->m_ScoreLimit = m_GameInfo.m_ScoreLimit;
 	pGameInfo->m_TimeLimit = m_GameInfo.m_TimeLimit;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -87,7 +87,7 @@ public:
 	const char *NetobjFailedOn() { return m_NetObjHandler.FailedObjOn(); };
 	int NetobjNumFailures() { return m_NetObjHandler.NumObjFailures(); };
 	const char *NetmsgFailedOn() { return m_NetObjHandler.FailedMsgOn(); };
-	
+
 	bool m_SuppressEvents;
 
 	// TODO: move this
@@ -129,7 +129,7 @@ public:
 		const CNetObj_GameDataTeam *m_pGameDataTeam;
 		const CNetObj_GameDataFlag *m_pGameDataFlag;
 		int m_GameDataFlagSnapID;
-		
+
 		int m_NotReadyCount;
 		int m_AliveCount[NUM_TEAMS];
 
@@ -194,6 +194,7 @@ public:
 	CClientData m_aClients[MAX_CLIENTS];
 	int m_LocalClientID;
 	int m_TeamCooldownTick;
+	bool m_MuteServerBroadcast;
 
 	struct CGameInfo
 	{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -241,6 +241,13 @@ void CGameContext::SendChat(int ChatterClientID, int Mode, int To, const char *p
 	}
 }
 
+void CGameContext::SendBroadcast(const char* pText, int ClientID)
+{
+	CNetMsg_Sv_Broadcast Msg;
+	Msg.m_pMessage = pText;
+	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
+}
+
 void CGameContext::SendEmoticon(int ClientID, int Emoticon)
 {
 	CNetMsg_Sv_Emoticon Msg;
@@ -1094,6 +1101,12 @@ void CGameContext::ConSay(IConsole::IResult *pResult, void *pUserData)
 	pSelf->SendChat(-1, CHAT_ALL, -1, pResult->GetString(0));
 }
 
+void CGameContext::ConBroadcast(IConsole::IResult* pResult, void* pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	pSelf->SendBroadcast(pResult->GetString(0), -1);
+}
+
 void CGameContext::ConSetTeam(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
@@ -1381,6 +1394,7 @@ void CGameContext::OnConsoleInit()
 	Console()->Register("change_map", "?r", CFGFLAG_SERVER|CFGFLAG_STORE, ConChangeMap, this, "Change map");
 	Console()->Register("restart", "?i", CFGFLAG_SERVER|CFGFLAG_STORE, ConRestart, this, "Restart in x seconds (0 = abort)");
 	Console()->Register("say", "r", CFGFLAG_SERVER, ConSay, this, "Say in chat");
+	Console()->Register("broadcast", "r", CFGFLAG_SERVER, ConBroadcast, this, "Broadcast message");
 	Console()->Register("set_team", "ii?i", CFGFLAG_SERVER, ConSetTeam, this, "Set team of player to team");
 	Console()->Register("set_team_all", "i", CFGFLAG_SERVER, ConSetTeamAll, this, "Set team of all players to team");
 	Console()->Register("swap_teams", "", CFGFLAG_SERVER, ConSwapTeams, this, "Swap the current teams");

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -49,6 +49,7 @@ class CGameContext : public IGameServer
 	static void ConChangeMap(IConsole::IResult *pResult, void *pUserData);
 	static void ConRestart(IConsole::IResult *pResult, void *pUserData);
 	static void ConSay(IConsole::IResult *pResult, void *pUserData);
+	static void ConBroadcast(IConsole::IResult *pResult, void *pUserData);
 	static void ConSetTeam(IConsole::IResult *pResult, void *pUserData);
 	static void ConSetTeamAll(IConsole::IResult *pResult, void *pUserData);
 	static void ConSwapTeams(IConsole::IResult *pResult, void *pUserData);
@@ -132,6 +133,7 @@ public:
 
 	// network
 	void SendChat(int ChatterClientID, int Mode, int To, const char *pText);
+	void SendBroadcast(const char *pText, int ClientID);
 	void SendEmoticon(int ClientID, int Emoticon);
 	void SendWeaponPickup(int ClientID, int Weapon);
 	void SendMotd(int ClientID);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/294603/48974576-4aa8c780-f05d-11e8-982c-cbb2c9319549.png)
![image](https://user-images.githubusercontent.com/294603/48974580-572d2000-f05d-11e8-8e3f-ebe205936eb7.png)
![image](https://user-images.githubusercontent.com/294603/48974569-01587800-f05d-11e8-9e3e-f3925f21ef29.png)

Server broadcasts appear at the bottom of the screen, and fade away after 10s. They can use different text colors with aspecial prefix: **^XXX**, with X = [0-9].
Examples: ^900 is full red, ^050 is half green.

This obviously can be abused quite a bit (just like chat), so there is an option to mute broadcasts on a given server, as well as globally (cl_show_server_broadcast).

This ended up being a lot more complex to implement than I expected, mostly because of the text api, which I hope we'll work on in the future. Also I only realized at the end that we had a *broadcast.cpp*. I can move the code over if this is an issue tomorrow, but for now, I'm going to sleep.

*Also thank you for the help testing, @Dune-jr*