### PR TITLE
Adjust mousesens scrollbar width for lengthy strings

### DIFF
--- a/src/game/client/components/menus_callback.cpp
+++ b/src/game/client/components/menus_callback.cpp
@@ -127,7 +127,7 @@ float CMenus::RenderSettingsControlsMovement(CUIRect View, void *pUser)
 	CUIRect Button;
 	View.HSplitTop(Spaceing, 0, &View);
 	View.HSplitTop(ButtonHeight, &Button, &View);
-	pSelf->DoScrollbarOption(&g_Config.m_InpMousesens, &g_Config.m_InpMousesens, &Button, Localize("Mouse sens."), 150.0f, 5, 500);
+	pSelf->DoScrollbarOption(&g_Config.m_InpMousesens, &g_Config.m_InpMousesens, &Button, Localize("Mouse sens."), 200.0f, 5, 500);
 
 	pSelf->UiDoGetButtons(0, 5, View, ButtonHeight, Spaceing);
 


### PR DESCRIPTION
Closes #1951 
![screenshot_2019-01-06_14-04-33](https://user-images.githubusercontent.com/355114/50736307-5c34d180-11bc-11e9-90a0-277af4d8ff35.png)
![screenshot_2019-01-06_14-04-40](https://user-images.githubusercontent.com/355114/50736308-5c34d180-11bc-11e9-90bb-908d25707a51.png)

There should be a way to put the scrollbar after the text, indeed. Should an issue be opened?