### PR TITLE
Fixed server browser entry text color & close region

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -539,7 +539,7 @@ private:
 	void RenderServerbrowserInfoTab(CUIRect View);
 	void RenderServerbrowserFriendList(CUIRect View);
 	void RenderDetailInfo(CUIRect View, const CServerInfo *pInfo);
-	void RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int RowCount);
+	void RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int RowCount, vec4 TextColor = vec4(1,1,1,1));
 	void RenderServerbrowserServerDetail(CUIRect View, const CServerInfo *pInfo);
 	//void RenderServerbrowserFriends(CUIRect View);
 	void RenderServerbrowserBottomBox(CUIRect View);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -606,7 +606,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 		NewClipArea.x = View.x;
 		NewClipArea.w = View.w;
 		UI()->ClipEnable(&NewClipArea);
-		RenderDetailScoreboard(View, pEntry, 4);
+		RenderDetailScoreboard(View, pEntry, 4, vec4(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha));
 		UI()->ClipEnable(&OldClipArea);
 	}
 
@@ -1898,7 +1898,7 @@ void CMenus::RenderDetailInfo(CUIRect View, const CServerInfo *pInfo)
 	}
 }
 
-void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int RowCount)
+void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int RowCount, vec4 TextColor)
 {
 	// slected filter
 	CBrowserFilter *pFilter = 0;
@@ -1915,6 +1915,8 @@ void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int 
 		return;
 	CServerFilterInfo FilterInfo;
 	pFilter->GetFilter(&FilterInfo);
+
+	TextRender()->TextColor(TextColor.r, TextColor.g, TextColor.b, TextColor.a);
 
 	// server scoreboard
 	CTextCursor Cursor;
@@ -2028,7 +2030,7 @@ void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int 
 					TextRender()->TextEx(&Cursor, pName, (int)(s - pName));
 					TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1.0f);
 					TextRender()->TextEx(&Cursor, s, str_length(g_Config.m_BrFilterString));
-					TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+					TextRender()->TextColor(TextColor.r, TextColor.g, TextColor.b, TextColor.a);
 					TextRender()->TextEx(&Cursor, s + str_length(g_Config.m_BrFilterString), -1);
 				}
 				else
@@ -2050,7 +2052,7 @@ void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int 
 					TextRender()->TextEx(&Cursor, pClan, (int)(s - pClan));
 					TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1.0f);
 					TextRender()->TextEx(&Cursor, s, str_length(g_Config.m_BrFilterString));
-					TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+					TextRender()->TextColor(TextColor.r, TextColor.g, TextColor.b, TextColor.a);
 					TextRender()->TextEx(&Cursor, s + str_length(g_Config.m_BrFilterString), -1);
 				}
 				else

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -594,6 +594,10 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 	{
 		CUIRect Info;
 		View.HSplitTop(ms_aBrowserCols[0].m_Rect.h, 0, &View);
+
+		if(ReturnValue && UI()->MouseInside(&View))
+			ReturnValue++;
+
 		View.VSplitLeft(160.0f, &Info, &View);
 		RenderDetailInfo(Info, pEntry);
 
@@ -604,9 +608,6 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 		UI()->ClipEnable(&NewClipArea);
 		RenderDetailScoreboard(View, pEntry, 4);
 		UI()->ClipEnable(&OldClipArea);
-
-		if(ReturnValue && UI()->MouseInside(&View))
-			ReturnValue++;
 	}
 
 	TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.3f);


### PR DESCRIPTION
Fixed clicking on "server details" rect closing the expanded entry line.
Fixes #1859.

![image](https://user-images.githubusercontent.com/294603/50100203-284f3780-0220-11e9-9b68-4a416ef19413.png)

![image](https://user-images.githubusercontent.com/294603/50100216-31d89f80-0220-11e9-8743-86e0c711fa42.png)
