### PR TITLE
Fix packet resending

### DIFF
--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -80,7 +80,7 @@ int CNetRecvUnpacker::FetchChunk(CNetChunk *pChunk)
 		// fill in the info
 		pChunk->m_ClientID = m_ClientID;
 		pChunk->m_Address = m_Addr;
-		pChunk->m_Flags = Header.m_Flags;
+		pChunk->m_Flags = (Header.m_Flags&NET_CHUNKFLAG_VITAL) ? NETSENDFLAG_VITAL : 0;
 		pChunk->m_DataSize = Header.m_Size;
 		pChunk->m_pData = pData;
 		return 1;


### PR DESCRIPTION
The unpacker copied the flags from `CNetChunkHeader` to `CNetChunk`.  Actually they use different enum types. Since `NETSENDFLAG_CONNLESS` and `NET_PACKETFLAG_RESEND` have the same value, resent packets were recognized as connless packets.

This probably fixes #1817, #1813 and #1775.