### PR TITLE
Fix damage indicators stacking

### DIFF
--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -56,7 +56,7 @@ void CEffects::DamageIndicator(vec2 Pos, int Amount)
 		return;
 
 	m_DamageTaken++;
-	int Angle;
+	float Angle;
 	// create healthmod indicator
 	if(Client()->LocalTime() < m_DamageTakenTick+0.5f)
 	{


### PR DESCRIPTION
Fix #1802
All that mess was caused by some wrongly typed `Angle`.