### PR TITLE
Add check before resetting the local rcon map list

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -936,7 +936,8 @@ void CConsole::DeregisterTempMap(const char *pName)
 
 void CConsole::DeregisterTempMapAll()
 {
-	m_pTempMapListHeap->Reset();
+	if(m_pTempMapListHeap)
+		m_pTempMapListHeap->Reset();
 	m_pFirstMapEntry = 0;
 	m_pLastMapEntry = 0;
 	m_NumMapListEntries = 0;


### PR DESCRIPTION
Fixes a crash if the server does not have the MapListEntries logic