### PR TITLE
use SO_REUSEPORT for tcp connections

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -995,6 +995,10 @@ static int priv_net_create_socket(int domain, int type, struct sockaddr *addr, i
 				((struct sockaddr_in6 *)(addr))->sin6_port = port;
 		}
 
+		if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &(int){ 1 }, sizeof(int)) < 0) {
+			dbg_msg("net", "failed to setsockopt SO_REUSEPORT");
+		}
+
 		e = bind(sock, addr, sockaddrlen);
 		if(e == 0)
 			break;

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -995,9 +995,15 @@ static int priv_net_create_socket(int domain, int type, struct sockaddr *addr, i
 				((struct sockaddr_in6 *)(addr))->sin6_port = port;
 		}
 
+#if defined(CONF_FAMILY_WINDOWS)
+		if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &(int){ 1 }, sizeof(int)) < 0) {
+			dbg_msg("net", "failed to setsockopt SO_REUSEADDR");
+		}
+#else
 		if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &(int){ 1 }, sizeof(int)) < 0) {
 			dbg_msg("net", "failed to setsockopt SO_REUSEPORT");
 		}
+#endif
 
 		e = bind(sock, addr, sockaddrlen);
 		if(e == 0)


### PR DESCRIPTION
Using SO_REUSEPORT allows to quickly kill the server via SIGINT, SIGTERM
or SIGKILL and start it again, without waiting for the OS to close the
socket by timeout.

Closes #804 (for the second time)