### PR TITLE
Fix sound notifications being displayed when client loads too quick

### DIFF
--- a/src/game/client/components/notifications.cpp
+++ b/src/game/client/components/notifications.cpp
@@ -12,7 +12,7 @@
 
 CNotifications::CNotifications()
 {
-	m_SoundToggleTime = 0.0f;
+	m_SoundToggleTime = -99.0f;
 }
 
 void CNotifications::OnConsoleInit()


### PR DESCRIPTION
If the client loads within 1.5s, a sound notification will briefly be displayed. I simply used a different magic number to fix this (`Client()->LocalTime()` starts at 0).