### PR TITLE
Fix missing GetClientIdRectSize in textwidth computation for score hud

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -292,7 +292,7 @@ void CHud::RenderScoreHud()
 					int ID = aPlayerInfo[t].m_ClientID;
 					char aName[64];
 					str_format(aName, sizeof(aName), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[ID].m_aName : "");
-					float w = TextRender()->TextWidth(0, 8.0f, aName, -1);
+					float w = TextRender()->TextWidth(0, 8.0f, aName, -1) + RenderTools()->GetClientIdRectSize(8.0f);
 
 					CTextCursor Cursor;
 					float x = min(Whole-w-1.0f, Whole-ScoreWidthMax-ImageSize-2*Split-PosSize);


### PR DESCRIPTION
Closes #2006 
![image](https://user-images.githubusercontent.com/355114/52061239-2b9f4800-256e-11e9-8e8a-c2fce0e49a97.png)
![image](https://user-images.githubusercontent.com/355114/52061248-2e9a3880-256e-11e9-94e9-33d33b1d06c7.png)
![image](https://user-images.githubusercontent.com/355114/52061254-31952900-256e-11e9-9d63-c0facec97c08.png)
