### PR TITLE
Scroll region api

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2743,26 +2743,23 @@ void CMenus::BeginScrollRegion(CScrollRegion* pSr, CUIRect* pClipRect, vec2* pOu
 	pSr->m_OldClipRect = *UI()->ClipArea();
 
 	// only show scrollbar if content overflows
-	if(pSr->m_ContentH > pClipRect->h ||
-		(pSr->m_Params.m_Flags&CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH))
+	const bool ShowScrollbar = pSr->m_ContentH > pClipRect->h ||
+		(pSr->m_Params.m_Flags&CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH);
+
+	CUIRect ScrollBarBg;
+	CUIRect* pModifyRect = ShowScrollbar ? pClipRect : 0;
+	pClipRect->VSplitRight(pSr->m_Params.m_ScrollbarWidth, pModifyRect, &ScrollBarBg);
+	ScrollBarBg.Margin(pSr->m_Params.m_ScrollbarMargin, &pSr->m_RailRect);
+
+	if(ShowScrollbar)
 	{
-		CUIRect ScrollBarBg;
-		pClipRect->VSplitRight(pSr->m_Params.m_ScrollbarWidth, pClipRect, &ScrollBarBg);
 		if(pSr->m_Params.m_ScrollbarBgColor.a > 0)
 			RenderTools()->DrawRoundRect(&ScrollBarBg, pSr->m_Params.m_ScrollbarBgColor, 4.0f);
-
-		ScrollBarBg.Margin(pSr->m_Params.m_ScrollbarMargin, &ScrollBarBg);
 		if(pSr->m_Params.m_RailBgColor.a > 0)
-			RenderTools()->DrawRoundRect(&ScrollBarBg, pSr->m_Params.m_RailBgColor, ScrollBarBg.w/2.0f);
-
-		pSr->m_RailRect = ScrollBarBg;
+			RenderTools()->DrawRoundRect(&pSr->m_RailRect, pSr->m_Params.m_RailBgColor, pSr->m_RailRect.w/2.0f);
 	}
 	else
-	{
-		pSr->m_RailRect = *pClipRect;
-		pSr->m_RailRect.w = 0;
 		pSr->m_ContentScrollOff.y = 0;
-	}
 
 	if(pSr->m_Params.m_ClipBgColor.a > 0)
 		RenderTools()->DrawRoundRect(pClipRect, pSr->m_Params.m_ClipBgColor, 4.0f);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2761,6 +2761,7 @@ void CMenus::BeginScrollRegion(CScrollRegion* pSr, CUIRect* pClipRect, vec2* pOu
 	{
 		pSr->m_RailRect = *pClipRect;
 		pSr->m_RailRect.w = 0;
+		pSr->m_ContentScrollOff.y = 0;
 	}
 
 	if(pSr->m_Params.m_ClipBgColor.a > 0)

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2732,3 +2732,170 @@ void CMenus::SetMenuPage(int NewPage) {
 			m_pClient->m_pCamera->ChangePosition(CameraPos);
 	}
 }
+
+
+void CMenus::BeginScrollRegion(CScrollRegion* pSr, CUIRect* pClipRect, vec2* pOutOffset, const CScrollRegionParams* pParams)
+{
+	if(pParams)
+		pSr->m_Params = *pParams;
+
+	pSr->m_WasClipped = UI()->IsClipped();
+	pSr->m_OldClipRect = *UI()->ClipArea();
+
+	// only show scrollbar if content overflows
+	if(pSr->m_ContentH > pClipRect->h ||
+		(pSr->m_Params.m_Flags&CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH))
+	{
+		CUIRect ScrollBarBg;
+		pClipRect->VSplitRight(pSr->m_Params.m_ScrollbarWidth, pClipRect, &ScrollBarBg);
+		if(pSr->m_Params.m_ScrollbarBgColor.a > 0)
+			RenderTools()->DrawRoundRect(&ScrollBarBg, pSr->m_Params.m_ScrollbarBgColor, 4.0f);
+
+		ScrollBarBg.Margin(pSr->m_Params.m_ScrollbarMargin, &ScrollBarBg);
+		if(pSr->m_Params.m_RailBgColor.a > 0)
+			RenderTools()->DrawRoundRect(&ScrollBarBg, pSr->m_Params.m_RailBgColor, ScrollBarBg.w/2.0f);
+
+		pSr->m_RailRect = ScrollBarBg;
+	}
+	else
+	{
+		pSr->m_RailRect = *pClipRect;
+		pSr->m_RailRect.w = 0;
+	}
+
+	if(pSr->m_Params.m_ClipBgColor.a > 0)
+		RenderTools()->DrawRoundRect(pClipRect, pSr->m_Params.m_ClipBgColor, 4.0f);
+
+	UI()->ClipEnable(pClipRect);
+
+	pSr->m_ClipRect = *pClipRect;
+	pSr->m_ContentH = 0;
+	*pOutOffset = pSr->m_ContentScrollOff;
+}
+
+void CMenus::EndScrollRegion(CScrollRegion* pSr)
+{
+	UI()->ClipDisable();
+	if(pSr->m_WasClipped)
+		UI()->ClipEnable(&pSr->m_OldClipRect);
+
+	dbg_assert(pSr->m_ContentH > 0, "Add some rects with ScrollRegionAddRect()");
+
+	// only show scrollbar if content overflows
+	if(pSr->m_ContentH <= pSr->m_ClipRect.h)
+		return;
+
+	// scroll wheel
+	CUIRect RegionRect = pSr->m_ClipRect;
+	RegionRect.w += pSr->m_Params.m_ScrollbarWidth;
+	if(UI()->MouseInside(&RegionRect))
+	{
+		if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP))
+			pSr->m_ScrollY -= pSr->m_Params.m_ScrollSpeed;
+		else if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
+			pSr->m_ScrollY += pSr->m_Params.m_ScrollSpeed;
+	}
+
+	const float SliderHeight = max(pSr->m_Params.m_SliderMinHeight,
+		pSr->m_ClipRect.h/pSr->m_ContentH * pSr->m_RailRect.h);
+
+	CUIRect Slider = pSr->m_RailRect;
+	Slider.h = SliderHeight;
+	const float MaxScroll = pSr->m_RailRect.h - SliderHeight;
+
+	if(pSr->m_RequestScrollY >= 0)
+	{
+		pSr->m_ScrollY = pSr->m_RequestScrollY/(pSr->m_ContentH - pSr->m_ClipRect.h) * MaxScroll;
+		pSr->m_RequestScrollY = -1;
+	}
+
+	pSr->m_ScrollY = clamp(pSr->m_ScrollY, 0.0f, MaxScroll);
+	Slider.y += pSr->m_ScrollY;
+
+	bool Hovered = false;
+	bool Grabbed = false;
+	const void* pID = &pSr->m_ScrollY;
+	int Inside = UI()->MouseInside(&Slider);
+
+	if(Inside)
+	{
+		UI()->SetHotItem(pID);
+
+		if(!UI()->CheckActiveItem(pID) && UI()->MouseButton(0))
+		{
+			UI()->SetActiveItem(pID);
+			pSr->m_MouseGrabStart.y = UI()->MouseY();
+		}
+
+		Hovered = true;
+	}
+
+	if(UI()->CheckActiveItem(pID) && !UI()->MouseButton(0))
+		UI()->SetActiveItem(0);
+
+	// move slider
+	if(UI()->CheckActiveItem(pID))
+	{
+		float my = UI()->MouseY();
+		pSr->m_ScrollY += my - pSr->m_MouseGrabStart.y;
+		pSr->m_MouseGrabStart.y = my;
+
+		Grabbed = true;
+	}
+
+	pSr->m_ScrollY = clamp(pSr->m_ScrollY, 0.0f, MaxScroll);
+	pSr->m_ContentScrollOff.y = -pSr->m_ScrollY/MaxScroll * (pSr->m_ContentH - pSr->m_ClipRect.h);
+
+	vec4 SliderColor = pSr->m_Params.m_SliderColor;
+	if(Grabbed)
+		SliderColor = pSr->m_Params.m_SliderColorGrabbed;
+	else if(Hovered)
+		SliderColor = pSr->m_Params.m_SliderColorHover;
+
+	RenderTools()->DrawRoundRect(&Slider, SliderColor, Slider.w/2.0f);
+}
+
+void CMenus::ScrollRegionAddRect(CScrollRegion* pSr, CUIRect Rect)
+{
+	vec2 ContentPos = vec2(pSr->m_ClipRect.x, pSr->m_ClipRect.y);
+	ContentPos.x += pSr->m_ContentScrollOff.x;
+	ContentPos.y += pSr->m_ContentScrollOff.y;
+	pSr->m_LastAddedRect = Rect;
+	pSr->m_ContentH = max(Rect.y + Rect.h - ContentPos.y, pSr->m_ContentH);
+}
+
+void CMenus::ScrollRegionScrollHere(CScrollRegion* pSr, int Option)
+{
+	const float MinHeight = min(pSr->m_ClipRect.h, pSr->m_LastAddedRect.h);
+	const float TopScroll = pSr->m_LastAddedRect.y -
+		(pSr->m_ClipRect.y + pSr->m_ContentScrollOff.y);
+
+	switch(Option)
+	{
+		case CScrollRegion::SCROLLHERE_TOP:
+			pSr->m_RequestScrollY = TopScroll;
+			break;
+
+		case CScrollRegion::SCROLLHERE_BOTTOM:
+			pSr->m_RequestScrollY = TopScroll - (pSr->m_ClipRect.h - MinHeight);
+			break;
+
+		case CScrollRegion::SCROLLHERE_KEEP_IN_VIEW:
+		default: {
+			const float dy = pSr->m_LastAddedRect.y - pSr->m_ClipRect.y;
+
+			if(dy < 0)
+				pSr->m_RequestScrollY = TopScroll;
+			else if(dy > (pSr->m_ClipRect.h-MinHeight))
+				pSr->m_RequestScrollY = TopScroll - (pSr->m_ClipRect.h - MinHeight);
+		} break;
+	}
+}
+
+bool CMenus::ScrollRegionIsRectClipped(CScrollRegion* pSr, const CUIRect& Rect)
+{
+	return (pSr->m_ClipRect.x > (Rect.x + Rect.w)
+		|| (pSr->m_ClipRect.x + pSr->m_ClipRect.w) < Rect.x
+		|| pSr->m_ClipRect.y > (Rect.y + Rect.h)
+		|| (pSr->m_ClipRect.y + pSr->m_ClipRect.h) < Rect.y);
+}

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -201,6 +201,35 @@ private:
 		}
 	};
 
+	// Scroll region
+	/*
+
+	Usage:
+		-- Initialization --
+		static CScrollRegion s_ScrollRegion;
+		vec2 ScrollOffset(0, 0);
+		BeginScrollRegion(&s_ScrollRegion, &ScrollRegionRect, &ScrollOffset);
+		Content = ScrollRegionRect;
+		Content.y += ScrollOffset.y;
+
+		-- "Register" your content rects --
+		CUIRect Rect;
+		Content.HSplitTop(SomeValue, &Rect, &Content);
+		ScrollRegionAddRect(&s_ScrollRegion, Rect);
+
+		-- [Optionnal] Knowing if a rect is clipped --
+		ScrollRegionIsRectClipped(&s_ScrollRegion, Rect);
+
+		-- [Optionnal] Scroll to a rect --
+		...
+		ScrollRegionAddRect(&s_ScrollRegion, Rect);
+		ScrollRegionScrollHere(&s_ScrollRegion, Rect, Option);
+
+		-- End --
+		EndScrollRegion(&s_ScrollRegion);
+
+	*/
+
 	void BeginScrollRegion(CScrollRegion* pSr, CUIRect* pClipRect, vec2* pOutOffset, const CScrollRegionParams* pParams = 0);
 	void EndScrollRegion(CScrollRegion* pSr);
 	void ScrollRegionAddRect(CScrollRegion* pSr, CUIRect Rect);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -136,6 +136,77 @@ private:
 	//static void demolist_listdir_callback(const char *name, int is_dir, void *user);
 	//static void demolist_list_callback(const CUIRect *rect, int index, void *user);
 
+	struct CScrollRegionParams
+	{
+		float m_ScrollbarWidth;
+		float m_ScrollbarMargin;
+		float m_SliderMinHeight;
+		float m_ScrollSpeed;
+		vec4 m_ClipBgColor;
+		vec4 m_ScrollbarBgColor;
+		vec4 m_RailBgColor;
+		vec4 m_SliderColor;
+		vec4 m_SliderColorHover;
+		vec4 m_SliderColorGrabbed;
+		int m_Flags;
+
+		enum {
+			FLAG_CONTENT_STATIC_WIDTH = 0x1
+		};
+
+		CScrollRegionParams()
+		{
+			m_ScrollbarWidth = 20;
+			m_ScrollbarMargin = 5;
+			m_SliderMinHeight = 25;
+			m_ScrollSpeed = 5;
+			m_ClipBgColor = vec4(0.0f, 0.0f, 0.0f, 0.5f);
+			m_ScrollbarBgColor = vec4(0.0f, 0.0f, 0.0f, 0.5f);
+			m_RailBgColor = vec4(1.0f, 1.0f, 1.0f, 0.25f);
+			m_SliderColor = vec4(0.8, 0.8, 0.8, 1.0);
+			m_SliderColorHover = vec4(1, 1, 1, 1);
+			m_SliderColorGrabbed = vec4(0.9, 0.9, 0.9, 1);
+			m_Flags = 0;
+		}
+	};
+
+	struct CScrollRegion
+	{
+		float m_ScrollY;
+		float m_ContentH;
+		float m_RequestScrollY; // [0, ContentHeight]
+		CUIRect m_ClipRect;
+		CUIRect m_OldClipRect;
+		CUIRect m_RailRect;
+		CUIRect m_LastAddedRect; // saved for ScrollHere()
+		vec2 m_MouseGrabStart;
+		vec2 m_ContentScrollOff;
+		bool m_WasClipped;
+		CScrollRegionParams m_Params;
+
+		enum {
+			SCROLLHERE_KEEP_IN_VIEW=0,
+			SCROLLHERE_TOP,
+			SCROLLHERE_BOTTOM,
+		};
+
+		CScrollRegion()
+		{
+			m_ScrollY = 0;
+			m_ContentH = 0;
+			m_RequestScrollY = -1;
+			m_ContentScrollOff = vec2(0,0);
+			m_WasClipped = false;
+			m_Params = CScrollRegionParams();
+		}
+	};
+
+	void BeginScrollRegion(CScrollRegion* pSr, CUIRect* pClipRect, vec2* pOutOffset, const CScrollRegionParams* pParams = 0);
+	void EndScrollRegion(CScrollRegion* pSr);
+	void ScrollRegionAddRect(CScrollRegion* pSr, CUIRect Rect);
+	void ScrollRegionScrollHere(CScrollRegion* pSr, int Option = CScrollRegion::SCROLLHERE_KEEP_IN_VIEW);
+	bool ScrollRegionIsRectClipped(CScrollRegion* pSr, const CUIRect& Rect);
+
 	enum
 	{
 		POPUP_NONE=0,

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -220,10 +220,10 @@ private:
 		-- [Optionnal] Knowing if a rect is clipped --
 		ScrollRegionIsRectClipped(&s_ScrollRegion, Rect);
 
-		-- [Optionnal] Scroll to a rect --
+		-- [Optionnal] Scroll to a rect (to the last added rect)--
 		...
 		ScrollRegionAddRect(&s_ScrollRegion, Rect);
-		ScrollRegionScrollHere(&s_ScrollRegion, Rect, Option);
+		ScrollRegionScrollHere(&s_ScrollRegion, Option);
 
 		-- End --
 		EndScrollRegion(&s_ScrollRegion);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1427,70 +1427,47 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	BottomView.HSplitTop(20.f, 0, &BottomView);
 
-	// split scrollbar from main view
-	CUIRect Scroll;
-	MainView.VSplitRight(20.0f, &MainView, &Scroll);
-	RenderTools()->DrawUIRect(&Scroll, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
-	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
-
 	const float HeaderHeight = 20.0f;
 	const float ItemHeight = 20.0f+2.0f;
-	const float MainViewH = MainView.h;
 
-	// make scrollbar
-	static int s_ScrollBar = 0;
-	static int s_ScrollNum = 0;
-	static float s_ScrollValue = 0.f;
-	static float TotalHeight = 0.f;
-	Scroll.HMargin(5.0f, &Scroll);
-	s_ScrollValue = DoScrollbarV(&s_ScrollBar, &Scroll, s_ScrollValue);
+	static CScrollRegion s_ScrollRegion;
+	vec2 ScrollOffset(0, 0);
+	BeginScrollRegion(&s_ScrollRegion, &MainView, &ScrollOffset);
+	MainView.y += ScrollOffset.y;
 
-	UI()->ClipEnable(&MainView);
-	if(TotalHeight - MainView.h > 0)
-		MainView.y -= s_ScrollValue*(TotalHeight - MainView.h);
-
-	TotalHeight = 0.f;
 	static int s_MovementDropdown = 0;
 	static bool s_MovementActive = true;
+	CUIRect LastExpandRect;
 	float Split = DoIndependentDropdownMenu(&s_MovementDropdown, &MainView, Localize("Movement"), HeaderHeight, RenderSettingsControlsMovement, &s_MovementActive);
 
-	TotalHeight += Split+10.0f;
-	MainView.HSplitTop(Split+10.0f, 0, &MainView);
+	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
+	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
 	static int s_WeaponDropdown = 0;
 	static bool s_WeaponActive = true;
 	Split = DoIndependentDropdownMenu(&s_WeaponDropdown, &MainView, Localize("Weapon"), HeaderHeight, RenderSettingsControlsWeapon, &s_WeaponActive);
 
-	TotalHeight += Split+10.0f;
-	MainView.HSplitTop(Split+10.0f, 0, &MainView);
+	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
+	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
 	static int s_VotingDropdown = 0;
 	static bool s_VotingActive = true;
 	Split = DoIndependentDropdownMenu(&s_VotingDropdown, &MainView, Localize("Voting"), HeaderHeight, RenderSettingsControlsVoting, &s_VotingActive);
 
-	TotalHeight += Split+10.0f;
-	MainView.HSplitTop(Split+10.0f, 0, &MainView);
+	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
+	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
 	static int s_ChatDropdown = 0;
 	static bool s_ChatActive = true;
 	Split = DoIndependentDropdownMenu(&s_ChatDropdown, &MainView, Localize("Chat"), HeaderHeight, RenderSettingsControlsChat, &s_ChatActive);
 
-	TotalHeight += Split+10.0f;
-	MainView.HSplitTop(Split+10.0f, 0, &MainView);
+	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
+	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
 	static int s_MiscDropdown = 0;
 	static bool s_MiscActive = true;
 	Split = DoIndependentDropdownMenu(&s_MiscDropdown, &MainView, Localize("Misc"), HeaderHeight, RenderSettingsControlsMisc, &s_MiscActive);
-	TotalHeight += Split;
-	UI()->ClipDisable();
 
-	// handle scrolling
-	float ProperHeight = (TotalHeight-5*HeaderHeight-40.0f);
-	s_ScrollNum = /*ceil*/((ProperHeight-MainViewH)/ItemHeight);
-	if(s_ScrollNum <= 0)
-		s_ScrollNum = 1;
-	// We could && UI()->MouseInside(&MainView)), but that does not work well because the controls settings menu got holes
-	if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP))
-		s_ScrollValue -= 3.0f/s_ScrollNum; // will be set to 0 by clamp if scrollnum is too small
-	if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
-		s_ScrollValue += 3.0f/s_ScrollNum; // will be set to 1 by clamp if scrollnum is too small
-	s_ScrollValue = clamp(s_ScrollValue, 0.f, 1.f);
+	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
+	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
+
+	EndScrollRegion(&s_ScrollRegion);
 
 	// reset button
 	float Spacing = 3.0f;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -111,6 +111,7 @@ public:
 	void ClipEnable(const CUIRect *pRect);
 	void ClipDisable();
 	const CUIRect *ClipArea() const { return &m_ClipRect; };
+	inline bool IsClipped() const { return m_Clipped; };
 
 	// TODO: Refactor: Redo UI scaling
 	float Scale() const;


### PR DESCRIPTION
As we currently don't have a universal way of doing scrollable regions (we do custom scrollbar code every time), I made a small api just for that. It currently only makes vertical scrollbars, but I've set it up in a way that makes adding horizontal scrollbars somewhat trivial, if we ever need it.

This includes:
* Few and easy to use functions
* A dynamically sized slider
* Ability to scroll anywhere, easily
* Auto resizing scrollbar on a 1 frame delay

This can be very useful for future UI development, such as the new editor I'm working on, scrollable chat or even to expand current *pages* where we ran out of space.

I've used the api to replace the scrollbar in the Settings > Controls page. You can also check out [this branch](https://github.com/LordSk/teeworlds/tree/develop/scrollbar_api) for a worst case scenario where every item changes size every frame.

Here is a small documentation that I also embedded in the code.
```cpp
-- Initialization --
static CScrollRegion s_ScrollRegion;
vec2 ScrollOffset(0, 0);
BeginScrollRegion(&s_ScrollRegion, &ScrollRegionRect, &ScrollOffset);
Content = ScrollRegionRect;
Content.y += ScrollOffset.y;

-- "Register" your content rects --
CUIRect Rect;
Content.HSplitTop(SomeValue, &Rect, &Content);
ScrollRegionAddRect(&s_ScrollRegion, Rect);

-- [Optionnal] Knowing if a rect is clipped --
ScrollRegionIsRectClipped(&s_ScrollRegion, Rect);

-- [Optionnal] Scroll to a rect (to the last added rect) --
...
ScrollRegionAddRect(&s_ScrollRegion, Rect);
ScrollRegionScrollHere(&s_ScrollRegion, Option);

-- End --
EndScrollRegion(&s_ScrollRegion);
```