### PR TITLE
Add GetDesktopResolution, improve the UI for gfx_screen

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -672,14 +672,11 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *Screen, int *pWidt
 	}
 
 	// store desktop resolution for settings reset button
-	SDL_DisplayMode DisplayMode;
-	if(SDL_GetDesktopDisplayMode(*Screen, &DisplayMode))
+	if(!GetDesktopResolution(*Screen, pDesktopWidth, pDesktopHeight))
 	{
 		dbg_msg("gfx", "unable to get desktop resolution: %s", SDL_GetError());
 		return -1;
 	}
-	*pDesktopWidth = DisplayMode.w;
-	*pDesktopHeight = DisplayMode.h;
 
 	// use desktop resolution as default resolution
 	if (*pWidth == 0 || *pHeight == 0)
@@ -847,6 +844,17 @@ bool CGraphicsBackend_SDL_OpenGL::SetWindowScreen(int Index)
 int CGraphicsBackend_SDL_OpenGL::GetWindowScreen()
 {
 	return SDL_GetWindowDisplayIndex(m_pWindow);
+}
+
+bool CGraphicsBackend_SDL_OpenGL::GetDesktopResolution(int Index, int *pDesktopWidth, int* pDesktopHeight)
+{
+	SDL_DisplayMode DisplayMode;
+	if(SDL_GetDesktopDisplayMode(Index, &DisplayMode))
+		return false;
+
+	*pDesktopWidth = DisplayMode.w;
+	*pDesktopHeight = DisplayMode.h;
+	return true;
 }
 
 int CGraphicsBackend_SDL_OpenGL::WindowActive()

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -212,6 +212,7 @@ public:
 	virtual void SetWindowBordered(bool State);	// on=true/off=false
 	virtual bool SetWindowScreen(int Index);
 	virtual int GetWindowScreen();
+	virtual bool GetDesktopResolution(int Index, int *pDesktopWidth, int* pDesktopHeight);
 	virtual int WindowActive();
 	virtual int WindowOpen();
 };

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -894,7 +894,13 @@ void CGraphics_Threaded::SetWindowBordered(bool State)
 
 bool CGraphics_Threaded::SetWindowScreen(int Index)
 {
-	return m_pBackend->SetWindowScreen(Index);
+	if(m_pBackend->SetWindowScreen(Index))
+	{
+		// update resolution info
+		m_pBackend->GetDesktopResolution(Index, &m_DesktopScreenWidth, &m_DesktopScreenHeight);
+		return true;
+	}
+	return false;
 }
 
 int CGraphics_Threaded::GetWindowScreen()

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -327,6 +327,7 @@ public:
 	virtual bool Fullscreen(bool State) = 0;
 	virtual void SetWindowBordered(bool State) = 0;
 	virtual bool SetWindowScreen(int Index) = 0;
+	virtual bool GetDesktopResolution(int Index, int *pDesktopWidth, int* pDesktopHeight) = 0;
 	virtual int GetWindowScreen() = 0;
 	virtual int WindowActive() = 0;
 	virtual int WindowOpen() = 0;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1566,8 +1566,8 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	BottomView.HSplitTop(20.f, 0, &BottomView);
 
 	// render screen menu background
-	int NumOptions = 3;// + (!g_Config.m_GfxFullscreen);
-	if(Graphics()->GetNumScreens() > 1)
+	int NumOptions = 3;
+	if(Graphics()->GetNumScreens() > 1 && !g_Config.m_GfxFullscreen)
 		++NumOptions;
 	float ButtonHeight = 20.0f;
 	float Spacing = 2.0f;
@@ -1613,6 +1613,29 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		static int s_ButtonGfxBorderless = 0;
 		if(DoButton_CheckBox(&s_ButtonGfxBorderless, Localize("Borderless window"), g_Config.m_GfxBorderless, &Button))
 			Client()->ToggleWindowBordered();
+	}
+
+	if(Graphics()->GetNumScreens() > 1)
+	{
+		char aBuf[64];
+		ScreenLeft.HSplitTop(Spacing, 0, &ScreenLeft);
+		ScreenLeft.HSplitTop(ButtonHeight, &Button, &ScreenLeft);
+		RenderTools()->DrawUIRect(&Button, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
+		CUIRect Text;
+		Button.VSplitLeft(ButtonHeight+5.0f, 0, &Button);
+		Button.VSplitLeft(100.0f-25.0f, &Text, &Button); // make button appear centered with FSAA
+		str_format(aBuf, sizeof(aBuf), Localize("Screen:"));
+		Text.y += 2.0f;
+		UI()->DoLabel(&Text, aBuf, Text.h*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
+
+		Button.VSplitLeft(120.0f, &Button, 0);
+		str_format(aBuf, sizeof(aBuf), "#%d  (%dx%d)", g_Config.m_GfxScreen+1, Graphics()->GetDesktopScreenWidth(), Graphics()->GetDesktopScreenHeight());
+		static CButtonContainer s_ButtonScreenId;
+		if(DoButton_Menu(&s_ButtonScreenId, aBuf, 0, &Button))
+		{
+			g_Config.m_GfxScreen = (g_Config.m_GfxScreen + 1) % Graphics()->GetNumScreens();
+			Client()->SwitchWindowScreen(g_Config.m_GfxScreen);
+		}
 	}
 
 	// FSAA button
@@ -1669,16 +1692,6 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 			DoScrollbarOption(&g_Config.m_GfxMaxFps, &g_Config.m_GfxMaxFps,
 							  &Button, Localize("Max fps"), 30, 300);
 		}
-	}
-
-	if(Graphics()->GetNumScreens() > 1)
-	{
-		ScreenRight.HSplitTop(Spacing, 0, &ScreenRight);
-		ScreenRight.HSplitTop(ButtonHeight, &Button, &ScreenRight);
-		int Index = g_Config.m_GfxScreen;
-		DoScrollbarOption(&g_Config.m_GfxScreen, &Index, &Button, Localize("Screen"), 0, Graphics()->GetNumScreens()-1);
-		if(Index != g_Config.m_GfxScreen)
-			Client()->SwitchWindowScreen(Index);
 	}
 
 	// render texture menu


### PR DESCRIPTION
## Technicals
Things done:

- Add a `GetDesktopResolution` function, that is called when the screen changes to update desktop information.
- Made the `gfx_screen` slider a button (FSAA-style) to avoid the setting being reset because the screen change puts the mouse on the other side of the slider, resulting in horrible blinking
- The UI Settings/Graphics page had holes and strange blank spaces under certain circumstances (for example, VSync on and several screens). I moved the screen resolution to the left column, figured it made the thing a bit more consistent and fixed the issues along the way.

## Visuals
I tried with three screens, one with a different resolution. 
Before:
![screenshot_2019-03-26_16-36-00](https://user-images.githubusercontent.com/355114/55011609-66f64a00-4fe6-11e9-89cb-400df3ad5fa9.png)
After:
![screenshot_2019-03-26_16-34-57](https://user-images.githubusercontent.com/355114/55011608-66f64a00-4fe6-11e9-88a2-15c1268b3e83.png)


## Side note: Bugs
I tried to mess around and switch gfx_screen while in fullscreen and with different resolutions. The game quickly displayed a bunch of bugs, distorted windows, wrong resolution, wrong screen, or part of the screen was all yellow (gfx_clear 1). I reproduced that on master though.

At this point I can't tell if the problem is Teeworlds, SDL, Linux, or a combination of the three. 
Linux especially got me used to a lot of insanity with fullscreen/several monitors so unless someone reproduces it on a different OS, well. :man_shrugging: 