### PR TITLE
Fix winter dark and grass main automap rules

### DIFF
--- a/datasrc/editor/automap/grass_main.json
+++ b/datasrc/editor/automap/grass_main.json
@@ -75,7 +75,7 @@
 			{
 				"index": 20,
 				"condition": [
-					{"x": -1, "y": 0, "value": "empty"},
+					{"x": -1, "y": 0, "value": "empty"}
 				]
 			},
 			{
@@ -143,8 +143,7 @@
 				"condition": [
 					{"x": -1, "y": 0, "value": "empty"},
 					{"x": -1, "y": 1, "value": "full"},
-					{"x": 0, "y": 1, "value": 48},
-					{"x": 0, "y": -1, "value": 4}
+					{"x": 0, "y": 1, "value": "full"}
 				]
 			},
 			{
@@ -153,88 +152,6 @@
 					{"x": 1, "y": 0, "value": "empty"},
 					{"x": 1, "y": 1, "value": "full"},
 					{"x": 0, "y": 1, "value": "full"}
-				]
-			},
-			{
-				"index": 101,
-				"condition": [
-					{"x": 0, "y": -1, "value": "empty"},
-					{"x": 0, "y": 1, "value": "empty"}
-				]
-			},
-			{
-				"index": 100,
-				"condition": [
-					{"x": 0, "y": -1, "value": "empty"},
-                    {"x": -1, "y": 0, "value": "empty"},
-                    {"x": 1, "y": 0, "value": "full"},
-                    {"x": 0, "y": 1, "value": "empty"},
-				]
-			},
-			{
-				"index": 102,
-				"condition": [
-					{"x": 0, "y": -1, "value": "empty"},
-                    {"x": 1, "y": 0, "value": "empty"},
-                    {"x": -1, "y": 0, "value": "full"},
-                    {"x": 0, "y": 1, "value": "empty"},
-				]
-			},
-			{
-				"index": 117,
-				"condition": [
-					{"x": 1, "y": 0, "value": "empty"},
-                    {"x": -1, "y": 0, "value": "empty"},
-				]
-			},
-			{
-				"index": 116,
-				"condition": [
-					{"x": 1, "y": 0, "value": "empty"},
-                    {"x": -1, "y": 0, "value": "empty"},
-                    {"x": 0, "y": 1, "value": "full"},
-                    {"x": 0, "y": -1, "value": "empty"},
-				]
-			},
-			{
-				"index": 118,
-				"condition": [
-					{"x": 1, "y": 0, "value": "empty"},
-                    {"x": -1, "y": 0, "value": "empty"},
-                    {"x": 0, "y": -1, "value": "full"},
-                    {"x": 0, "y": 1, "value": "empty"},
-				]
-			},
-			{
-				"index": 128,
-				"condition": [
-					{"x": 1, "y": 0, "value": "full"},
-                    {"x": -1, "y": 0, "value": "empty"},
-                    {"x": 0, "y": -1, "value": "empty"},
-                    {"x": 0, "y": 1, "value": "full"},
-                    {"x": 1, "y": 1, "value": "empty"},
-				]
-			},
-			{
-				"index": 166,
-				"condition": [
-					{"x": 1, "y": 0, "value": "full"},
-                    {"x": -1, "y": 0, "value": "full"},
-                    {"x": 0, "y": -1, "value": "full"},
-                    {"x": 0, "y": 1, "value": "full"},
-                    {"x": -1, "y": 1, "value": "empty"},
-                    {"x": -1, "y": -1, "value": "empty"},
-				]
-			},
-			{
-				"index": 150,
-				"condition": [
-					{"x": 1, "y": 0, "value": "full"},
-                    {"x": -1, "y": 0, "value": "full"},
-                    {"x": 0, "y": -1, "value": "full"},
-                    {"x": 0, "y": 1, "value": "full"},
-                    {"x": 1, "y": 1, "value": "empty"},
-                    {"x": -1, "y": -1, "value": "empty"},
 				]
 			},
 			{
@@ -251,6 +168,344 @@
 					{"x": 0, "y": -1, "value": "empty"},
 					{"x": -1, "y": 0, "value": "empty"},
 					{"x": -1, "y": 1, "value": "full"}
+				]
+			},
+			{
+				"index": 101,
+				"condition": [
+					{"x": 0, "y": -1, "value": "empty"},
+					{"x": 0, "y": 1, "value": "empty"}
+				]
+			},
+			{
+				"index": 96,
+				"condition": [
+					{"x": 1, "y": 1, "value": "empty"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "empty"},
+					{"x": 0, "y": 1, "value": "full"}
+				]
+			},
+			{
+				"index": 97,
+				"condition": [
+					{"x": -1, "y": 1, "value": "empty"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 1, "y": 0, "value": "empty"},
+					{"x": 0, "y": 1, "value": "full"}
+				]
+			},
+			{
+				"index": 98,
+				"condition": [
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "empty"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 1, "y": 1, "value": "empty"}
+				]
+			},
+			{
+				"index": 99,
+				"condition": [
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "empty"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": -1, "y": 1, "value": "empty"}
+				]
+			},
+			{
+				"index": 129,
+				"condition": [
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "empty"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 1, "y": 1, "value": "empty"},					
+					{"x": -1, "y": 1, "value": "empty"}
+				]
+			},
+			{
+				"index": 100,
+				"condition": [
+					{"x": 0, "y": -1, "value": "empty"},
+					{"x": -1, "y": 0, "value": "empty"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": 0, "y": 1, "value": "empty"}
+				]
+			},
+			{
+				"index": 102,
+				"condition": [
+					{"x": 0, "y": -1, "value": "empty"},
+					{"x": 1, "y": 0, "value": "empty"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 0, "y": 1, "value": "empty"}
+				]
+			},
+			{
+				"index": 112,
+				"condition": [
+					{"x": 1, "y": -1, "value": "empty"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "empty"},
+					{"x": 0, "y": -1, "value": "full"}
+				]
+			},
+			{
+				"index": 144,
+				"condition": [
+					{"x": 1, "y": -1, "value": "empty"},
+					{"x": 1, "y": 1, "value": "empty"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "empty"},
+					{"x": 0, "y": -1, "value": "full"}
+				]
+			},
+			{
+				"index": 113,
+				"condition": [
+					{"x": -1, "y": -1, "value": "empty"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 1, "y": 0, "value": "empty"},
+					{"x": 0, "y": -1, "value": "full"}
+				]
+			},
+			{
+				"index": 146,
+				"condition": [
+					{"x": -1, "y": -1, "value": "empty"},
+					{"x": -1, "y": 1, "value": "empty"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 1, "y": 0, "value": "empty"},
+					{"x": 0, "y": -1, "value": "full"}
+				]
+			},
+			{
+				"index": 114,
+				"condition": [
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "empty"},
+					{"x": 1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 115,
+				"condition": [
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "empty"},
+					{"x": -1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 117,
+				"condition": [
+					{"x": 1, "y": 0, "value": "empty"},
+					{"x": -1, "y": 0, "value": "empty"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"}
+				]
+			},
+			{
+				"index": 116,
+				"condition": [
+					{"x": 1, "y": 0, "value": "empty"},
+					{"x": -1, "y": 0, "value": "empty"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 0, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 118,
+				"condition": [
+					{"x": 1, "y": 0, "value": "empty"},
+					{"x": -1, "y": 0, "value": "empty"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "empty"}
+				]
+			},
+			{
+				"index": 128,
+				"condition": [
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "empty"},
+					{"x": 0, "y": -1, "value": "empty"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 1, "y": 1, "value": "empty"}
+				]
+			},
+			{
+				"index": 130,
+				"condition": [
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 0, "y": -1, "value": "empty"},
+					{"x": 1, "y": 0, "value": "empty"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": -1, "y": 1, "value": "empty"}
+				]
+			},
+			{
+				"index": 160,
+				"condition": [
+					{"x": 0, "y": 1, "value": "empty"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "empty"},
+					{"x": 1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 162,
+				"condition": [
+					{"x": 0, "y": 1, "value": "empty"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 1, "y": 0, "value": "empty"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": -1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 133,
+				"condition": [
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 1, "y": 1, "value": "empty"},
+					{"x": -1, "y": 1, "value": "empty"}
+				]
+			},
+			{
+				"index": 149,
+				"condition": [
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": -1, "y": -1, "value": "empty"},
+					{"x": 1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 165,
+				"condition": [
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 1, "y": 1, "value": "empty"},
+					{"x": 1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 166,
+				"condition": [
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": -1, "y": 1, "value": "empty"},
+					{"x": -1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 150,
+				"condition": [
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 1, "y": 1, "value": "empty"},
+					{"x": -1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 150,
+				"hflip" : 1,
+				"condition": [
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": -1, "y": 1, "value": "empty"},
+					{"x": 1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 147,
+				"condition": [
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 1, "y": 1, "value": "empty"},
+					{"x": -1, "y": -1, "value": "empty"},
+					{"x": 1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 148,
+				"condition": [
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": -1, "y": 1, "value": "empty"},
+					{"x": -1, "y": -1, "value": "empty"},
+					{"x": 1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 163,
+				"condition": [
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 1, "y": 1, "value": "empty"},
+					{"x": -1, "y": 1, "value": "empty"},
+					{"x": 1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 164,
+				"condition": [
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 1, "y": 1, "value": "empty"},
+					{"x": -1, "y": -1, "value": "empty"},
+					{"x": -1, "y": 1, "value": "empty"}
+				]
+			},
+			{
+				"index": 145,
+				"condition": [
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "full"},
+					{"x": 1, "y": 1, "value": "empty"},
+					{"x": -1, "y": -1, "value": "empty"},
+					{"x": -1, "y": 1, "value": "empty"},
+					{"x": 1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 161,
+				"condition": [
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 0, "y": 1, "value": "empty"},
+					{"x": -1, "y": -1, "value": "empty"},
+					{"x": 1, "y": -1, "value": "empty"}
 				]
 			}]
 		}

--- a/datasrc/editor/automap/winter_main.json
+++ b/datasrc/editor/automap/winter_main.json
@@ -7,125 +7,125 @@
 			{
 				"index": 17,
 				"condition": [
-					{"x": 0, "y":-1, "value": "empty"},
-				],
+					{"x": 0, "y":-1, "value": "empty"}
+				]
 			},
 			{
 				"index": 18,
 				"condition": [
 					{"x": 0, "y":-1, "value": "empty"},
-					{"x": -1, "y":0, "value": 17},
-				],
+					{"x": -1, "y":0, "value": 17}
+				]
 			},
 			{
 				"index": 19,
 				"condition": [
 					{"x": 0, "y":-1, "value": "empty"},
-					{"x": -1, "y":0, "value": 18},
-				],
+					{"x": -1, "y":0, "value": 18}
+				]
 			},
 			{
 				"index": 97,
 				"condition": [
-					{"x": 0, "y":1, "value": "empty"},
-				],
+					{"x": 0, "y":1, "value": "empty"}
+				]
 			},
 			{
 				"index": 98,
 				"condition": [
 					{"x": 0, "y":1, "value": "empty"},
-					{"x": -1, "y":0, "value": 97},
-				],
+					{"x": -1, "y":0, "value": 97}
+				]
 			},
 			{
 				"index": 99,
 				"condition": [
 					{"x": 0, "y":1, "value": "empty"},
-					{"x": -1, "y":0, "value": 98},
-				],
+					{"x": -1, "y":0, "value": 98}
+				]
 			},
 			{
 				"index": 2,
 				"hflip": 1,
 				"condition": [
-					{"x": 1, "y":0, "value": "empty"},
-				],
+					{"x": 1, "y":0, "value": "empty"}
+				]
 			},
 			{
 				"index": 2,
 				"condition": [
-					{"x": -1, "y":0, "value": "empty"},
-				],
+					{"x": -1, "y":0, "value": "empty"}
+				]
 			},
 			{
 				"index": 20,
 				"condition": [
 					{"x": 0, "y":-1, "value": "empty"},
-					{"x": 1, "y":0, "value": "empty"},
-				],
+					{"x": 1, "y":0, "value": "empty"}
+				]
 			},
 			{
 				"index": 8,
 				"condition": [
 					{"x": 0, "y":1, "value": "full"},
 					{"x": -1, "y":0, "value": "full"},
-					{"x": -1, "y":1, "value": "empty"},
-				],
+					{"x": -1, "y":1, "value": "empty"}
+				]
 			},
 			{
 				"index": 7,
 				"condition": [
 					{"x": 0, "y":1, "value": "full"},
 					{"x": 1, "y":0, "value": "full"},
-					{"x": 1, "y":1, "value": "empty"},
-				],
+					{"x": 1, "y":1, "value": "empty"}
+				]
 			},
 			{
 				"index": 4,
 				"condition": [
 					{"x": 0, "y":-1, "value": "full"},
 					{"x": -1, "y":0, "value": "full"},
-					{"x": -1, "y":-1, "value": "empty"},
-				],
+					{"x": -1, "y":-1, "value": "empty"}
+				]
 			},
 			{
 				"index": 3,
 				"condition": [
 					{"x": 0, "y":-1, "value": "full"},
 					{"x": 1, "y":0, "value": "full"},
-					{"x": 1, "y":-1, "value": "empty"},
-				],
+					{"x": 1, "y":-1, "value": "empty"}
+				]
 			},
 			{
 				"index": 113,
 				"condition": [
 					{"x": 0, "y":1, "value": "empty"},
-					{"x": 0, "y":-1, "value": "empty"},
-				],
+					{"x": 0, "y":-1, "value": "empty"}
+				]
 			},
 			{
 				"index": 114,
 				"condition": [
 					{"x": 0, "y":1, "value": "empty"},
 					{"x": 0, "y":-1, "value": "empty"},
-					{"x": -1, "y":0, "value": 113},
-				],
+					{"x": -1, "y":0, "value": 113}
+				]
 			},
 			{
 				"index": 115,
 				"condition": [
 					{"x": 0, "y":1, "value": "empty"},
 					{"x": 0, "y":-1, "value": "empty"},
-					{"x": -1, "y":0, "value": 114},
-				],
+					{"x": -1, "y":0, "value": 114}
+				]
 			},
 			{
 				"index": 116,
 				"condition": [
 					{"x": 0, "y":1, "value": "empty"},
 					{"x": 0, "y":-1, "value": "empty"},
-					{"x": 1, "y":0, "value": "empty"},
-				],
+					{"x": 1, "y":0, "value": "empty"}
+				]
 			},
 			{
 				"index": 120,
@@ -133,16 +133,16 @@
 					{"x": 0, "y":1, "value": "empty"},
 					{"x": 0, "y":-1, "value": "empty"},
 					{"x": 1, "y":0, "value": "empty"},
-					{"x": -1, "y":0, "value": 113},
-				],
+					{"x": -1, "y":0, "value": 113}
+				]
 			},
 			{
 				"index": 112,
 				"condition": [
 					{"x": 0, "y":1, "value": "empty"},
 					{"x": 0, "y":-1, "value": "empty"},
-					{"x": -1, "y":0, "value": "empty"},
-				],
+					{"x": -1, "y":0, "value": "empty"}
+				]
 			},
 			{
 				"index": 6,
@@ -150,8 +150,8 @@
 					{"x": -1, "y":-1, "value": "empty"},
 					{"x": -1, "y":0, "value": "full"},
 					{"x": 0, "y":-1, "value": "full"},
-					{"x": -1, "y":1, "value": "empty"},
-				],
+					{"x": -1, "y":1, "value": "empty"}
+				]
 			},
 			{
 				"index": 5,
@@ -159,7 +159,7 @@
 					{"x": 1, "y":-1, "value": "empty"},
 					{"x": 1, "y":0, "value": "full"},
 					{"x": 0, "y":-1, "value": "full"},
-					{"x": 1, "y":1, "value": "empty"},
+					{"x": 1, "y":1, "value": "empty"}
 				]
 			},
 			{
@@ -167,99 +167,148 @@
 				"condition": [
 					{"x": 0, "y":-1, "value": "empty"},
 					{"x": 1, "y":0, "value": "empty"},
-					{"x": -1, "y":0, "value": 17},
-				],
+					{"x": -1, "y":0, "value": 17}
+				]
 			},
 			{
 				"index": 16,
 				"condition": [
 					{"x": 0, "y":-1, "value": "empty"},
-					{"x": -1, "y":0, "value": "empty"},
-				],
+					{"x": -1, "y":0, "value": "empty"}
+				]
 			},
 			{
 				"index": 100,
 				"condition": [
 					{"x": 0, "y":1, "value": "empty"},
-					{"x": 1, "y":0, "value": "empty"},
-				],
+					{"x": 1, "y":0, "value": "empty"}
+				]
 			},
 			{
 				"index": 96,
 				"condition": [
 					{"x": 0, "y":1, "value": "empty"},
-					{"x": -1, "y":0, "value": "empty"},
-				],
+					{"x": -1, "y":0, "value": "empty"}
+				]
 			}]			
 		}
 	},
 	{"winter dark":
 		{
-			"basetile": 177,
+			"basetile": 160,
 
 			"rules": [
+			{
+				"index": 177,
+				"vflip" : 1,
+				"condition": [
+					{"x": 0, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 178,
+				"vflip" : 1,
+				"condition": [
+					{"x": 0, "y": -1, "value": "empty"},
+					{"x": -1, "y": 0, "value": 177}
+				]
+			},
+			{
+				"index": 193,
+				"condition": [
+					{"x": 0, "y": 1, "value": "empty"}
+				]
+			},
 			{
 				"index": 194,
 				"condition": [
 					{"x": 0, "y": 1, "value": "empty"},
-				],
+					{"x": -1, "y": 0, "value": 193}
+				]
 			},
 			{
 				"index": 195,
 				"condition": [
 					{"x": 0, "y": 1, "value": "empty"},
-					{"x": -1, "y": 0, "value": 194},
-				],
+					{"x": -1, "y": 0, "value": 194}
+				]
+			},
+			{
+				"index": 161,
+				"hflip": 1,
+				"condition": [
+					{"x": 1, "y": 0, "value": "empty"}
+				]
+			},
+			{
+				"index": 161,
+				"condition": [
+					{"x": -1, "y": 0, "value": "empty"}
+				]
+			},
+			{
+				"index": 196,
+				"vflip" : 1,
+				"condition": [
+					{"x": 0, "y": -1, "value": "empty"},
+					{"x": 1, "y": 0, "value": "empty"}
+				]
+			},
+			{
+				"index": 192,
+				"vflip" : 1,
+				"condition": [
+					{"x": 0, "y": -1, "value": "empty"},
+					{"x": -1, "y": 0, "value": "empty"}
+				]
 			},
 			{
 				"index": 196,
 				"condition": [
 					{"x": 0, "y": 1, "value": "empty"},
-					{"x": -1, "y": 0, "value": 195},
-				],
+					{"x": 1, "y": 0, "value": "empty"}
+				]
 			},
 			{
-				"index": 178,
-				"hflip": 1,
-				"condition": [
-					{"x": 1, "y": 0, "value": "empty"},
-				],
-			},
-			{
-				"index": 178,
-				"condition": [
-					{"x": -1, "y": 0, "value": "empty"},
-				],
-			},
-			{
-				"index": 197,
+				"index": 192,
 				"condition": [
 					{"x": 0, "y": 1, "value": "empty"},
-					{"x": 1, "y": 0, "value": "empty"},
-				],
+					{"x": -1, "y": 0, "value": "empty"}
+				]
 			},
 			{
-				"index": 193,
+				"index": 163,
+				"vflip": 1,
 				"condition": [
-					{"x": 0, "y": 1, "value": "empty"},
-					{"x": -1, "y": 0, "value": "empty"},
-				],
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": -1, "y": 0, "value": "full"},
+					{"x": -1, "y": -1, "value": "empty"}
+				]
 			},
 			{
-				"index": 180,
+				"index": 162,
+				"vflip": 1,
+				"condition": [
+					{"x": 0, "y": -1, "value": "full"},
+					{"x": 1, "y": 0, "value": "full"},
+					{"x": 1, "y": -1, "value": "empty"}
+				]
+			},
+			{
+				"index": 163,
 				"condition": [
 					{"x": 0, "y": 1, "value": "full"},
 					{"x": -1, "y": 0, "value": "full"},
-					{"x": -1, "y": 1, "value": "empty"},
-				],
+					{"x": -1, "y": 1, "value": "empty"}
+				]
 			},
 			{
-				"index": 179,
+				"index": 162,
 				"condition": [
 					{"x": 0, "y": 1, "value": "full"},
 					{"x": 1, "y": 0, "value": "full"},
-					{"x": 1, "y": 1, "value": "empty"},
-				],
+					{"x": 1, "y": 1, "value": "empty"}
+				]
 			}]			
 		}
 	}]


### PR DESCRIPTION
All the rules I could think of are in there. Unfortunately, some tiles in grass_main link bad together even if they are the one that should be there. Those tiles are 114, 115, 150, 163, 164, 165 and 166. To fix that, those tiles would need to have the same grass corner as tiles 48-51.

Fixes #2089 