### PR TITLE
Fixed the selection of UK flags

### DIFF
--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -155,8 +155,15 @@ const CCountryFlags::CCountryFlag *CCountryFlags::GetByCountryCode(int CountryCo
 	return GetByIndex(m_CodeIndexLUT[max(0, (CountryCode-CODE_LB)%CODE_RANGE)]);
 }
 
-const CCountryFlags::CCountryFlag *CCountryFlags::GetByIndex(int Index) const
+const CCountryFlags::CCountryFlag *CCountryFlags::GetByIndex(int Index, bool SkipBlocked) const
 {
+	if(SkipBlocked)
+	{
+		for(int i = 0; i < m_aCountryFlags.size(); i++)
+			if(!m_aCountryFlags[i].m_Blocked)
+				if(!Index--)
+					return &m_aCountryFlags[i];
+	}
 	return &m_aCountryFlags[max(0, Index%m_aCountryFlags.size())];
 }
 

--- a/src/game/client/components/countryflags.h
+++ b/src/game/client/components/countryflags.h
@@ -23,7 +23,7 @@ public:
 
 	int Num() const;
 	const CCountryFlag *GetByCountryCode(int CountryCode) const;
-	const CCountryFlag *GetByIndex(int Index) const;
+	const CCountryFlag *GetByIndex(int Index, bool SkipBlocked = false) const;
 	void Render(int CountryCode, const vec4 *pColor, float x, float y, float w, float h, bool AllowBlocked=false);
 
 private:

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2043,7 +2043,7 @@ int CMenus::Render()
 
 			const int NewSelected = UiDoListboxEnd(&s_ListBoxState, 0);
 			if(OldSelected != NewSelected)
-				ActSelection = m_pClient->m_pCountryFlags->GetByIndex(NewSelected)->m_CountryCode;
+				ActSelection = m_pClient->m_pCountryFlags->GetByIndex(NewSelected, true)->m_CountryCode;
 
 			Part.VMargin(120.0f, &Part);
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1202,9 +1202,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 
 	const int NewSelected = UiDoListboxEnd(&s_ListBoxState, 0);
 	if(OldSelected != NewSelected)
-	{
-		g_Config.m_PlayerCountry = m_pClient->m_pCountryFlags->GetByIndex(NewSelected)->m_CountryCode;
-	}
+		g_Config.m_PlayerCountry = m_pClient->m_pCountryFlags->GetByIndex(NewSelected, true)->m_CountryCode;
 }
 
 void CMenus::RenderSettingsTeeBasic(CUIRect MainView)


### PR DESCRIPTION
Fixes #1808.
That bug was introduced by the `m_Blocked` skip there:

https://github.com/teeworlds/teeworlds/blob/c25fd502a0ef0f63f6eddb2e75885f13a2125c88/src/game/client/components/menus_settings.cpp#L1170-L1175

The indexes would get out of sync, causing a bug there: https://github.com/teeworlds/teeworlds/blob/c25fd502a0ef0f63f6eddb2e75885f13a2125c88/src/game/client/components/menus_settings.cpp#L1206