### PR TITLE
Fix broken key helper in callvote popup

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -160,9 +160,9 @@ const char *CBinds::Get(int KeyID, int Modifier)
 	return "";
 }
 
-void CBinds::GetKey(const char *pBindStr, char aBuf[64], unsigned BufSize)
+void CBinds::GetKey(const char *pBindStr, char aKey[64], unsigned BufSize)
 {
-	aBuf[0] = 0;
+	aKey[0] = 0;
 	for(int KeyID = 0; KeyID < KEY_LAST; KeyID++)
 	{
 		for(int m = 0; m < MODIFIER_COUNT; m++)
@@ -172,9 +172,13 @@ void CBinds::GetKey(const char *pBindStr, char aBuf[64], unsigned BufSize)
 				continue;
 
 			if(str_comp(pBind, pBindStr) == 0)
-				str_format(aBuf, BufSize, "key %s%s not found", Input()->KeyName(KeyID), GetModifierName(m));
+			{
+				str_format(aKey, BufSize, "%s%s", GetModifierName(m), Input()->KeyName(KeyID));
+				return;
+			}
 		}
 	}
+	str_copy(aKey, "key not found", BufSize);
 }
 
 void CBinds::SetDefaults()

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -42,7 +42,7 @@ public:
 	void SetDefaults();
 	void UnbindAll();
 	const char *Get(int KeyID, int Modifier);
-	void GetKey(const char *pBindStr, char aBuf[64], unsigned BufSize);
+	void GetKey(const char *pBindStr, char aKey[64], unsigned BufSize);
 	static const char *GetModifierName(int m);
 	static int GetModifierMask(IInput *i);
 	static int GetModifierMaskOfKey(int Key);


### PR DESCRIPTION
Closes #1779
I messed that line up. It is fixed now:

![image](https://user-images.githubusercontent.com/355114/49545717-b0f3dc80-f8de-11e8-86da-327a165785b3.png)

When the key is unbound though, the "key not found" overlaps with the rest though. Not sure how to fix that.
