### PR TITLE
Add -msse2 flag to bam.lua for linux x86 compilation

### DIFF
--- a/bam.lua
+++ b/bam.lua
@@ -169,6 +169,7 @@ end
 
 function GenerateLinuxSettings(settings, conf, arch, compiler)
 	if arch == "x86" then
+		settings.cc.flags:Add("-msse2") -- for the _mm_pause call
 		settings.cc.flags:Add("-m32")
 		settings.link.flags:Add("-m32")
 	elseif arch == "x86_64" then


### PR DESCRIPTION
This is the `bam.lua` change that was applied to build the 0.7.1 x86 linux release.

Closes #1844 

---
**PS**: I also had to hardcode
```
settings.cc.flags:Add("-I/usr/include/freetype2")
settings.link.flags:Add("-lfreetype")
```
in other/freetype/freetype.lua for some reason