### PR TITLE
Ported aarch64.patch from flathub

### DIFF
--- a/bam.lua
+++ b/bam.lua
@@ -177,6 +177,8 @@ function GenerateLinuxSettings(settings, conf, arch, compiler)
 		settings.link.flags:Add("-m64")
 	elseif arch == "armv7l" then
 		-- arm 32 bit
+	elseif arch == "aarch64" then
+		-- arm 64 bit
 	else
 		print("Unknown Architecture '" .. arch .. "'. Supported: x86, x86_64")
 		os.exit(1)

--- a/src/base/detect.h
+++ b/src/base/detect.h
@@ -142,12 +142,19 @@
 
 #if defined(__arm__)
 	#define CONF_ARCH_ARM 1
-	#define CONF_ARCH_STRING "arm"
+	#define CONF_ARCH_STRING "armx"
 	#if !defined(CONF_ARCH_ENDIAN_LITTLE) && !defined(CONF_ARCH_ENDIAN_BIG)
 		#define CONF_ARCH_ENDIAN_LITTLE 1
 	#endif
 #endif
 
+#if defined(__aarch64__)
+	#define CONF_ARCH_AARCH64 1
+	#define CONF_ARCH_STRING "aarch64"
+	#if !defined(CONF_ARCH_ENDIAN_LITTLE) && !defined(CONF_ARCH_ENDIAN_BIG)
+		#define CONF_ARCH_ENDIAN_LITTLE 1
+	#endif
+#endif
 
 #ifndef CONF_FAMILY_STRING
 #define CONF_FAMILY_STRING "unknown"


### PR DESCRIPTION
Flathub uses a patch for 64 bit ARM: https://github.com/flathub/com.teeworlds.Teeworlds/blob/master/aarch64.patch#L17
It reportedly builds, but the build hasn't been tested.
Should it be included in Teeworlds?