### PR TITLE
Make chat ignore permanent

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1708,7 +1708,8 @@ void CClient::RegisterInterfaces()
 	Kernel()->RegisterInterface(static_cast<IDemoRecorder*>(&m_DemoRecorder));
 	Kernel()->RegisterInterface(static_cast<IDemoPlayer*>(&m_DemoPlayer));
 	Kernel()->RegisterInterface(static_cast<IServerBrowser*>(&m_ServerBrowser));
-	Kernel()->RegisterInterface(static_cast<IFriends*>(&m_Friends));
+	Kernel()->RegisterInterface(static_cast<IGoodFriends*>(&m_GoodFriends));
+	Kernel()->RegisterInterface(static_cast<IBadFriends*>(&m_BadFriends));
 }
 
 void CClient::InitInterfaces()
@@ -1726,7 +1727,8 @@ void CClient::InitInterfaces()
 
 	//
 	m_ServerBrowser.Init(&m_ContactClient, m_pGameClient->NetVersion());
-	m_Friends.Init();
+	m_GoodFriends.Init();
+	m_BadFriends.Init();
 }
 
 bool CClient::LimitFps()

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -75,7 +75,8 @@ class CClient : public IClient, public CDemoPlayer::IListner
 	class CDemoPlayer m_DemoPlayer;
 	class CDemoRecorder m_DemoRecorder;
 	class CServerBrowser m_ServerBrowser;
-	class CFriends m_Friends;
+	class CGoodFriends m_GoodFriends;
+	class CBadFriends m_BadFriends;
 	class CMapChecker m_MapChecker;
 
 	char m_aServerAddressStr[256];

--- a/src/engine/client/friends.h
+++ b/src/engine/client/friends.h
@@ -5,20 +5,21 @@
 
 #include <engine/friends.h>
 
-class CFriends : public IFriends
+class CFriends : public virtual IFriends
 {
+protected:
 	CFriendInfo m_aFriends[MAX_FRIENDS];
 	int m_NumFriends;
-
-	static void ConAddFriend(IConsole::IResult *pResult, void *pUserData);
-	static void ConRemoveFriend(IConsole::IResult *pResult, void *pUserData);
-
-	static void ConfigSaveCallback(IConfig *pConfig, void *pUserData);
 
 public:
 	CFriends();
 
-	void Init();
+	void ConfigSave(IConfig *pConfig, const char* pCmdStr);
+
+	static void ConAddFriend(IConsole::IResult *pResult, void *pUserData);
+	static void ConRemoveFriend(IConsole::IResult *pResult, void *pUserData);
+
+	virtual void Init() = 0;
 
 	int NumFriends() const { return m_NumFriends; }
 	const CFriendInfo *GetFriend(int Index) const;
@@ -28,6 +29,22 @@ public:
 	void AddFriend(const char *pName, const char *pClan);
 	void RemoveFriend(const char *pName, const char *pClan);
 	void RemoveFriend(int Index);
+};
+
+class CGoodFriends: public CFriends, public IGoodFriends
+{
+public:
+	static void ConfigSaveCallback(IConfig *pConfig, void *pUserData);
+
+	void Init();
+};
+
+class CBadFriends: public CFriends, public IBadFriends
+{
+public:
+	static void ConfigSaveCallback(IConfig *pConfig, void *pUserData);
+
+	void Init();
 };
 
 #endif

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -84,7 +84,7 @@ void CServerBrowser::Init(class CNetClient *pNetClient, const char *pNetVersion)
 	m_pNetClient = pNetClient;
 
 	m_ServerBrowserFavorites.Init(pNetClient, m_pConsole, Kernel()->RequestInterface<IEngine>(), Kernel()->RequestInterface<IConfig>());
-	m_ServerBrowserFilter.Init(Kernel()->RequestInterface<IFriends>(), pNetVersion);
+	m_ServerBrowserFilter.Init(static_cast<IFriends *>(Kernel()->RequestInterface<IGoodFriends>()), pNetVersion);
 }
 
 void CServerBrowser::Set(const NETADDR &Addr, int SetType, int Token, const CServerInfo *pInfo)

--- a/src/engine/friends.h
+++ b/src/engine/friends.h
@@ -17,7 +17,6 @@ struct CFriendInfo
 
 class IFriends : public IInterface
 {
-	MACRO_INTERFACE("friends", 0)
 public:
 	enum
 	{
@@ -37,6 +36,16 @@ public:
 
 	virtual void AddFriend(const char *pName, const char *pClan) = 0;
 	virtual void RemoveFriend(const char *pName, const char *pClan) = 0;
+};
+
+class IGoodFriends: public virtual IFriends
+{
+	MACRO_INTERFACE("good friends", 0)
+};
+
+class IBadFriends: public virtual IFriends
+{
+	MACRO_INTERFACE("bad friends", 0)
 };
 
 #endif

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -323,7 +323,14 @@ void CMenus::RenderPlayers(CUIRect MainView)
 				DoButton_Toggle(&s_aPlayerIDs[i][0], 1, &Label, false);
 			else
 				if(DoButton_Toggle(&s_aPlayerIDs[i][0], m_pClient->m_aClients[i].m_ChatIgnore, &Label, true))
+				{
+					if(m_pClient->m_aClients[i].m_ChatIgnore)
+						m_pClient->Enemies()->RemoveFriend(m_pClient->m_aClients[i].m_aName, m_pClient->m_aClients[i].m_aClan);
+					else
+						m_pClient->Enemies()->AddFriend(m_pClient->m_aClients[i].m_aName, m_pClient->m_aClients[i].m_aClan);
+
 					m_pClient->m_aClients[i].m_ChatIgnore ^= 1;
+				}
 
 			// friend button
 			Row.VSplitRight(2*Spacing+ButtonHeight,&Row, 0);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -163,7 +163,8 @@ void CGameClient::OnConsoleInit()
 	m_pDemoRecorder = Kernel()->RequestInterface<IDemoRecorder>();
 	m_pServerBrowser = Kernel()->RequestInterface<IServerBrowser>();
 	m_pEditor = Kernel()->RequestInterface<IEditor>();
-	m_pFriends = Kernel()->RequestInterface<IFriends>();
+	m_pGoodFriends = Kernel()->RequestInterface<IGoodFriends>();
+	m_pBadFriends = Kernel()->RequestInterface<IBadFriends>();
 
 	// setup pointers
 	m_pBinds = &::gs_Binds;
@@ -242,6 +243,8 @@ void CGameClient::OnConsoleInit()
 
 	Console()->Chain("add_friend", ConchainFriendUpdate, this);
 	Console()->Chain("remove_friend", ConchainFriendUpdate, this);
+	Console()->Chain("add_ignore", ConchainEnemyUpdate, this);
+	Console()->Chain("remove_ignore", ConchainEnemyUpdate, this);
 	Console()->Chain("cl_show_xmas_hats", ConchainXmasHatUpdate, this);
 
 	for(int i = 0; i < m_All.m_Num; i++)
@@ -675,6 +678,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 
 		// update friend state
 		m_aClients[pMsg->m_ClientID].m_Friend = Friends()->IsFriend(m_aClients[pMsg->m_ClientID].m_aName, m_aClients[pMsg->m_ClientID].m_aClan, true);
+		m_aClients[pMsg->m_ClientID].m_ChatIgnore = Enemies()->IsFriend(m_aClients[pMsg->m_ClientID].m_aName, m_aClients[pMsg->m_ClientID].m_aClan, true);
 
 		m_aClients[pMsg->m_ClientID].UpdateRenderInfo(this, pMsg->m_ClientID, true);
 
@@ -1525,6 +1529,17 @@ void CGameClient::ConchainFriendUpdate(IConsole::IResult *pResult, void *pUserDa
 	{
 		if(pClient->m_aClients[i].m_Active)
 			pClient->m_aClients[i].m_Friend = pClient->Friends()->IsFriend(pClient->m_aClients[i].m_aName, pClient->m_aClients[i].m_aClan, true);
+	}
+}
+
+void CGameClient::ConchainEnemyUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	pfnCallback(pResult, pCallbackUserData);
+	CGameClient *pClient = static_cast<CGameClient *>(pUserData);
+	for(int i = 0; i < MAX_CLIENTS; ++i)
+	{
+		if(pClient->m_aClients[i].m_Active)
+			pClient->m_aClients[i].m_ChatIgnore = pClient->Enemies()->IsFriend(pClient->m_aClients[i].m_aName, pClient->m_aClients[i].m_aClan, true);
 	}
 }
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -678,7 +678,16 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 
 		// update friend state
 		m_aClients[pMsg->m_ClientID].m_Friend = Friends()->IsFriend(m_aClients[pMsg->m_ClientID].m_aName, m_aClients[pMsg->m_ClientID].m_aClan, true);
+		// update chat ignore state
 		m_aClients[pMsg->m_ClientID].m_ChatIgnore = Enemies()->IsFriend(m_aClients[pMsg->m_ClientID].m_aName, m_aClients[pMsg->m_ClientID].m_aClan, true);
+		if(m_aClients[pMsg->m_ClientID].m_ChatIgnore)
+		{
+			char aBuf[128];
+			char aLabel[64];
+			GetPlayerLabel(aLabel, sizeof(aLabel), pMsg->m_ClientID, m_aClients[pMsg->m_ClientID].m_aName);
+			str_format(aBuf, sizeof(aBuf), Localize("%s is muted by you"), aLabel);
+			m_pChat->AddLine(-1, 0, aBuf);
+		}
 
 		m_aClients[pMsg->m_ClientID].UpdateRenderInfo(this, pMsg->m_ClientID, true);
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -43,7 +43,8 @@ class CGameClient : public IGameClient
 	class IDemoRecorder *m_pDemoRecorder;
 	class IServerBrowser *m_pServerBrowser;
 	class IEditor *m_pEditor;
-	class IFriends *m_pFriends;
+	class IGoodFriends *m_pGoodFriends;
+	class IBadFriends *m_pBadFriends;
 
 	CLayers m_Layers;
 	class CCollision m_Collision;
@@ -60,6 +61,7 @@ class CGameClient : public IGameClient
 	static void ConKill(IConsole::IResult *pResult, void *pUserData);
 	static void ConReadyChange(IConsole::IResult *pResult, void *pUserData);
 	static void ConchainFriendUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainEnemyUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainXmasHatUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
 	void EvolveCharacter(CNetObj_Character *pCharacter, int Tick);
@@ -82,7 +84,8 @@ public:
 	class CLayers *Layers() { return &m_Layers; };
 	class CCollision *Collision() { return &m_Collision; };
 	class IEditor *Editor() { return m_pEditor; }
-	class IFriends *Friends() { return m_pFriends; }
+	class IFriends *Friends() { return reinterpret_cast<IFriends *>(m_pGoodFriends); }
+	class IFriends *Enemies() { return reinterpret_cast<IFriends *>(m_pBadFriends); }
 
 	const char *NetobjFailedOn() { return m_NetObjHandler.FailedObjOn(); };
 	int NetobjNumFailures() { return m_NetObjHandler.NumObjFailures(); };


### PR DESCRIPTION
**Note**: this slightly conflicts with https://github.com/teeworlds/teeworlds/pull/2042 (since it modifies the mute feature)

### Behaviour
This feature makes use of the existing friends system to implement a permanent chat ignore. It adds two console commands `add_ignore` and `remove_ignore` (feel free to suggest different wording...)

- Muting or unmuting a player, from the console or the menus, is always permanent (and player+clan based)
- An information message is displayed when
  - a previously muted player join the server
  - the player joins a server with previously muted players

`%s is muted by you` sounds like broken English, maybe @oy will have a better suggestion :)
![image](https://user-images.githubusercontent.com/355114/53110942-66c4e380-353c-11e9-8784-650e11214638.png)


### Implementation
As mentioned above, this feature makes use of the `IFriends` and `CFriends` classes.

In order to register two IFriends interfaces, I ran into the ["diamond problem"](https://en.wikipedia.org/wiki/Multiple_inheritance#The_diamond_problem) where a class inherits of two classes which themselves inherit from the same baseclass. This is solved using virtual inheritence:

```cpp
class IFriends: public IInterface
class IGoodFriends: public virtual IFriends
class IBadFriends: public virtual IFriends
class CFriends : public virtual IFriends
class CGoodFriends: public CFriends, public IGoodFriends
class CBadFriends: public CFriends, public IBadFriends
```

Multiple inheritance is generally frowned upon, but it seems like it tends to be given a pass for interfaces. 

Due to this, there can be some nasty runtime errors if you use a `static_cast` instead of a `reinterpret_cast` (you get a cryptic "virtual baseclass botch" error) in gameclient.h.

It seemed somewhat clever and avoids code redundancy but I'm as much of an OOP nerd as my neighbor's cat is a leopard and I won't mind if I have to scrap that and find another way, given that it is somewhat obscure and possibly unfitting for the Teeworlds basecode.