### PR TITLE
Implement live auto map

### DIFF
--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -110,7 +110,7 @@ const char* CTilesetMapper::GetRuleSetName(int Index) const
 	return m_aRuleSets[Index].m_aName;
 }
 
-void CTilesetMapper::Proceed(CLayerTiles *pLayer, int ConfigID)
+void CTilesetMapper::Proceed(CLayerTiles *pLayer, int ConfigID, RECTi Area)
 {
 	if(pLayer->m_Readonly || ConfigID < 0 || ConfigID >= m_aRuleSets.size())
 		return;
@@ -120,12 +120,14 @@ void CTilesetMapper::Proceed(CLayerTiles *pLayer, int ConfigID)
 	if(!pConf->m_aRules.size())
 		return;
 
+	pLayer->Clamp(&Area);
+	
 	int BaseTile = pConf->m_BaseTile;
 
 	// auto map !
 	int MaxIndex = pLayer->m_Width*pLayer->m_Height;
-	for(int y = 0; y < pLayer->m_Height; y++)
-		for(int x = 0; x < pLayer->m_Width; x++)
+	for(int y = Area.y; y < Area.y + Area.h; y++)
+		for(int x = Area.x; x < Area.x + Area.w; x++)
 		{
 			CTile *pTile = &(pLayer->m_pTiles[y*pLayer->m_Width+x]);
 			if(pTile->m_Index == 0)

--- a/src/game/editor/auto_map.h
+++ b/src/game/editor/auto_map.h
@@ -6,6 +6,11 @@
 
 #include <engine/external/json-parser/json.h>
 
+typedef struct
+{
+	int x, y;
+	int w, h;
+} RECTi;
 
 class IAutoMapper
 {
@@ -22,17 +27,15 @@ public:
 		MAX_RULES=256
 	};
 
-	//
 	IAutoMapper(class CEditor *pEditor, int Type) : m_pEditor(pEditor), m_Type(Type) {}
 	virtual ~IAutoMapper() {};
 	virtual void Load(const json_value &rElement) = 0;
-	virtual void Proceed(class CLayerTiles *pLayer, int ConfigID) {}
+	virtual void Proceed(class CLayerTiles *pLayer, int ConfigID, RECTi Area) {}
 	virtual void Proceed(class CLayerTiles *pLayer, int ConfigID, int Ammount) {} // for convenience purposes
 
 	virtual int RuleSetNum() = 0;
 	virtual const char* GetRuleSetName(int Index) const = 0;
 
-	//
 	int GetType() const { return m_Type; }
 
 	static bool Random(int Value)
@@ -91,7 +94,7 @@ public:
 	CTilesetMapper(class CEditor *pEditor) : IAutoMapper(pEditor, TYPE_TILESET) { m_aRuleSets.clear(); }
 
 	virtual void Load(const json_value &rElement);
-	virtual void Proceed(class CLayerTiles *pLayer, int ConfigID);
+	virtual void Proceed(class CLayerTiles *pLayer, int ConfigID, RECTi Area);
 
 	virtual int RuleSetNum() { return m_aRuleSets.size(); }
 	virtual const char* GetRuleSetName(int Index) const;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2709,6 +2709,23 @@ void CEditor::ReplaceImage(const char *pFileName, int StorageType, void *pUser)
 	{
 		delete pImg->m_pAutoMapper;
 		pImg->m_pAutoMapper = 0;
+		for (int g = 0; g < pEditor->m_Map.m_lGroups.size(); g++)
+		{
+			CLayerGroup *pGroup = pEditor->m_Map.m_lGroups[g];
+			for (int l = 0; l < pGroup->m_lLayers.size(); l++)
+			{
+				if (pGroup->m_lLayers[l]->m_Type == LAYERTYPE_TILES)
+				{
+					CLayerTiles *pLayer = static_cast<CLayerTiles *>(pGroup->m_lLayers[l]);
+					//resets live auto map of affected layers
+					if (pLayer->m_Image == pEditor->m_SelectedImage)
+					{
+						pLayer->m_SelectedRuleSet = 0;
+						pLayer->m_LiveAutoMap = false;
+					}
+				}
+			}
+		}
 	}
 	*pImg = ImgInfo;
 	pImg->m_External = External;
@@ -3897,7 +3914,6 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 									pEnvelope->m_lPoints[i].m_aOutTangentdx[c] = clamp(pEnvelope->m_lPoints[i].m_aOutTangentdx[c], 0,
 																						(int)(EndTime*1000.f - pEnvelope->m_lPoints[i].m_Time));
 
-									//
 									m_SelectedQuadEnvelope = m_SelectedEnvelope;
 									m_ShowEnvelopePreview = SHOWENV_SELECTED;
 									m_SelectedEnvelopePoint = i;
@@ -3981,7 +3997,6 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 									// clamp time value
 									pEnvelope->m_lPoints[i].m_aInTangentdx[c] = clamp(pEnvelope->m_lPoints[i].m_aInTangentdx[c], -pEnvelope->m_lPoints[i].m_Time, 0);
 
-									//
 									m_SelectedQuadEnvelope = m_SelectedEnvelope;
 									m_ShowEnvelopePreview = SHOWENV_SELECTED;
 									m_SelectedEnvelopePoint = i;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -409,12 +409,6 @@ enum
 	PROPTYPE_SHIFT,
 };
 
-typedef struct
-{
-	int x, y;
-	int w, h;
-} RECTi;
-
 class CLayerTiles : public CLayer
 {
 public:
@@ -464,6 +458,7 @@ public:
 	int m_SaveTilesSize;
 	CTile *m_pTiles;
 	int m_SelectedRuleSet;
+	bool m_LiveAutoMap;
 	int m_SelectedAmount;
 };
 

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -348,6 +348,9 @@ void CLayerTiles::BrushFlipX()
 		for(int y = 0; y < m_Height; y++)
 			for(int x = 0; x < m_Width; x++)
 				m_pTiles[y*m_Width+x].m_Flags ^= m_pTiles[y*m_Width+x].m_Flags&TILEFLAG_ROTATE ? TILEFLAG_HFLIP : TILEFLAG_VFLIP;
+
+	s_lastBrushX = -1;
+	s_lastBrushY = -1;
 }
 
 void CLayerTiles::BrushFlipY()
@@ -364,6 +367,9 @@ void CLayerTiles::BrushFlipY()
 		for(int y = 0; y < m_Height; y++)
 			for(int x = 0; x < m_Width; x++)
 				m_pTiles[y*m_Width+x].m_Flags ^= m_pTiles[y*m_Width+x].m_Flags&TILEFLAG_ROTATE ? TILEFLAG_VFLIP : TILEFLAG_HFLIP;
+
+	s_lastBrushX = -1;
+	s_lastBrushY = -1;
 }
 
 void CLayerTiles::BrushRotate(float Amount)
@@ -401,6 +407,9 @@ void CLayerTiles::BrushRotate(float Amount)
 		BrushFlipX();
 		BrushFlipY();
 	}
+
+	s_lastBrushX = -1;
+	s_lastBrushY = -1;
 }
 
 void CLayerTiles::Resize(int NewW, int NewH)
@@ -451,6 +460,9 @@ void CLayerTiles::Shift(int Direction)
 				mem_copy(&m_pTiles[y*m_Width], &m_pTiles[(y-1)*m_Width], m_Width*sizeof(CTile));
 		}
 	}
+
+	s_lastBrushX = -1;
+	s_lastBrushY = -1;
 }
 
 void CLayerTiles::ShowInfo()

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -230,6 +230,7 @@ void CLayerTiles::BrushSelecting(CUIRect Rect)
 	TextRender()->Text(0, Rect.x+3.0f, Rect.y+3.0f, m_pEditor->m_ShowTilePicker?15.0f:15.0f*m_pEditor->m_WorldZoom, aBuf, -1);
 }
 
+static int s_lastBrushX = -1, s_lastBrushY = -1;
 int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 {
 	RECTi r;
@@ -252,6 +253,8 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		for(int x = 0; x < r.w; x++)
 			pGrabbed->m_pTiles[y*pGrabbed->m_Width+x] = m_pTiles[(r.y+y)*m_Width+(r.x+x)];
 
+	s_lastBrushX = -1;
+	s_lastBrushY = -1;
 	return 1;
 }
 
@@ -295,7 +298,6 @@ void CLayerTiles::FillSelection(bool Empty, CLayer *pBrush, CUIRect Rect)
 	m_pEditor->m_Map.m_Modified = true;
 }
 
-static int s_lastBrushX = -1, s_lastBrushY = -1;
 void CLayerTiles::BrushDraw(CLayer *pBrush, float wx, float wy)
 {
 	if(m_Readonly)

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -287,7 +287,10 @@ void CLayerTiles::FillSelection(bool Empty, CLayer *pBrush, CUIRect Rect)
 	}
 
 	if(m_LiveAutoMap)
-		m_pEditor->m_Map.m_lImages[m_Image]->m_pAutoMapper->Proceed(this, m_SelectedRuleSet, {sx - 1, sy - 1, w + 2, h + 2});
+	{
+		RECTi r = {sx - 1, sy - 1, w + 2, h + 2};	
+		m_pEditor->m_Map.m_lImages[m_Image]->m_pAutoMapper->Proceed(this, m_SelectedRuleSet, r);
+	}
 
 	m_pEditor->m_Map.m_Modified = true;
 }
@@ -318,7 +321,10 @@ void CLayerTiles::BrushDraw(CLayer *pBrush, float wx, float wy)
 		}
 
 	if(m_LiveAutoMap)
-		m_pEditor->m_Map.m_lImages[m_Image]->m_pAutoMapper->Proceed(this, m_SelectedRuleSet, {sx - 1, sy - 1, l->m_Width + 2, l->m_Height + 2});
+	{
+		RECTi r = {sx - 1, sy - 1, l->m_Width + 2, l->m_Height + 2};
+		m_pEditor->m_Map.m_lImages[m_Image]->m_pAutoMapper->Proceed(this, m_SelectedRuleSet, r);
+	}
 
 	m_pEditor->m_Map.m_Modified = true;
 
@@ -499,7 +505,8 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 			{
 				if(m_pEditor->m_Map.m_lImages[m_Image]->m_pAutoMapper->GetType() == IAutoMapper::TYPE_TILESET)
 				{
-					m_pEditor->m_Map.m_lImages[m_Image]->m_pAutoMapper->Proceed(this, m_SelectedRuleSet, {0, 0, m_Width, m_Height});
+					RECTi r = {0, 0, m_Width, m_Height};
+					m_pEditor->m_Map.m_lImages[m_Image]->m_pAutoMapper->Proceed(this, m_SelectedRuleSet, r);
 					return 1; // only close the popup when it's a tileset
 				}
 				else if(m_pEditor->m_Map.m_lImages[m_Image]->m_pAutoMapper->GetType() == IAutoMapper::TYPE_DOODADS)

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -994,12 +994,31 @@ int CEditor::PopupSelectConfigAutoMap(CEditor *pEditor, CUIRect View)
 	{
 		View.HSplitTop(2.0f, 0, &View);
 		View.HSplitTop(12.0f, &Button, &View);
-		if(pEditor->DoButton_Editor(&s_AutoMapperConfigButtons[i], pEditor->m_Map.m_lImages[pLayer->m_Image]->m_pAutoMapper->GetRuleSetName(i), 0, &Button, 0, 0))
+		if(pEditor->DoButton_Editor(&s_AutoMapperConfigButtons[i], pEditor->m_Map.m_lImages[pLayer->m_Image]->m_pAutoMapper->GetRuleSetName(i), pLayer->m_LiveAutoMap && pLayer->m_SelectedRuleSet == i, &Button, 0, 0))
 		{
 			pLayer->m_SelectedRuleSet = i;
-			s_AutoMapProceedOrder = true;
+			if(!pLayer->m_LiveAutoMap)
+				s_AutoMapProceedOrder = true;
 			break;
 		}
+	}
+
+	View.HSplitTop(2.0f, 0, &View);
+
+	static int s_aIds[2] = {0};
+
+	CUIRect Label, Full, Live;
+	View.VSplitMid(&Label, &View);
+	pEditor->UI()->DoLabel(&Label, "Type", 10.0f, CUI::ALIGN_LEFT);
+
+	View.VSplitMid(&Full, &Live);
+	if(pEditor->DoButton_ButtonDec(&s_aIds[0], "Full", !pLayer->m_LiveAutoMap, &Full, 0, ""))
+	{
+		pLayer->m_LiveAutoMap = false;
+	}
+	if(pEditor->DoButton_ButtonInc(((char *)&s_aIds[0])+1, "Live", pLayer->m_LiveAutoMap, &Live, 0, ""))
+	{
+		pLayer->m_LiveAutoMap = true;
 	}
 
 	return 0;
@@ -1014,7 +1033,7 @@ void CEditor::PopupSelectConfigAutoMapInvoke(float x, float y)
 		m_Map.m_lImages[pLayer->m_Image]->m_pAutoMapper->RuleSetNum())
 	{
 		if(m_Map.m_lImages[pLayer->m_Image]->m_pAutoMapper->GetType() == IAutoMapper::TYPE_TILESET)
-			UiInvokePopupMenu(&s_AutoMapConfigSelectID, 0, x, y, 120.0f, 12.0f+14.0f*m_Map.m_lImages[pLayer->m_Image]->m_pAutoMapper->RuleSetNum(), PopupSelectConfigAutoMap);
+			UiInvokePopupMenu(&s_AutoMapConfigSelectID, 0, x, y, 120.0f, 12.0f+14.0f*m_Map.m_lImages[pLayer->m_Image]->m_pAutoMapper->RuleSetNum()+14.0f, PopupSelectConfigAutoMap);
 		else if(m_Map.m_lImages[pLayer->m_Image]->m_pAutoMapper->GetType() == IAutoMapper::TYPE_DOODADS)
 			UiInvokePopupMenu(&s_AutoMapConfigSelectID, 0, x, y, 120.0f, 60.0f, PopupDoodadAutoMap);
 	}


### PR DESCRIPTION
Here's something that makes mapping more interesting. It should also help new mappers.

The way it works is you select the layer you want to enable live mapping on, you click on Auto map then choose the "Live" Type and select the automap rule to use. It will then automap around the area where new tiles are placed/removed by hand or with the fill tool.

Here it is in action :

![liveautomap](https://user-images.githubusercontent.com/5041807/56059164-72a97680-5d31-11e9-9c80-7c1b6215985f.gif)
