### PR TITLE
Adjust chat messages to not display UID when option is turned off

### DIFF
--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -179,11 +179,12 @@ void CVoting::OnMessage(int MsgType, void *pRawMsg)
 			m_Closetime = time_get() + time_freq() * pMsg->m_Timeout;
 			if(pMsg->m_ClientID != -1)
 			{
+				char aLabel[64];
+				CGameClient::GetPlayerLabel(aLabel, sizeof(aLabel), pMsg->m_ClientID, m_pClient->m_aClients[pMsg->m_ClientID].m_aName);
 				switch(pMsg->m_Type)
 				{
 				case VOTE_START_OP:
-					str_format(aBuf, sizeof(aBuf), Localize("'%2d: %s' called vote to change server option '%s' (%s)"), pMsg->m_ClientID,
-								g_Config.m_ClShowsocial ? m_pClient->m_aClients[pMsg->m_ClientID].m_aName : "", pMsg->m_pDescription, pMsg->m_pReason);
+					str_format(aBuf, sizeof(aBuf), Localize("'%s' called vote to change server option '%s' (%s)"), aLabel, pMsg->m_pDescription, pMsg->m_pReason);
 					str_copy(m_aDescription, pMsg->m_pDescription, sizeof(m_aDescription));
 					m_pClient->m_pChat->AddLine(-1, 0, aBuf);
 					break;
@@ -192,8 +193,7 @@ void CVoting::OnMessage(int MsgType, void *pRawMsg)
 						char aName[4];
 						if(!g_Config.m_ClShowsocial)
 							str_copy(aName, pMsg->m_pDescription, sizeof(aName));
-						str_format(aBuf, sizeof(aBuf), Localize("'%2d: %s' called for vote to kick '%s' (%s)"), pMsg->m_ClientID,
-							g_Config.m_ClShowsocial ? m_pClient->m_aClients[pMsg->m_ClientID].m_aName : "", g_Config.m_ClShowsocial ? pMsg->m_pDescription : aName, pMsg->m_pReason);
+						str_format(aBuf, sizeof(aBuf), Localize("'%s' called for vote to kick '%s' (%s)"), aLabel, g_Config.m_ClShowsocial ? pMsg->m_pDescription : aName, pMsg->m_pReason);
 						str_format(m_aDescription, sizeof(m_aDescription), "Kick '%s'", g_Config.m_ClShowsocial ? pMsg->m_pDescription : aName);
 						m_pClient->m_pChat->AddLine(-1, 0, aBuf);
 						break;
@@ -203,8 +203,7 @@ void CVoting::OnMessage(int MsgType, void *pRawMsg)
 						char aName[4];
 						if(!g_Config.m_ClShowsocial)
 							str_copy(aName, pMsg->m_pDescription, sizeof(aName));
-						str_format(aBuf, sizeof(aBuf), Localize("'%2d: %s' called for vote to move '%s' to spectators (%s)"), pMsg->m_ClientID,
-							g_Config.m_ClShowsocial ? m_pClient->m_aClients[pMsg->m_ClientID].m_aName : "", g_Config.m_ClShowsocial ? pMsg->m_pDescription : aName, pMsg->m_pReason);
+						str_format(aBuf, sizeof(aBuf), Localize("'%s' called for vote to move '%s' to spectators (%s)"), aLabel, g_Config.m_ClShowsocial ? pMsg->m_pDescription : aName, pMsg->m_pReason);
 						str_format(m_aDescription, sizeof(m_aDescription), "Move '%s' to spectators", g_Config.m_ClShowsocial ? pMsg->m_pDescription : aName);
 						m_pClient->m_pChat->AddLine(-1, 0, aBuf);
 					}

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -250,6 +250,7 @@ public:
 	virtual const char *NetVersion() const;
 	virtual int ClientVersion() const;
 	const char *GetTeamName(int Team, bool Teamplay) const;
+	static void GetPlayerLabel(char* aBuf, int BufferSize, int ClientID, const char* ClientName);
 
 	//
 	void DoEnterMessage(const char *pName, int ClientID, int Team);


### PR DESCRIPTION
Close #1776

`cl_show_user_id 1`
![image](https://user-images.githubusercontent.com/355114/50090400-b5869200-0208-11e9-840d-65ecf2f86da9.png)
`cl_show_user_id 0`
![image](https://user-images.githubusercontent.com/355114/50090413-be776380-0208-11e9-87a2-98be5b1398d2.png)
`cl_showsocial 0`
![image](https://user-images.githubusercontent.com/355114/50090444-d4852400-0208-11e9-8021-cc3e3339c5d5.png)

CTF messages work too:
![image](https://user-images.githubusercontent.com/355114/50090471-e961b780-0208-11e9-92ed-efccc08673d4.png)
