### PR TITLE
sv_player_slots < num_player → player cannot spectate

### DIFF
--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -35,7 +35,10 @@ void CMenus::GetSwitchTeamInfo(CSwitchTeamInfo *pInfo)
 		str_format(pInfo->m_aNotification, sizeof(pInfo->m_aNotification), Localize("Only %d active players are allowed"), m_pClient->m_ServerSettings.m_PlayerSlots);
 	}
 	else if(m_pClient->m_ServerSettings.m_TeamLock)
+	{
 		str_copy(pInfo->m_aNotification, Localize("Teams are locked"), sizeof(pInfo->m_aNotification));
+		pInfo->m_AllowSpec = false;
+	}
 	else if(m_pClient->m_TeamCooldownTick + 1 >= Client()->GameTick())
 	{
 		pInfo->m_TimeLeft = (m_pClient->m_TeamCooldownTick - Client()->GameTick()) / Client()->GameTickSpeed() + 1;
@@ -86,7 +89,7 @@ void CMenus::RenderGame(CUIRect MainView)
 
 		// specator button
 		int Team = m_pClient->m_aClients[m_pClient->m_LocalClientID].m_Team;
-		if(Info.m_aNotification[0] && Team != TEAM_SPECTATORS)
+		if(!Info.m_AllowSpec && Team != TEAM_SPECTATORS)
 		{
 			if(Info.m_TimeLeft)
 				str_format(aBuf, sizeof(aBuf), "(%d)", Info.m_TimeLeft);
@@ -99,7 +102,7 @@ void CMenus::RenderGame(CUIRect MainView)
 		ButtonRow.VSplitLeft(ButtonWidth, &Button, &ButtonRow);
 		ButtonRow.VSplitLeft(Spacing, 0, &ButtonRow);
 		static CButtonContainer s_SpectateButton;
-		if(DoButton_Menu(&s_SpectateButton, aBuf, Team == TEAM_SPECTATORS, &Button) && Team != TEAM_SPECTATORS && Info.m_AllowSpec && !(Info.m_aNotification[0]))
+		if(DoButton_Menu(&s_SpectateButton, aBuf, Team == TEAM_SPECTATORS, &Button) && Team != TEAM_SPECTATORS && Info.m_AllowSpec)
 		{
 			m_pClient->SendSwitchTeam(TEAM_SPECTATORS);
 			SetActive(false);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1501,7 +1501,7 @@ void CGameClient::ConTeam(IConsole::IResult *pResult, void *pUserData)
 	CMenus::CSwitchTeamInfo Info;
 	pClient->m_pMenus->GetSwitchTeamInfo(&Info);
 	int Team = pResult->GetInteger(0);
-	if(pClient->m_aClients[pClient->m_LocalClientID].m_Team == Team || (Team == TEAM_SPECTATORS && !(Info.m_AllowSpec)) || Info.m_aNotification[0])
+	if(pClient->m_aClients[pClient->m_LocalClientID].m_Team == Team || (Team == TEAM_SPECTATORS && !(Info.m_AllowSpec)) || (Team != TEAM_SPECTATORS && Info.m_aNotification[0]))
 	{
 		if(Info.m_aNotification[0])
 			pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "gameclient", Info.m_aNotification);


### PR DESCRIPTION
while the previous issue was wrong (basically, 0.6 work the same way), there is another, when lowering the number of player slots, exceeding player cannot spectate themselves.

There is a use case (at least) I don't consider here : 
 - sv_player_slots 16 (with 16 players)
 - lock the teams
 - set sv_player_slots 8
 - with the PR, player can join spectator while teams are locked