### PR TITLE
(#2085) Introduce AxisTolerance for Joystick

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -106,34 +106,25 @@ void CInput::MouseRelative(float *x, float *y)
 
 	SDL_GetRelativeMouseState(&nx,&ny);
 
-	float jx = 0.0f;
-	float jy = 0.0f;
+	vec2 j = vec2(0.0f, 0.0f);
 
 	if(m_pJoystick)
 	{
 		const float Max = 50.0f;
-		jx = static_cast<float>(SDL_JoystickGetAxis(m_pJoystick, g_Config.m_JoystickX)) / 32768.0f * Max;
-		jy = static_cast<float>(SDL_JoystickGetAxis(m_pJoystick, g_Config.m_JoystickY)) / 32768.0f * Max;
+		j.x = static_cast<float>(SDL_JoystickGetAxis(m_pJoystick, g_Config.m_JoystickX)) / 32768.0f * Max;
+		j.y = static_cast<float>(SDL_JoystickGetAxis(m_pJoystick, g_Config.m_JoystickY)) / 32768.0f * Max;
+		const float Len = length(j);
 
-		float len = sqrtf(jx * jx + jy * jy);
-		float njx = jx / len;
-		float njy = jy / len;
-
-		len = fminf(len, Max);
-		jx = njx * len;
-		jy = njy * len;
-
-		if (len <= g_Config.m_AxisTolerance) {
-			jx = 0.0f;
-			jy = 0.0f;
+		if (Len <= g_Config.m_AxisTolerance) {
+			j = vec2(0.0f, 0.0f);
 		} else {
-			jx -= njx * g_Config.m_AxisTolerance;
-			jy -= njy * g_Config.m_AxisTolerance;
+			const vec2 nj = Len > 0.0f ? j / Len : vec2(0.0f, 0.0f);
+			j = nj * fminf(Len, Max) - nj * g_Config.m_AxisTolerance;
 		}
 	}
 
-	*x = (nx + jx)*Sens;
-	*y = (ny + jy)*Sens;
+	*x = (nx + j.x)*Sens;
+	*y = (ny + j.y)*Sens;
 }
 
 void CInput::MouseModeAbsolute()

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -115,11 +115,11 @@ void CInput::MouseRelative(float *x, float *y)
 		j.y = static_cast<float>(SDL_JoystickGetAxis(m_pJoystick, g_Config.m_JoystickY)) / 32768.0f * Max;
 		const float Len = length(j);
 
-		if (Len <= g_Config.m_AxisTolerance) {
+		if (Len <= g_Config.m_JoystickTolerance) {
 			j = vec2(0.0f, 0.0f);
 		} else {
 			const vec2 nj = Len > 0.0f ? j / Len : vec2(0.0f, 0.0f);
-			j = nj * fminf(Len, Max) - nj * g_Config.m_AxisTolerance;
+			j = nj * fminf(Len, Max) - nj * g_Config.m_JoystickTolerance;
 		}
 	}
 

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -111,8 +111,25 @@ void CInput::MouseRelative(float *x, float *y)
 
 	if(m_pJoystick)
 	{
-		jx = static_cast<float>(SDL_JoystickGetAxis(m_pJoystick, g_Config.m_JoystickX)) / 32768.0f * 50.0f;
-		jy = static_cast<float>(SDL_JoystickGetAxis(m_pJoystick, g_Config.m_JoystickY)) / 32768.0f * 50.0f;
+		const float Max = 50.0f;
+		jx = static_cast<float>(SDL_JoystickGetAxis(m_pJoystick, g_Config.m_JoystickX)) / 32768.0f * Max;
+		jy = static_cast<float>(SDL_JoystickGetAxis(m_pJoystick, g_Config.m_JoystickY)) / 32768.0f * Max;
+
+		float len = sqrtf(jx * jx + jy * jy);
+		float njx = jx / len;
+		float njy = jy / len;
+
+		len = fminf(len, Max);
+		jx = njx * len;
+		jy = njy * len;
+
+		if (len <= g_Config.m_AxisTolerance) {
+			jx = 0.0f;
+			jy = 0.0f;
+		} else {
+			jx -= njx * g_Config.m_AxisTolerance;
+			jy -= njy * g_Config.m_AxisTolerance;
+		}
 	}
 
 	*x = (nx + jx)*Sens;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -67,7 +67,7 @@ MACRO_CONFIG_INT(InpMousesens, inp_mousesens, 100, 5, 100000, CFGFLAG_SAVE|CFGFL
 
 MACRO_CONFIG_INT(JoystickX, joystick_x, 0, 0, 6, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick Axis that controls X axis of mouse")
 MACRO_CONFIG_INT(JoystickY, joystick_y, 1, 0, 6, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick Axis that controls Y axis of mouse")
-MACRO_CONFIG_INT(AxisTolerance, axis_tolerance, 5, 0, 50, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick Axis tolerance to account for jitter")
+MACRO_CONFIG_INT(JoystickTolerance, joystick_tolerance, 5, 0, 50, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick Axis tolerance to account for jitter")
 
 MACRO_CONFIG_STR(SvName, sv_name, 128, "unnamed server", CFGFLAG_SAVE|CFGFLAG_SERVER, "Server name")
 MACRO_CONFIG_STR(SvHostname, sv_hostname, 128, "", CFGFLAG_SAVE|CFGFLAG_SERVER, "Server hostname")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -67,6 +67,7 @@ MACRO_CONFIG_INT(InpMousesens, inp_mousesens, 100, 5, 100000, CFGFLAG_SAVE|CFGFL
 
 MACRO_CONFIG_INT(JoystickX, joystick_x, 0, 0, 6, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick Axis that controls X axis of mouse")
 MACRO_CONFIG_INT(JoystickY, joystick_y, 1, 0, 6, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick Axis that controls Y axis of mouse")
+MACRO_CONFIG_INT(AxisTolerance, axis_tolerance, 5, 0, 50, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick Axis tolerance to account for jitter")
 
 MACRO_CONFIG_STR(SvName, sv_name, 128, "unnamed server", CFGFLAG_SAVE|CFGFLAG_SERVER, "Server name")
 MACRO_CONFIG_STR(SvHostname, sv_hostname, 128, "", CFGFLAG_SAVE|CFGFLAG_SERVER, "Server hostname")


### PR DESCRIPTION
A possible solution for #2085 

- Introduced `AxisTolerance` config variable. Can be changed only in the console right now. It has range `[0 .. 50]`. The higher the value, the more tilt the stick requires to move the cursor. It's basically a radius of the deadzone. Default value is 5.
- I'd like to ask @EbrahimBGA or @LordSk to test this solution on their side and verify if it fixes their problem and what is the optimal tolerance level for them.