### PR TITLE
Emotes can now be cancelled by releasing the mouse in the middle of the circle

### DIFF
--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -119,6 +119,8 @@ void CEmoticon::OnRender()
 
 	if (length(m_SelectorMouse) > 110.0f)
 		m_SelectedEmote = (int)(SelectedAngle / (2*pi) * NUM_EMOTICONS);
+	else
+		m_SelectedEmote = -1;
 
 	CUIRect Screen = *UI()->Screen();
 


### PR DESCRIPTION
Closes #1786

Since this is a feature, it should probably not be merged for 0.7.1?
Maybe set the 0.7.2 milestone on this PR.