### PR TITLE
Use the secure RNG for network tokens

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2534,6 +2534,12 @@ int main(int argc, const char **argv) // ignore_convention
 		}
 	}
 
+	if(secure_random_init() != 0)
+	{
+		dbg_msg("secure", "could not initialize secure RNG");
+		return -1;
+	}
+
 	CClient *pClient = CreateClient();
 	IKernel *pKernel = IKernel::Create();
 	pKernel->RegisterInterface(pClient);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1778,11 +1778,10 @@ int main(int argc, const char **argv) // ignore_convention
 		}
 	}
 
-	bool SkipPWGen = false;
 	if(secure_random_init() != 0)
 	{
 		dbg_msg("secure", "could not initialize secure RNG");
-		SkipPWGen = true;	// skip automatic password generation
+		return -1;
 	}
 
 	CServer *pServer = CreateServer();
@@ -1841,8 +1840,7 @@ int main(int argc, const char **argv) // ignore_convention
 
 	pEngine->InitLogfile();
 
-	if(!SkipPWGen)
-		pServer->InitRconPasswordIfUnset();
+	pServer->InitRconPasswordIfUnset();
 
 	// run the server
 	dbg_msg("server", "starting...");

--- a/src/engine/shared/network_token.cpp
+++ b/src/engine/shared/network_token.cpp
@@ -77,11 +77,7 @@ void CNetTokenManager::GenerateSeed()
 	static const NETADDR NullAddr = { 0 };
 	m_PrevSeed = m_Seed;
 
-	for(int i = 0; i < 2; i++)
-	{
-		m_Seed <<= 32;
-		m_Seed ^= random_int();
-	}
+	secure_random_fill(&m_Seed, sizeof(m_Seed));
 
 	m_PrevGlobalToken = m_GlobalToken;
 	m_GlobalToken = GenerateToken(&NullAddr);


### PR DESCRIPTION
These tokens benefit from being unpredictable by an adversary, so let's
make them unpredictable.