### PR TITLE
Revive cl_connect feature

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1898,11 +1898,12 @@ void CClient::Run()
 	m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aBuf);
 
 	// connect to the server if wanted
-	/*
-	if(config.cl_connect[0] != 0)
-		Connect(config.cl_connect);
-	config.cl_connect[0] = 0;
-	*/
+	if(g_Config.m_ClConnect[0] != 0)
+	{
+		str_copy(g_Config.m_UiServerAddress, g_Config.m_ClConnect, sizeof(g_Config.m_UiServerAddress));
+		Connect(g_Config.m_ClConnect);
+	}
+	g_Config.m_ClConnect[0] = 0;
 
 	//
 	m_FpsGraph.Init(0.0f, 120.0f);

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -6,6 +6,7 @@
 
 
 // client
+MACRO_CONFIG_STR(ClConnect, cl_connect, 64, "", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Ip to connect on launch")
 MACRO_CONFIG_INT(ClPredict, cl_predict, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Predict client movements")
 MACRO_CONFIG_INT(ClNameplates, cl_nameplates, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show name plates")
 MACRO_CONFIG_INT(ClNameplatesAlways, cl_nameplates_always, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Always show name plates disregarding of distance")


### PR DESCRIPTION
I found this commented code snipped and it looks very usefull.
It allows players to write a ``cl_connect "ipaddr"`` in the autoexec.cfg and the client will directly connect on launch.