### PR TITLE
Fix none theme not saving properly (default is selected at restart) - #1833

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -790,6 +790,8 @@ void CMenus::RenderThemeSelection(CUIRect MainView, bool Header)
 
 	if(m_lThemes.size() == 0) // not loaded yet
 	{
+		if(!g_Config.m_ClShowMenuMap)
+			str_copy(g_Config.m_ClMenuMap, "", sizeof(g_Config.m_ClMenuMap)); // cl_menu_map otherwise resets to default on loading
 		m_lThemes.add(CTheme("", false, false)); // no theme
 		Storage()->ListDirectory(IStorage::TYPE_ALL, "ui/themes", ThemeScan, (CMenus*)this);
 		Storage()->ListDirectory(IStorage::TYPE_ALL, "ui/themes", ThemeIconScan, (CMenus*)this);


### PR DESCRIPTION
Fixes #1833

> Alright, it seems that

https://github.com/teeworlds/teeworlds/blob/899f9f00863243ec8a0c9f63e6379cc64dfe7c76/src/game/variables.h#L89

> 
>  MACRO_CONFIG_STR(ClMenuMap, cl_menu_map, 64, "heavens", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Background map in the menu") 
> 
> resets `cl_menu_map` to default :/
> A fix would be to simply reset `cl_menu_map` to "" when `cl_show_menu_map` is 0


There could be a prettier fix, if we could somehow prevent cl_menu_map from being reset to default even though it is written `cl_menu_map ""` in the `settings.cfg`.