### PR TITLE
Fix `IStorage::FindFile` in case no CRC or size are specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1558,6 +1558,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
   set_src(TESTS GLOB src/test
     fs.cpp
     git_revision.cpp
+    storage.cpp
     str.cpp
     test.cpp
     test.h

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -21,7 +21,8 @@ public:
 
 	virtual void ListDirectory(int Type, const char *pPath, FS_LISTDIR_CALLBACK pfnCallback, void *pUser) = 0;
 	virtual IOHANDLE OpenFile(const char *pFilename, int Flags, int Type, char *pBuffer = 0, int BufferSize = 0) = 0;
-	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize, unsigned WantedCrc = 0, unsigned WantedSize = 0) = 0;
+	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize) = 0;
+	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize, unsigned WantedCrc, unsigned WantedSize) = 0;
 	virtual bool RemoveFile(const char *pFilename, int Type) = 0;
 	virtual bool RenameFile(const char* pOldFilename, const char* pNewFilename, int Type) = 0;
 	virtual bool CreateFolder(const char *pFoldername, int Type) = 0;
@@ -29,7 +30,8 @@ public:
 	virtual bool GetCrcSize(const char *pFilename, int StorageType, unsigned *pCrc, unsigned *pSize) = 0;
 };
 
-extern IStorage *CreateStorage(const char *pApplicationName, int StorageType, int NumArgs, const char **ppArguments);
+IStorage *CreateStorage(const char *pApplicationName, int StorageType, int NumArgs, const char **ppArguments);
+IStorage *CreateTestStorage();
 
 
 #endif

--- a/src/test/storage.cpp
+++ b/src/test/storage.cpp
@@ -1,0 +1,32 @@
+#include "test.h"
+
+#include <gtest/gtest.h>
+
+#include <engine/storage.h>
+
+TEST(Storage, FindFile)
+{
+	CTestInfo Info;
+	char aFilenameWithDot[128];
+	str_format(aFilenameWithDot, sizeof(aFilenameWithDot), "./%s", Info.m_aFilename);
+
+	IStorage *pStorage = CreateTestStorage();
+	IOHANDLE File = pStorage->OpenFile(Info.m_aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+	ASSERT_TRUE(File);
+	EXPECT_EQ(io_write(File, "test\n", 5), 5);
+	EXPECT_FALSE(io_close(File));
+
+	char aFound[128];
+
+	EXPECT_TRUE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound)));
+	EXPECT_STREQ(aFound, aFilenameWithDot);
+
+	EXPECT_TRUE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), 0x3bb935c6, 5));
+	EXPECT_STREQ(aFound, aFilenameWithDot);
+
+	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), 0, 0));
+	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), 0x3bb935c6, 0));
+	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), 0, 5));
+	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), 0x3bb935c5, 5));
+	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), 0x3bb935c6, 6));
+}


### PR DESCRIPTION
Previously, it only returned files with CRC 0 and size 0 (so empty
files) in case you didn't specify CRC and size.

Also add some tests covering that behavior.