### PR TITLE
Fix release inputs not being counted, impacting mousewheel gameplay (#1792)

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -209,11 +209,9 @@ int CInput::Update()
 			//
 			if(Key != -1)
 			{
+				m_aInputCount[Key] = m_InputCounter;
 				if(Action&IInput::FLAG_PRESS)
-				{
 					m_aInputState[Scancode] = 1;
-					m_aInputCount[Key] = m_InputCounter;
-				}
 				AddEvent(0, Key, Action);
 			}
 


### PR DESCRIPTION
Closes https://github.com/teeworlds/teeworlds/issues/1792
Carpal tunnel users rejoice, this reverts the state of the mousewheel inputs to the 0.6 state.
Mousewheel inputs are always flagged release:
https://github.com/teeworlds/teeworlds/blob/19e918d0f15011c6231d05e5cbe491516de2deeb/src/engine/client/input.cpp#L188-L192

Back in 0.6, all inputs were taken in account in `m_aInputCount` thanks to `			m_aInputCount[m_InputCurrent][Key].m_Presses++;`:
https://github.com/teeworlds/teeworlds/blob/7d8234e31c65c645731f0fb7b8e079251050b77a/src/engine/client/input.cpp#L197-L203

But in 0.7, it is no longer the case, because of this `if`:
https://github.com/teeworlds/teeworlds/blob/19e918d0f15011c6231d05e5cbe491516de2deeb/src/engine/client/input.cpp#L210-L216


This reverts back to 0.6. I could not find any other side-effect, but my understanding of the input stack is a bit limited, so hopefully this doesn't break anything. Testing appreciated.