### PR TITLE
Move 'Show user IDs' option up to keep consistency

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -993,15 +993,15 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 
 	GameRight.HSplitTop(Spacing, 0, &GameRight);
 	GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
-	static int s_Showsocial = 0;
-	if(DoButton_CheckBox(&s_Showsocial, Localize("Show social"), g_Config.m_ClShowsocial, &Button))
-		g_Config.m_ClShowsocial ^= 1;
-
-	GameRight.HSplitTop(Spacing, 0, &GameRight);
-	GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
 	static int s_ShowUserId = 0;
 	if(DoButton_CheckBox(&s_ShowUserId, Localize("Show user IDs"), g_Config.m_ClShowUserId, &Button))
 		g_Config.m_ClShowUserId ^= 1;
+
+	GameRight.HSplitTop(Spacing, 0, &GameRight);
+	GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
+	static int s_Showsocial = 0;
+	if(DoButton_CheckBox(&s_Showsocial, Localize("Show social"), g_Config.m_ClShowsocial, &Button))
+		g_Config.m_ClShowsocial ^= 1;
 
 	// show chat messages button
 	if(g_Config.m_ClShowsocial)


### PR DESCRIPTION
Right now the placement of the show user IDs breaks with the logic of the settings:

![image](https://user-images.githubusercontent.com/355114/49464027-14f0a500-f7fa-11e8-9713-aacaf69ddb6c.png)
![image](https://user-images.githubusercontent.com/355114/49464044-1de17680-f7fa-11e8-9f99-9f5a9b25a645.png)

So I fixed it by moving the "Show user IDs" option up
