### PR TITLE
Adjust volume label size

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1921,7 +1921,7 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 		}
 
 		Right.HSplitTop(ButtonHeight, &Button, &Right);
-		DoScrollbarOption(&g_Config.m_SndVolume, &g_Config.m_SndVolume, &Button, Localize("Volume"), 110.0f, 0, 100);
+		DoScrollbarOption(&g_Config.m_SndVolume, &g_Config.m_SndVolume, &Button, Localize("Volume"), 130.0f, 0, 100);
 	}
 	else
 	{


### PR DESCRIPTION
Refers to https://github.com/teeworlds/teeworlds-translation/issues/61
Fits with all languages (but Gaelic Scottish, which is really long):

![image](https://user-images.githubusercontent.com/355114/49939325-cb304a80-fedc-11e8-809d-0bd97dfbadd4.png)
![image](https://user-images.githubusercontent.com/355114/49939501-54e01800-fedd-11e8-8e3d-b3cc69f2d1f6.png)
![image](https://user-images.githubusercontent.com/355114/49939588-8f49b500-fedd-11e8-8049-9e2e1cad57b5.png)
![image](https://user-images.githubusercontent.com/355114/49939511-5dd0e980-fedd-11e8-823d-f7656f7572a2.png)
![image](https://user-images.githubusercontent.com/355114/49939546-73deaa00-fedd-11e8-9062-c867bb5d2a54.png)
