### PR TITLE
Broadcast: parse new line character

### DIFF
--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -315,6 +315,16 @@ void CBroadcast::OnMessage(int MsgType, void* pRawMsg)
 				}
 			}
 
+			if(*c == CharUtf8 && *c == '\n')
+			{
+				CBcLineInfo Line = { m_aSrvBroadcastMsg+LastUserLineStartPoint,
+									 m_aSrvBroadcastMsgLen-LastUserLineStartPoint, 0 };
+				if(Line.m_StrLen > 0)
+					UserLines[UserLineCount++] = Line;
+				LastUserLineStartPoint = m_aSrvBroadcastMsgLen;
+				continue;
+			}
+
 			if(m_aSrvBroadcastMsgLen+Utf8Len < MAX_BROADCAST_MSG_LENGTH)
 				m_aSrvBroadcastMsg[m_aSrvBroadcastMsgLen++] = *c;
 		}

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -315,7 +315,7 @@ void CBroadcast::OnMessage(int MsgType, void* pRawMsg)
 				}
 			}
 
-			if(*c == CharUtf8 && *c == '\n')
+			if(*c == '\n')
 			{
 				CBcLineInfo Line = { m_aSrvBroadcastMsg+LastUserLineStartPoint,
 									 m_aSrvBroadcastMsgLen-LastUserLineStartPoint, 0 };


### PR DESCRIPTION
This had unintended behaviour, it was only parsed by the text function at the end and thus would cause the text to be mis-positioned. The new line character can only be sent via code modification so this was only an issue for mods.

![image](https://user-images.githubusercontent.com/294603/50344480-75d2e980-052b-11e9-8cac-61e9c5cb361a.png)

*"Sometext\nOOP new ^900LINE\\\nAnother ^090one"*