### PR TITLE
Try resetting the screen index when gfx init fails

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -754,6 +754,16 @@ int CGraphics_Threaded::InitWindow()
 	if(IssueInit() == 0)
 		return 0;
 
+	// try resetting the screen index
+	if(g_Config.m_GfxScreen != 0)
+	{
+		dbg_msg("gfx", "resetting screen index and trying again");
+		g_Config.m_GfxScreen = 0;
+
+		if(IssueInit() == 0)
+			return 0;
+	}
+
 	// try disabling fsaa
 	while(g_Config.m_GfxFsaaSamples)
 	{


### PR DESCRIPTION
Fixes #2036 

Starting teeworlds with `./teeworlds "gfx_screen 1"` fails if only one screen is available. It will output

```
[5c67d6e0][client]: starting...
[5c67d6e0][gfx]: unable to retrieve screen information: displayIndex must be in the range 0 - 0
[5c67d6e0][gfx]: lowering FSAA to 1 and trying again
[5c67d6e0][gfx]: unable to retrieve screen information: displayIndex must be in the range 0 - 0
[5c67d6e0][gfx]: disabling FSAA and trying again
[5c67d6e0][gfx]: unable to retrieve screen information: displayIndex must be in the range 0 - 0
[5c67d6e0][gfx]: setting resolution to 640x480 and trying again
[5c67d6e0][gfx]: unable to retrieve screen information: displayIndex must be in the range 0 - 0
[5c67d6e0][gfx]: out of ideas. failed to init graphics
[5c67d6e0][client]: couldn't init graphics
```

Now, it works and outputs
```
[5c67f829][client]: starting...
[5c67f829][gfx]: unable to retrieve screen information: displayIndex must be in the range 0 - 0
[5c67f829][gfx]: resetting screen index and trying again
[5c67f829][render]: opengl max texture sizes: 16384, 2048(3D)
[5c67f829][client/sound]: sound init successful
```