### PR TITLE
Demo list marker indicator

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -967,13 +967,18 @@ CMenus::CListboxItem CMenus::UiDoListboxNextItem(CListBoxState* pState, const vo
 	}
 
 	CListboxItem Item = UiDoListboxNextRow(pState);
+	static bool s_ItemClicked = false;
 
 	if(Item.m_Visible && UI()->DoButtonLogic(pId, "", pState->m_ListBoxSelectedIndex == pState->m_ListBoxItemIndex, &Item.m_HitRect))
 	{
+		s_ItemClicked = true;
 		pState->m_ListBoxNewSelected = ThisItemIndex;
 		if(pActive)
 			*pActive = true;
 	}
+	else
+		s_ItemClicked = false;
+
 	const bool ProcessInput = !pActive || *pActive;
 
 	// process input, regard selected index
@@ -983,7 +988,7 @@ CMenus::CListboxItem CMenus::UiDoListboxNextItem(CListBoxState* pState, const vo
 		{
 			pState->m_ListBoxDoneEvents = 1;
 
-			if(m_EnterPressed || (UI()->LastActiveItem() == pId && Input()->MouseDoubleClick()))
+			if(m_EnterPressed || (s_ItemClicked && Input()->MouseDoubleClick()))
 			{
 				pState->m_ListBoxItemActivated = true;
 				UI()->SetActiveItem(0);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -107,6 +107,18 @@ int CMenus::DoIcon(int ImageId, int SpriteId, const CUIRect *pRect)
 	return 0;
 }
 
+void CMenus::DoIconColor(int ImageId, int SpriteId, const CUIRect* pRect, const vec4& Color)
+{
+	Graphics()->TextureSet(g_pData->m_aImages[ImageId].m_Id);
+
+	Graphics()->QuadsBegin();
+	RenderTools()->SelectSprite(SpriteId);
+	Graphics()->SetColor(Color.r*Color.a, Color.g*Color.a, Color.b*Color.a, Color.a);
+	IGraphics::CQuadItem QuadItem(pRect->x, pRect->y, pRect->w, pRect->h);
+	Graphics()->QuadsDrawTL(&QuadItem, 1);
+	Graphics()->QuadsEnd();
+}
+
 int CMenus::DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, bool Active)
 {
 	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_GUIBUTTONS].m_Id);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -971,7 +971,7 @@ CMenus::CListboxItem CMenus::UiDoListboxNextItem(CListBoxState* pState, const vo
 		{
 			pState->m_ListBoxDoneEvents = 1;
 
-			if(m_EnterPressed || (UI()->CheckActiveItem(pId) && Input()->MouseDoubleClick()))
+			if(m_EnterPressed || (UI()->LastActiveItem() == pId && Input()->MouseDoubleClick()))
 			{
 				pState->m_ListBoxItemActivated = true;
 				UI()->SetActiveItem(0);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -71,6 +71,7 @@ private:
 	*/
 
 	int DoIcon(int ImageId, int SpriteId, const CUIRect *pRect);
+	void DoIconColor(int ImageId, int SpriteId, const CUIRect *pRect, const vec4& Color);
 	int DoButton_GridHeader(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
 	int DoButton_GridHeaderIcon(CButtonContainer *pBC, int ImageID, int SpriteID, const CUIRect *pRect, int Corners);
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -310,6 +310,15 @@ void CMenus::DemolistOnUpdate(bool Reset)
 	m_DemolistSelectedIsDir = m_DemolistSelectedIndex < 0 ? false : m_lDemos[m_DemolistSelectedIndex].m_IsDir;
 }
 
+inline int DemoGetMarkerCount(CDemoHeader Demo)
+{
+	int DemoMarkerCount = ((Demo.m_aNumTimelineMarkers[0]<<24)&0xFF000000) |
+			((Demo.m_aNumTimelineMarkers[1]<<16)&0xFF0000) |
+			((Demo.m_aNumTimelineMarkers[2]<<8)&0xFF00) |
+			(Demo.m_aNumTimelineMarkers[3]&0xFF);
+	return DemoMarkerCount;
+}
+
 void CMenus::RenderDemoList(CUIRect MainView)
 {
 	CUIRect BottomView;
@@ -364,13 +373,20 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	for(sorted_array<CDemoItem>::range r = m_lDemos.all(); !r.empty(); r.pop_front())
 	{
 		CListboxItem Item = UiDoListboxNextItem(&s_ListBoxState, (void*)(&r.front()));
+		// marker count
+		const CDemoItem& DemoItem = r.front();
+		int DemoMarkerCount = 0;
+		if(DemoItem.m_Valid && DemoItem.m_InfosLoaded)
+			DemoMarkerCount = DemoGetMarkerCount(DemoItem.m_Info);
+
 		if(Item.m_Visible)
 		{
 			Item.m_Rect.VSplitLeft(Item.m_Rect.h, &FileIcon, &Item.m_Rect);
 			Item.m_Rect.VSplitLeft(5.0f, 0, &Item.m_Rect);
 			FileIcon.Margin(3.0f, &FileIcon);
 			FileIcon.x += 3.0f;
-			DoIcon(IMAGE_FILEICONS, r.front().m_IsDir?SPRITE_FILE_FOLDER:SPRITE_FILE_DEMO1, &FileIcon);
+			const vec4 IconColor = DemoMarkerCount > 0 ? vec4(0.5, 1, 0.5, 1) : vec4(1,1,1,1);
+			DoIconColor(IMAGE_FILEICONS, r.front().m_IsDir?SPRITE_FILE_FOLDER:SPRITE_FILE_DEMO1, &FileIcon, IconColor);
 			if((&r.front() - m_lDemos.base_ptr()) == m_DemolistSelectedIndex) // selected
 			{
 				TextRender()->TextColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -433,23 +449,32 @@ void CMenus::RenderDemoList(CUIRect MainView)
 
 		MainView.HSplitTop(Spacing, 0, &MainView);
 		MainView.HSplitTop(ButtonHeight, &Button, &MainView);
+		const int MarkerCount = DemoGetMarkerCount(m_lDemos[m_DemolistSelectedIndex].m_Info);
+		str_format(aBuf, sizeof(aBuf), "%d", MarkerCount);
+		if(MarkerCount > 0)
+			TextRender()->TextColor(0.5, 1, 0.5, 1);
+		DoInfoBox(&Button, Localize("Markers"), aBuf);
+		TextRender()->TextColor(1, 1, 1, 1);
+
+		MainView.HSplitTop(Spacing, 0, &MainView);
+		MainView.HSplitTop(ButtonHeight, &Button, &MainView);
 		DoInfoBox(&Button, Localize("Map"), m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapName);
 
 		MainView.HSplitTop(Spacing, 0, &MainView);
 		MainView.HSplitTop(ButtonHeight, &Button, &MainView);
 		Button.VSplitLeft(ButtonHeight, 0, &Button);
+
+		CUIRect ButtonRight;
+		Button.VSplitMid(&Button, &ButtonRight);
 		float Size = float((m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapSize[0]<<24) | (m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapSize[1]<<16) |
-					(m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapSize[2]<<8) | (m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapSize[3]))/1024.0f;
+							(m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapSize[2]<<8) | (m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapSize[3]))/1024.0f;
 		str_format(aBuf, sizeof(aBuf), Localize("%.3f KiB"), Size);
 		DoInfoBox(&Button, Localize("Size"), aBuf);
 
-		MainView.HSplitTop(Spacing, 0, &MainView);
-		MainView.HSplitTop(ButtonHeight, &Button, &MainView);
-		Button.VSplitLeft(ButtonHeight, 0, &Button);
 		unsigned Crc = (m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapCrc[0]<<24) | (m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapCrc[1]<<16) |
 					(m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapCrc[2]<<8) | (m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapCrc[3]);
 		str_format(aBuf, sizeof(aBuf), "%08x", Crc);
-		DoInfoBox(&Button, Localize("Crc"), aBuf);
+		DoInfoBox(&ButtonRight, Localize("Crc"), aBuf);
 	}
 
 	// demo buttons

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -385,7 +385,15 @@ void CMenus::RenderDemoList(CUIRect MainView)
 			Item.m_Rect.VSplitLeft(5.0f, 0, &Item.m_Rect);
 			FileIcon.Margin(3.0f, &FileIcon);
 			FileIcon.x += 3.0f;
-			const vec4 IconColor = DemoMarkerCount > 0 ? vec4(0.5, 1, 0.5, 1) : vec4(1,1,1,1);
+
+			vec4 IconColor = vec4(1, 1, 1, 1);
+			if(!DemoItem.m_IsDir)
+			{
+				IconColor = vec4(0.6, 0.6, 0.6, 1); // not loaded
+				if(DemoItem.m_Valid && DemoItem.m_InfosLoaded)
+					IconColor = DemoMarkerCount > 0 ? vec4(0.5, 1, 0.5, 1) : vec4(1,1,1,1);
+			}
+
 			DoIconColor(IMAGE_FILEICONS, r.front().m_IsDir?SPRITE_FILE_FOLDER:SPRITE_FILE_DEMO1, &FileIcon, IconColor);
 			if((&r.front() - m_lDemos.base_ptr()) == m_DemolistSelectedIndex) // selected
 			{

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -358,10 +358,9 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	CUIRect ListBox, Button, Label, FileIcon;
 	MainView.HSplitTop(230.0f, &ListBox, &MainView);
 
-	static int s_DemoListId = 0;
 	static CListBoxState s_ListBoxState;
 	UiDoListboxHeader(&s_ListBoxState, &ListBox, Localize("Recorded"), 20.0f, 2.0f);
-	UiDoListboxStart(&s_ListBoxState, &s_DemoListId, 20.0f, 0, m_lDemos.size(), 1, m_DemolistSelectedIndex);
+	UiDoListboxStart(&s_ListBoxState, &s_ListBoxState, 20.0f, 0, m_lDemos.size(), 1, m_DemolistSelectedIndex);
 	for(sorted_array<CDemoItem>::range r = m_lDemos.all(); !r.empty(); r.pop_front())
 	{
 		CListboxItem Item = UiDoListboxNextItem(&s_ListBoxState, (void*)(&r.front()));
@@ -372,7 +371,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 			FileIcon.Margin(3.0f, &FileIcon);
 			FileIcon.x += 3.0f;
 			DoIcon(IMAGE_FILEICONS, r.front().m_IsDir?SPRITE_FILE_FOLDER:SPRITE_FILE_DEMO1, &FileIcon);
-			if(!str_comp(m_lDemos[m_DemolistSelectedIndex].m_aName, r.front().m_aName))
+			if((&r.front() - m_lDemos.base_ptr()) == m_DemolistSelectedIndex) // selected
 			{
 				TextRender()->TextColor(0.0f, 0.0f, 0.0f, 1.0f);
 				TextRender()->TextOutlineColor(1.0f, 1.0f, 1.0f, 0.25f);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/294603/50357189-5cdf2e00-0555-11e9-9ab6-d4edb3d1d570.png)


When a demo info is loaded and has markers, the icon becomes green. Markers are also displayed in the info section. It doesn't look amazing but it's functional. We can perhaps do a better job designing this part of the UI later.

Edit: "not loaded" status is now a grey icon.

I also fixed a double click issue (a triple click was needed and even that sometimes didn't work).