### PR TITLE
Implement statboard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1341,6 +1341,8 @@ if(CLIENT)
     components/sounds.h
     components/spectator.cpp
     components/spectator.h
+    components/stats.cpp
+    components/stats.h
     components/voting.cpp
     components/voting.h
     gameclient.cpp

--- a/src/game/client/animstate.h
+++ b/src/game/client/animstate.h
@@ -3,6 +3,8 @@
 #ifndef GAME_CLIENT_ANIMSTATE_H
 #define GAME_CLIENT_ANIMSTATE_H
 
+#include <generated/client_data.h>
+
 class CAnimState
 {
 	CAnimKeyframe m_Body;

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -15,7 +15,7 @@ const int CBinds::s_aaDefaultBindKeys[][2] = {
 	{'r', 0},
 };
 const char CBinds::s_aaDefaultBindValues[][32] = {
-	"toggle_local_console", "toggle_remote_console", "+scoreboard", "+stats 1", "+show_chat", "screenshot", "snd_toggle",
+	"toggle_local_console", "toggle_remote_console", "+scoreboard", "+stats", "+show_chat", "screenshot", "snd_toggle",
 	"+left", "+right",
 	"+jump", "+fire", "+hook", "+emote", "+spectate", "spectate_next", "spectate_previous",
 	"+weapon1", "+weapon2", "+weapon3", "+weapon4", "+weapon5",

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -5,7 +5,7 @@
 #include "binds.h"
 
 const int CBinds::s_aaDefaultBindKeys[][2] = {
-	{KEY_F1, 0}, {KEY_F2, 0}, {KEY_TAB, 0}, {'u', 0}, {KEY_F10, 0}, {'s', CBinds::MODIFIER_CTRL},
+	{KEY_F1, 0}, {KEY_F2, 0}, {KEY_TAB, 0}, {'e', 0}, {'u', 0}, {KEY_F10, 0}, {'s', CBinds::MODIFIER_CTRL},
 	{'a', 0}, {'d', 0},
 	{KEY_SPACE, 0}, {KEY_MOUSE_1, 0}, {KEY_MOUSE_2, 0}, {KEY_LSHIFT, 0}, {KEY_RSHIFT, 0}, {KEY_RIGHT, 0}, {KEY_LEFT, 0},
 	{'1', 0}, {'2', 0}, {'3', 0}, {'4', 0}, {'5', 0},
@@ -15,7 +15,7 @@ const int CBinds::s_aaDefaultBindKeys[][2] = {
 	{'r', 0},
 };
 const char CBinds::s_aaDefaultBindValues[][32] = {
-	"toggle_local_console", "toggle_remote_console", "+scoreboard", "+show_chat", "screenshot", "snd_toggle",
+	"toggle_local_console", "toggle_remote_console", "+scoreboard", "+stats 1", "+show_chat", "screenshot", "snd_toggle",
 	"+left", "+right",
 	"+jump", "+fire", "+hook", "+emote", "+spectate", "spectate_next", "spectate_previous",
 	"+weapon1", "+weapon2", "+weapon3", "+weapon4", "+weapon5",

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -672,6 +672,7 @@ private:
 	void RenderSettingsControls(CUIRect MainView);
 	void RenderSettingsGraphics(CUIRect MainView);
 	void RenderSettingsSound(CUIRect MainView);
+	void RenderSettingsStats(CUIRect MainView);
 	void RenderSettings(CUIRect MainView);
 
 	bool DoResolutionList(CUIRect* pRect, CListBoxState* pListBoxState,
@@ -682,6 +683,8 @@ private:
 	static float RenderSettingsControlsWeapon(CUIRect View, void *pUser);
 	static float RenderSettingsControlsVoting(CUIRect View, void *pUser);
 	static float RenderSettingsControlsChat(CUIRect View, void *pUser);
+	static float RenderSettingsControlsScoreboard(CUIRect View, void *pUser);
+	static float RenderSettingsControlsStats(CUIRect View, void *pUser);
 	static float RenderSettingsControlsMisc(CUIRect View, void *pUser);
 
 	void SetActive(bool Active);

--- a/src/game/client/components/menus_callback.cpp
+++ b/src/game/client/components/menus_callback.cpp
@@ -34,6 +34,8 @@ static CKeyInfo gs_aKeys[] =
 	{ "Team chat", "chat team", 0, 0},
 	{ "Whisper", "chat whisper", 0, 0},
 	{ "Show chat", "+show_chat", 0, 0},
+	{ "Scoreboard", "+scoreboard", 0, 0},
+	{ "Statboard", "+stats 1", 0, 0},
 	{ "Emoticon", "+emote", 0, 0},
 	{ "Spectator mode", "+spectate", 0, 0},
 	{ "Spectate next", "spectate_next", 0, 0},
@@ -41,7 +43,6 @@ static CKeyInfo gs_aKeys[] =
 	{ "Console", "toggle_local_console", 0, 0},
 	{ "Remote console", "toggle_remote_console", 0, 0},
 	{ "Screenshot", "screenshot", 0, 0},
-	{ "Scoreboard", "+scoreboard", 0, 0},
 	{ "Respawn", "kill", 0, 0},
 	{ "Ready", "ready_change", 0, 0},
 	{ "Add demo marker", "add_demomarker", 0, 0},
@@ -53,7 +54,7 @@ static CKeyInfo gs_aKeys[] =
 	Localize("Pistol");Localize("Shotgun");Localize("Grenade");Localize("Laser");Localize("Next weapon");Localize("Prev. weapon");
 	Localize("Vote yes");Localize("Vote no");Localize("Chat");Localize("Team chat");Localize("Whisper");Localize("Show chat");Localize("Emoticon");
 	Localize("Spectator mode");Localize("Spectate next");Localize("Spectate previous");Localize("Console");Localize("Remote console");
-	Localize("Screenshot");Localize("Scoreboard");Localize("Respawn");Localize("Ready");Localize("Add demo marker");
+	Localize("Screenshot");Localize("Scoreboard");Localize("Statboard");Localize("Respawn");Localize("Ready");Localize("Add demo marker");
 */
 
 const int g_KeyCount = sizeof(gs_aKeys) / sizeof(CKeyInfo);
@@ -271,6 +272,56 @@ float CMenus::RenderSettingsControlsChat(CUIRect View, void *pUser)
 	return BackgroundHeight;
 }
 
+float CMenus::RenderSettingsControlsScoreboard(CUIRect View, void *pUser)
+{
+	CMenus *pSelf = (CMenus*)pUser;
+
+	// this is kinda slow, but whatever
+	for(int i = 0; i < g_KeyCount; i++)
+	{
+		gs_aKeys[i].m_KeyId = 0;
+		gs_aKeys[i].m_Modifier = 0;
+	}
+
+	for(int KeyId = 0; KeyId < KEY_LAST; KeyId++)
+	{
+		for(int m = 0; m < CBinds::MODIFIER_COUNT; m++)
+		{
+			const char *pBind = pSelf->m_pClient->m_pBinds->Get(KeyId, m);
+			if(!pBind[0])
+				continue;
+
+			for(int i = 0; i < g_KeyCount; i++)
+				if(str_comp(pBind, gs_aKeys[i].m_pCommand) == 0)
+				{
+					gs_aKeys[i].m_KeyId = KeyId;
+					gs_aKeys[i].m_Modifier = m;
+					break;
+				}
+		}
+	}
+
+	int NumOptions = 2;
+	int StartOption = 18;
+	float ButtonHeight = 20.0f;
+	float Spaceing = 2.0f;
+	float BackgroundHeight = (float)NumOptions*ButtonHeight+(float)NumOptions*Spaceing;
+
+	View.HSplitTop(BackgroundHeight, &View, 0);
+	pSelf->RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
+
+	pSelf->UiDoGetButtons(StartOption, StartOption+2, View, ButtonHeight, Spaceing);
+
+	View.HSplitTop(ButtonHeight*2+Spaceing*3, 0, &View);
+	View.VSplitLeft(View.w/3, 0, &View);
+	View.VSplitRight(View.w/2, &View, 0);
+	static int s_StatboardConfigDropdown = 0;
+	static bool s_StatboardConfigActive = false;
+	float Split = pSelf->DoIndependentDropdownMenu(&s_StatboardConfigDropdown, &View, Localize("Configure statboard"), 20.0f, pSelf->RenderSettingsControlsStats, &s_StatboardConfigActive);
+
+	return BackgroundHeight+Split;
+}
+
 float CMenus::RenderSettingsControlsMisc(CUIRect View, void *pUser)
 {
 	CMenus *pSelf = (CMenus*)pUser;
@@ -300,8 +351,8 @@ float CMenus::RenderSettingsControlsMisc(CUIRect View, void *pUser)
 		}
 	}
 
-	int NumOptions = 12;
-	int StartOption = 18;
+	int NumOptions = 11;
+	int StartOption = 20;
 	float ButtonHeight = 20.0f;
 	float Spaceing = 2.0f;
 	float BackgroundHeight = (float)NumOptions*ButtonHeight+(float)NumOptions*Spaceing;

--- a/src/game/client/components/menus_callback.cpp
+++ b/src/game/client/components/menus_callback.cpp
@@ -35,7 +35,7 @@ static CKeyInfo gs_aKeys[] =
 	{ "Whisper", "chat whisper", 0, 0},
 	{ "Show chat", "+show_chat", 0, 0},
 	{ "Scoreboard", "+scoreboard", 0, 0},
-	{ "Statboard", "+stats 1", 0, 0},
+	{ "Statboard", "+stats", 0, 0},
 	{ "Emoticon", "+emote", 0, 0},
 	{ "Spectator mode", "+spectate", 0, 0},
 	{ "Spectate next", "spectate_next", 0, 0},

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -17,6 +17,7 @@
 
 #include <game/client/components/maplayers.h>
 #include <game/client/components/sounds.h>
+#include <game/client/components/stats.h>
 #include <game/client/ui.h>
 #include <game/client/render.h>
 #include <game/client/gameclient.h>
@@ -1469,6 +1470,12 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 
 	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
 	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
+	static int s_ScoreboardDropdown = 0;
+	static bool s_ScoreboardActive = true;
+	Split = DoIndependentDropdownMenu(&s_ScoreboardDropdown, &MainView, Localize("Scoreboard"), HeaderHeight, RenderSettingsControlsScoreboard, &s_ScoreboardActive);
+
+	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
+	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
 	static int s_MiscDropdown = 0;
 	static bool s_MiscActive = true;
 	Split = DoIndependentDropdownMenu(&s_MiscDropdown, &MainView, Localize("Misc"), HeaderHeight, RenderSettingsControlsMisc, &s_MiscActive);
@@ -1490,6 +1497,59 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 	static CButtonContainer s_ResetButton;
 	if(DoButton_Menu(&s_ResetButton, Localize("Reset"), 0, &Button))
 		m_pClient->m_pBinds->SetDefaults();
+}
+
+float CMenus::RenderSettingsControlsStats(CUIRect View, void *pUser)
+{
+	CMenus *pSelf = (CMenus*)pUser;
+
+	CUIRect Button;
+
+	View.HSplitTop(20.0f, &Button, &View);
+	if(pSelf->DoButton_CheckBox(&g_Config.m_ClStatboardInfos, Localize("Frags"), g_Config.m_ClStatboardInfos & TC_STATS_FRAGS, &Button))
+		g_Config.m_ClStatboardInfos ^= TC_STATS_FRAGS;
+
+	View.HSplitTop(20.0f, &Button, &View);
+	if(pSelf->DoButton_CheckBox(&g_Config.m_ClStatboardInfos+1, Localize("Deaths"), g_Config.m_ClStatboardInfos & TC_STATS_DEATHS, &Button))
+		g_Config.m_ClStatboardInfos ^= TC_STATS_DEATHS;
+
+	View.HSplitTop(20.0f, &Button, &View);
+	if(pSelf->DoButton_CheckBox(&g_Config.m_ClStatboardInfos+2, Localize("Suicides"), g_Config.m_ClStatboardInfos & TC_STATS_SUICIDES, &Button))
+		g_Config.m_ClStatboardInfos ^= TC_STATS_SUICIDES;
+
+	View.HSplitTop(20.0f, &Button, &View);
+	if(pSelf->DoButton_CheckBox(&g_Config.m_ClStatboardInfos+3, Localize("Ratio"), g_Config.m_ClStatboardInfos & TC_STATS_RATIO, &Button))
+		g_Config.m_ClStatboardInfos ^= TC_STATS_RATIO;
+
+	View.HSplitTop(20.0f, &Button, &View);
+	if(pSelf->DoButton_CheckBox(&g_Config.m_ClStatboardInfos+4, Localize("Net score"), g_Config.m_ClStatboardInfos & TC_STATS_NET, &Button))
+		g_Config.m_ClStatboardInfos ^= TC_STATS_NET;
+
+	View.HSplitTop(20.0f, &Button, &View);
+	if(pSelf->DoButton_CheckBox(&g_Config.m_ClStatboardInfos+5, Localize("Frags per minute"), g_Config.m_ClStatboardInfos & TC_STATS_FPM, &Button))
+		g_Config.m_ClStatboardInfos ^= TC_STATS_FPM;
+		
+	View.HSplitTop(20.0f, &Button, &View);
+	if(pSelf->DoButton_CheckBox(&g_Config.m_ClStatboardInfos+6, Localize("Current spree"), g_Config.m_ClStatboardInfos & TC_STATS_SPREE, &Button))
+		g_Config.m_ClStatboardInfos ^= TC_STATS_SPREE;
+		
+	View.HSplitTop(20.0f, &Button, &View);
+	if(pSelf->DoButton_CheckBox(&g_Config.m_ClStatboardInfos+7, Localize("Best spree"), g_Config.m_ClStatboardInfos & TC_STATS_BESTSPREE, &Button))
+		g_Config.m_ClStatboardInfos ^= TC_STATS_BESTSPREE;
+
+	View.HSplitTop(20.0f, &Button, &View);
+	if(pSelf->DoButton_CheckBox(&g_Config.m_ClStatboardInfos+9, Localize("Weapons stats"), g_Config.m_ClStatboardInfos & TC_STATS_WEAPS, &Button))
+		g_Config.m_ClStatboardInfos ^= TC_STATS_WEAPS;
+
+	View.HSplitTop(20.0f, &Button, &View);
+	if(pSelf->DoButton_CheckBox(&g_Config.m_ClStatboardInfos+8, Localize("Flag grabs"), g_Config.m_ClStatboardInfos & TC_STATS_FLAGGRABS, &Button))
+		g_Config.m_ClStatboardInfos ^= TC_STATS_FLAGGRABS;
+
+	View.HSplitTop(20.0f, &Button, &View);
+	if(pSelf->DoButton_CheckBox(&g_Config.m_ClStatboardInfos+10, Localize("Flag captures"), g_Config.m_ClStatboardInfos & TC_STATS_FLAGCAPTURES, &Button))
+		g_Config.m_ClStatboardInfos ^= TC_STATS_FLAGCAPTURES;
+
+	return 11*20.0f;
 }
 
 bool CMenus::DoResolutionList(CUIRect* pRect, CListBoxState* pListBoxState,

--- a/src/game/client/components/sounds.h
+++ b/src/game/client/components/sounds.h
@@ -5,6 +5,7 @@
 
 #include <engine/sound.h>
 #include <game/client/component.h>
+#include <engine/shared/jobs.h>
 
 class CSounds : public CComponent
 {

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -10,32 +10,27 @@
 
 CStats::CStats()
 {
-	m_Mode = 0;
+	m_Active = false;
 }
 
 void CStats::OnReset()
 {
 	for(int i=0; i<MAX_CLIENTS; i++)
 		m_pClient->m_aStats[i].Reset();
-	m_Mode = 0;
+	m_Active = false;
 }
 
 void CStats::ConKeyStats(IConsole::IResult *pResult, void *pUserData)
 {
 	if(pResult->GetInteger(0) != 0)
-		((CStats *)pUserData)->m_Mode = 1;
+		((CStats *)pUserData)->m_Active = true;
 	else
-		((CStats *)pUserData)->m_Mode = 0;
+		((CStats *)pUserData)->m_Active = false;
 }
 
 void CStats::OnConsoleInit()
 {
 	Console()->Register("+stats", "i", CFGFLAG_CLIENT, ConKeyStats, this, "Show stats");
-}
-
-bool CStats::IsActive()
-{
-	return (m_Mode > 0);
 }
 
 void CStats::OnMessage(int MsgType, void *pRawMsg)
@@ -72,7 +67,7 @@ void CStats::OnMessage(int MsgType, void *pRawMsg)
 
 void CStats::OnRender()
 {
-	if(m_Mode != 1)
+	if(!m_Active)
 		return;
 
 	float Width = 400*3.0f*Graphics()->ScreenAspect();

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -22,15 +22,12 @@ void CStats::OnReset()
 
 void CStats::ConKeyStats(IConsole::IResult *pResult, void *pUserData)
 {
-	if(pResult->GetInteger(0) != 0)
-		((CStats *)pUserData)->m_Active = true;
-	else
-		((CStats *)pUserData)->m_Active = false;
+	((CStats *)pUserData)->m_Active = pResult->GetInteger(0) != 0;
 }
 
 void CStats::OnConsoleInit()
 {
-	Console()->Register("+stats", "i", CFGFLAG_CLIENT, ConKeyStats, this, "Show stats");
+	Console()->Register("+stats", "", CFGFLAG_CLIENT, ConKeyStats, this, "Show stats");
 }
 
 void CStats::OnMessage(int MsgType, void *pRawMsg)

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -1,0 +1,314 @@
+#include <engine/shared/config.h>
+#include <engine/textrender.h>
+#include <engine/graphics.h>
+#include <engine/serverbrowser.h>
+#include <game/client/animstate.h>
+#include <game/client/components/sounds.h>
+#include <game/client/gameclient.h>
+#include <generated/client_data.h>
+#include "stats.h"
+
+CStats::CStats()
+{
+	m_Mode = 0;
+}
+
+void CStats::OnReset()
+{
+	for(int i=0; i<MAX_CLIENTS; i++)
+		m_pClient->m_aStats[i].Reset();
+	m_Mode = 0;
+}
+
+void CStats::ConKeyStats(IConsole::IResult *pResult, void *pUserData)
+{
+	if(pResult->GetInteger(0) != 0)
+		((CStats *)pUserData)->m_Mode = 1;
+	else
+		((CStats *)pUserData)->m_Mode = 0;
+}
+
+void CStats::OnConsoleInit()
+{
+	Console()->Register("+stats", "i", CFGFLAG_CLIENT, ConKeyStats, this, "Show stats");
+}
+
+bool CStats::IsActive()
+{
+	return (m_Mode > 0);
+}
+
+void CStats::OnMessage(int MsgType, void *pRawMsg)
+{
+	if(MsgType == NETMSGTYPE_SV_KILLMSG)
+	{
+		CNetMsg_Sv_KillMsg *pMsg = (CNetMsg_Sv_KillMsg *)pRawMsg;
+		CGameClient::CClientStats *pStats = m_pClient->m_aStats;
+		
+		pStats[pMsg->m_Victim].m_Deaths++;
+		pStats[pMsg->m_Victim].m_CurrentSpree = 0;
+		if(pMsg->m_Weapon >= 0)
+			pStats[pMsg->m_Victim].m_aDeathsFrom[pMsg->m_Weapon]++;
+		if(pMsg->m_ModeSpecial & 1)
+			pStats[pMsg->m_Victim].m_DeathsCarrying++;
+		if(pMsg->m_Victim != pMsg->m_Killer)
+		{
+			pStats[pMsg->m_Killer].m_Frags++;
+			pStats[pMsg->m_Killer].m_CurrentSpree++;
+
+			if(pStats[pMsg->m_Killer].m_CurrentSpree > pStats[pMsg->m_Killer].m_BestSpree)
+				pStats[pMsg->m_Killer].m_BestSpree = pStats[pMsg->m_Killer].m_CurrentSpree;
+			if(pMsg->m_Weapon >= 0)
+				pStats[pMsg->m_Killer].m_aFragsWith[pMsg->m_Weapon]++;
+			if(pMsg->m_ModeSpecial & 1)
+				pStats[pMsg->m_Killer].m_CarriersKilled++;
+			if(pMsg->m_ModeSpecial & 2)
+				pStats[pMsg->m_Killer].m_KillsCarrying++;
+		}
+		else
+			pStats[pMsg->m_Victim].m_Suicides++;
+	}
+}
+
+void CStats::OnRender()
+{
+	if(m_Mode != 1)
+		return;
+
+	float Width = 400*3.0f*Graphics()->ScreenAspect();
+	float Height = 400*3.0f;
+	float w = 250.0f;
+	float h = 750.0f;
+
+	int apPlayers[MAX_CLIENTS] = {0};
+	int NumPlayers = 0;
+	int i;
+	for(i=0; i<MAX_CLIENTS; i++)
+	{
+		if(!m_pClient->m_aClients[i].m_Active)
+			continue;
+
+		apPlayers[NumPlayers] = i;
+		NumPlayers++;
+	}
+
+	for(int i=0; i<9; i++)
+		if(g_Config.m_ClStatboardInfos & (1<<i))
+		{
+			if((1<<i) == (TC_STATS_BESTSPREE))
+				w += 140;
+			else
+				w += 100;
+		}
+
+	if(m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS && g_Config.m_ClStatboardInfos&TC_STATS_FLAGCAPTURES)
+		w += 100;
+
+	bool aDisplayWeapon[NUM_WEAPONS] = {false};
+	if(g_Config.m_ClStatboardInfos & TC_STATS_WEAPS)
+	{
+		w += 10;
+		for(i=0; i<NumPlayers; i++)
+		{
+			const CGameClient::CClientStats pStats = m_pClient->m_aStats[apPlayers[i]];
+			for(int j=0; j<NUM_WEAPONS; j++)
+				aDisplayWeapon[j] = aDisplayWeapon[j] || pStats.m_aFragsWith[j] || pStats.m_aDeathsFrom[j];
+		}
+		for(i=0; i<NUM_WEAPONS; i++)
+			if(aDisplayWeapon[i])
+				w += 80;
+	}
+
+	float x = Width/2-w/2;
+	float y = 200.0f;
+
+	Graphics()->MapScreen(0, 0, Width, Height);
+
+	Graphics()->BlendNormal();
+	{
+		CUIRect Rect = {x-10.f, y-10.f, w, h};
+		RenderTools()->DrawRoundRect(&Rect, vec4(0,0,0,0.5f), 17.0f);
+	}
+
+	float tw;
+	int px = 325;
+
+	TextRender()->Text(0, x+10, y-5, 24.0f, Localize("Name"), -1);
+	const char *apHeaders[] = { Localize("Frags"), Localize("Deaths"), Localize("Suicides"), Localize("Ratio"), Localize("Net"), Localize("FPM"), Localize("Spree"), Localize("Best spree"), Localize("Grabs") };
+	for(i=0; i<9; i++)
+		if(g_Config.m_ClStatboardInfos & (1<<i))
+		{
+			if(1<<i == TC_STATS_BESTSPREE)
+				px += 40.0f;
+			tw = TextRender()->TextWidth(0, 24.0f, apHeaders[i], -1);
+			TextRender()->Text(0, x+px-tw, y-5, 24.0f, apHeaders[i], -1);
+			px += 100;
+		}
+
+	if(g_Config.m_ClStatboardInfos & TC_STATS_WEAPS)
+	{
+		Graphics()->TextureSet(g_pData->m_aImages[IMAGE_GAME].m_Id);
+		Graphics()->QuadsBegin();
+		for(i=0, px-=40; i<NUM_WEAPONS; i++)
+		{
+			if(!aDisplayWeapon[i])
+				continue;
+
+			RenderTools()->SelectSprite(g_pData->m_Weapons.m_aId[i].m_pSpriteBody);
+			if(i == 0)
+				RenderTools()->DrawSprite(x+px, y+10, g_pData->m_Weapons.m_aId[i].m_VisualSize*0.8);
+			else
+				RenderTools()->DrawSprite(x+px, y+10, g_pData->m_Weapons.m_aId[i].m_VisualSize);
+			px += 80;
+		}
+		Graphics()->QuadsEnd();
+		px += 40;
+	}
+
+	if(m_pClient->m_Snap.m_pGameData && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS && g_Config.m_ClStatboardInfos&TC_STATS_FLAGCAPTURES)
+	{
+		px -= 40;
+		Graphics()->TextureSet(g_pData->m_aImages[IMAGE_GAME].m_Id);
+		Graphics()->QuadsBegin();
+		Graphics()->QuadsSetRotation(0.78f);
+		RenderTools()->SelectSprite(SPRITE_FLAG_RED);
+		RenderTools()->DrawSprite(x+px, y+15, 48);
+		Graphics()->QuadsEnd();
+	}
+
+	y += 29.0f;
+
+	float FontSize = 30.0f;
+	float LineHeight = 50.0f;
+	float TeeSizemod = 1.0f;
+	float TeeOffset = 0.0f;
+
+	if(NumPlayers > 14)
+	{
+		FontSize = 30.0f;
+		LineHeight = 40.0f;
+		TeeSizemod = 0.8f;
+		TeeOffset = -5.0f;
+	}
+	for(int j=0; j<NumPlayers; j++)
+	{
+		// workaround
+		if(j == 16)
+		{
+			char aBuf[128];
+			str_format(aBuf, sizeof(aBuf), "... %d other players", NumPlayers-j);
+			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1);
+			TextRender()->Text(0, x+64, y, FontSize, aBuf, -1);
+			px += 100;
+			break;
+		}
+
+		const CGameClient::CClientStats Stats = m_pClient->m_aStats[apPlayers[j]];		
+
+		if(apPlayers[j] == m_pClient->m_LocalClientID)
+		{
+			// background so it's easy to find the local player
+			CUIRect Rect = {x, y, w-20, LineHeight*0.95f};
+			RenderTools()->DrawRoundRect(&Rect, vec4(1,1,1,0.25f), 17.0f);
+		}
+
+		CTeeRenderInfo Teeinfo = m_pClient->m_aClients[apPlayers[j]].m_RenderInfo;
+		Teeinfo.m_Size *= TeeSizemod;
+		RenderTools()->RenderTee(CAnimState::GetIdle(), &Teeinfo, EMOTE_NORMAL, vec2(1,0), vec2(x+28, y+28+TeeOffset));
+
+		char aBuf[128];
+		CTextCursor Cursor;
+		tw = TextRender()->TextWidth(0, FontSize, m_pClient->m_aClients[apPlayers[j]].m_aName, -1);
+		TextRender()->SetCursor(&Cursor, x+64, y, FontSize, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
+		Cursor.m_LineWidth = 220;
+		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[apPlayers[j]].m_aName, -1);
+
+		px = 325;
+		if(g_Config.m_ClStatboardInfos & TC_STATS_FRAGS)
+		{
+			str_format(aBuf, sizeof(aBuf), "%d", Stats.m_Frags);
+			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1);
+			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1);
+			px += 100;
+		}
+		if(g_Config.m_ClStatboardInfos & TC_STATS_DEATHS)
+		{
+			str_format(aBuf, sizeof(aBuf), "%d", Stats.m_Deaths);
+			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1);
+			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1);
+			px += 100;
+		}
+		if(g_Config.m_ClStatboardInfos & TC_STATS_SUICIDES)
+		{
+			str_format(aBuf, sizeof(aBuf), "%d", Stats.m_Suicides);
+			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1);
+			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1);
+			px += 100;
+		}
+		if(g_Config.m_ClStatboardInfos & TC_STATS_RATIO)
+		{
+			if(Stats.m_Deaths == 0)
+				str_format(aBuf, sizeof(aBuf), "--");
+			else
+				str_format(aBuf, sizeof(aBuf), "%.2f", (float)(Stats.m_Frags)/Stats.m_Deaths);
+			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1);
+			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1);
+			px += 100;
+		}
+		if(g_Config.m_ClStatboardInfos & TC_STATS_NET)
+		{
+			str_format(aBuf, sizeof(aBuf), "%+d", Stats.m_Frags-Stats.m_Deaths);
+			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1);
+			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1);
+			px += 100;
+		}
+		if(g_Config.m_ClStatboardInfos & TC_STATS_FPM)
+		{
+			float Fpm = (float)(Stats.m_Frags*60)/((float)(Client()->GameTick()-Stats.m_JoinDate)/Client()->GameTickSpeed());
+			str_format(aBuf, sizeof(aBuf), "%.1f", Fpm);
+			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1);
+			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1);
+			px += 100;
+		}
+		if(g_Config.m_ClStatboardInfos & TC_STATS_SPREE)
+		{
+			str_format(aBuf, sizeof(aBuf), "%d", Stats.m_CurrentSpree);
+			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1);
+			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1);
+			px += 100;
+		}
+		if(g_Config.m_ClStatboardInfos & TC_STATS_BESTSPREE)
+		{
+			px += 40;
+			str_format(aBuf, sizeof(aBuf), "%d", Stats.m_BestSpree);
+			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1);
+			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1);
+			px += 100;
+		}
+		if(m_pClient->m_Snap.m_pGameData && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS && g_Config.m_ClStatboardInfos&TC_STATS_FLAGGRABS)
+		{
+			str_format(aBuf, sizeof(aBuf), "%d", Stats.m_FlagGrabs);
+			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1);
+			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1);
+			px += 100;
+		}
+		for(i=0, px=px-40; i<NUM_WEAPONS; i++)
+		{
+			if(!aDisplayWeapon[i])
+				continue;
+
+			str_format(aBuf, sizeof(aBuf), "%d/%d", Stats.m_aFragsWith[i], Stats.m_aDeathsFrom[i]);
+			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1);
+			TextRender()->Text(0, x+px-tw/2, y, FontSize, aBuf, -1);
+			px += 80;
+		}
+		if(m_pClient->m_Snap.m_pGameData && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS && g_Config.m_ClStatboardInfos&TC_STATS_FLAGCAPTURES)
+		{
+			str_format(aBuf, sizeof(aBuf), "%d", Stats.m_FlagCaptures);
+			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1);
+			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1);
+			px += 100;
+		}
+		y += LineHeight;
+	}
+}

--- a/src/game/client/components/stats.h
+++ b/src/game/client/components/stats.h
@@ -17,7 +17,7 @@ enum {
 class CStats: public CComponent
 {
 private:
-	int m_Mode;
+	int m_Active;
 	static void ConKeyStats(IConsole::IResult *pResult, void *pUserData);
 
 public:
@@ -26,5 +26,4 @@ public:
 	virtual void OnConsoleInit();
 	virtual void OnRender();
 	virtual void OnMessage(int MsgType, void *pRawMsg);
-	bool IsActive();
 };

--- a/src/game/client/components/stats.h
+++ b/src/game/client/components/stats.h
@@ -1,0 +1,30 @@
+#include <game/client/component.h>
+
+enum {
+	TC_STATS_FRAGS=1,
+	TC_STATS_DEATHS=2,
+	TC_STATS_SUICIDES=4,
+	TC_STATS_RATIO=8,
+	TC_STATS_NET=16,
+	TC_STATS_FPM=32,
+	TC_STATS_SPREE=64,
+	TC_STATS_BESTSPREE=128,
+	TC_STATS_FLAGGRABS=256,
+	TC_STATS_WEAPS=512,
+	TC_STATS_FLAGCAPTURES=1024,
+};
+
+class CStats: public CComponent
+{
+private:
+	int m_Mode;
+	static void ConKeyStats(IConsole::IResult *pResult, void *pUserData);
+
+public:
+	CStats();
+	virtual void OnReset();
+	virtual void OnConsoleInit();
+	virtual void OnRender();
+	virtual void OnMessage(int MsgType, void *pRawMsg);
+	bool IsActive();
+};

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -49,6 +49,7 @@
 #include "components/skins.h"
 #include "components/sounds.h"
 #include "components/spectator.h"
+#include "components/stats.h"
 #include "components/voting.h"
 
 // instanciate all systems
@@ -75,6 +76,7 @@ static CEmoticon gs_Emoticon;
 static CDamageInd gsDamageInd;
 static CVoting gs_Voting;
 static CSpectator gs_Spectator;
+static CStats gs_Stats;
 
 static CPlayers gs_Players;
 static CNamePlates gs_NamePlates;
@@ -199,6 +201,7 @@ void CGameClient::OnConsoleInit()
 	m_pItems = &::gs_Items;
 	m_pMapLayersBackGround = &::gs_MapLayersBackGround;
 	m_pMapLayersForeGround = &::gs_MapLayersForeGround;
+	m_pStats = &::gs_Stats;
 
 	// make a list of all the systems, make sure to add them in the corrent render order
 	m_All.Add(m_pSkins);
@@ -231,6 +234,7 @@ void CGameClient::OnConsoleInit()
 	m_All.Add(&gs_DebugHud);
 	m_All.Add(&gs_Notifications);
 	m_All.Add(&gs_Scoreboard);
+	m_All.Add(m_pStats);
 	m_All.Add(m_pMotd);
 	m_All.Add(m_pMenus);
 	m_All.Add(&m_pMenus->m_Binder);
@@ -634,6 +638,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 			case GAMEMSG_CTF_CAPTURE:
 				m_pSounds->Enqueue(CSounds::CHN_GLOBAL, SOUND_CTF_CAPTURE);
 				int ClientID = clamp(aParaI[1], 0, MAX_CLIENTS - 1);
+				m_aStats[ClientID].m_FlagCaptures++;
 				char aLabel[64];
 				GetPlayerLabel(aLabel, sizeof(aLabel), ClientID, m_aClients[ClientID].m_aName);
 
@@ -1042,6 +1047,10 @@ void CGameClient::OnNewSnapshot()
 
 	// go trough all the items in the snapshot and gather the info we want
 	{
+		// stats
+		for(int i = 0; i < MAX_CLIENTS; i++)
+			m_aStats[i].m_Active = false;
+
 		int Num = Client()->SnapNumItems(IClient::SNAP_CURRENT);
 		for(int i = 0; i < Num; i++)
 		{
@@ -1177,9 +1186,34 @@ void CGameClient::OnNewSnapshot()
 			{
 				m_Snap.m_pGameDataFlag = (const CNetObj_GameDataFlag *)pData;
 				m_Snap.m_GameDataFlagSnapID = Item.m_ID;
+
+				// stats
+				{
+					static int s_FlagCarrierRed = FLAG_ATSTAND;
+					static int s_FlagCarrierBlue = FLAG_ATSTAND;
+					if(s_FlagCarrierRed == FLAG_ATSTAND && m_Snap.m_pGameDataFlag->m_FlagCarrierRed >= 0)
+						OnFlagGrab(TEAM_RED);
+					else if(s_FlagCarrierBlue == FLAG_ATSTAND && m_Snap.m_pGameDataFlag->m_FlagCarrierBlue >= 0)
+						OnFlagGrab(TEAM_BLUE);
+
+					s_FlagCarrierRed = m_Snap.m_pGameDataFlag->m_FlagCarrierRed;
+					s_FlagCarrierBlue = m_Snap.m_pGameDataFlag->m_FlagCarrierBlue;
+				}
 			}
 			else if(Item.m_Type == NETOBJTYPE_FLAG)
 				m_Snap.m_paFlags[Item.m_ID%2] = (const CNetObj_Flag *)pData;
+		}
+
+		// stats
+		for(int i = 0; i < MAX_CLIENTS; i++)
+		{
+			if(m_aStats[i].m_Active && !m_aStats[i].m_WasActive)
+			{
+				m_aStats[i].Reset(); // Client connected, reset stats
+				m_aStats[i].m_Active = true;
+				m_aStats[i].m_JoinDate = Client()->GameTick();
+			}
+			m_aStats[i].m_WasActive = m_aStats[i].m_Active;
 		}
 	}
 
@@ -1432,6 +1466,12 @@ void CGameClient::OnPredict()
 	m_PredictedTick = Client()->PredGameTick();
 }
 
+// stats
+void CGameClient::OnGameRestart()
+{	
+	m_pStats->OnReset();
+}
+
 void CGameClient::OnActivateEditor()
 {
 	OnRelease();
@@ -1468,6 +1508,62 @@ void CGameClient::CClientData::UpdateBotRenderInfo(CGameClient *pGameClient, int
 		m_RenderInfo.m_BotTexture.Invalidate();
 		m_RenderInfo.m_BotColor = vec4(0.0f, 0.0f, 0.0f, 0.0f);
 	}
+}
+
+void CGameClient::OnRoundStart()
+{
+	for(int i=0; i<MAX_CLIENTS; i++)
+		m_aStats[i].Reset();
+}
+
+void CGameClient::OnFlagGrab(int ID)
+{
+	if(ID == TEAM_RED)
+		m_aStats[m_Snap.m_pGameDataFlag->m_FlagCarrierRed].m_FlagGrabs++;
+	else
+		m_aStats[m_Snap.m_pGameDataFlag->m_FlagCarrierBlue].m_FlagGrabs++;
+}
+
+CGameClient::CClientStats::CClientStats()
+{
+	m_JoinDate  = 0;
+	m_Active    = false;
+	m_WasActive = false;
+	m_Frags     = 0;
+	m_Deaths    = 0;
+	m_Suicides  = 0;
+	for(int j = 0; j < NUM_WEAPONS; j++)
+	{
+		m_aFragsWith[j]  = 0;
+		m_aDeathsFrom[j] = 0;
+	}
+	m_FlagGrabs      = 0;
+	m_FlagCaptures   = 0;
+	m_CarriersKilled = 0;
+	m_KillsCarrying  = 0;
+	m_DeathsCarrying = 0;
+}
+
+void CGameClient::CClientStats::Reset()
+{
+	m_JoinDate  = 0;
+	m_Active    = false;
+	m_WasActive = false;
+	m_Frags     = 0;
+	m_Deaths    = 0;
+	m_Suicides  = 0;
+	m_BestSpree = 0;
+	m_CurrentSpree = 0;
+	for(int j = 0; j < NUM_WEAPONS; j++)
+	{
+		m_aFragsWith[j]  = 0;
+		m_aDeathsFrom[j] = 0;
+	}
+	m_FlagGrabs      = 0;
+	m_FlagCaptures   = 0;
+	m_CarriersKilled = 0;
+	m_KillsCarrying  = 0;
+	m_DeathsCarrying = 0;
 }
 
 void CGameClient::CClientData::UpdateRenderInfo(CGameClient *pGameClient, int ClientID, bool UpdateSkinInfo)

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -232,8 +232,6 @@ public:
 		CClientStats();
 		
 		int m_JoinDate;
-		bool m_Active;
-		bool m_WasActive;
 
 		int m_aFragsWith[NUM_WEAPONS];
 		int m_aDeathsFrom[NUM_WEAPONS];

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -225,6 +225,34 @@ public:
 		int m_PlayerSlots;
 	} m_ServerSettings;
 
+	// stats
+	class CClientStats
+	{
+	public:
+		CClientStats();
+		
+		int m_JoinDate;
+		bool m_Active;
+		bool m_WasActive;
+
+		int m_aFragsWith[NUM_WEAPONS];
+		int m_aDeathsFrom[NUM_WEAPONS];
+		int m_Frags;
+		int m_Deaths;
+		int m_Suicides;
+		int m_BestSpree;
+		int m_CurrentSpree;
+
+		int m_FlagGrabs;
+		int m_FlagCaptures;
+		int m_CarriersKilled;
+		int m_KillsCarrying;
+		int m_DeathsCarrying;
+
+		void Reset();
+	};
+	CClientStats m_aStats[MAX_CLIENTS];
+
 	CRenderTools m_RenderTools;
 
 	void OnReset();
@@ -248,6 +276,13 @@ public:
 	virtual void OnRconLine(const char *pLine);
 	virtual void OnGameOver();
 	virtual void OnStartGame();
+
+	// stats hooks
+	int m_LastGameOver;
+	int m_LastRoundStartTick;
+	void OnGameRestart();
+	void OnRoundStart();
+	void OnFlagGrab(int Id);
 
 	virtual const char *GetItemName(int Type) const;
 	virtual const char *Version() const;
@@ -288,6 +323,7 @@ public:
 	class CMapImages *m_pMapimages;
 	class CVoting *m_pVoting;
 	class CScoreboard *m_pScoreboard;
+	class CStats *m_pStats;
 	class CItems *m_pItems;
 	class CMapLayers *m_pMapLayersBackGround;
 	class CMapLayers *m_pMapLayersForeGround;

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -95,6 +95,8 @@ MACRO_CONFIG_INT(ClCameraSpeed, cl_camera_speed, 5, 1, 10, CFGFLAG_CLIENT|CFGFLA
 MACRO_CONFIG_INT(ClShowStartMenuImages, cl_show_start_menu_images, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show start menu images")
 MACRO_CONFIG_INT(ClSkipStartMenu, cl_skip_start_menu, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Skip the start menu")
 
+MACRO_CONFIG_INT(ClStatboardInfos, cl_statboard_infos, 1259, 1, 2047, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Mask of infos to display on the global statboard")
+
 // server
 MACRO_CONFIG_INT(SvWarmup, sv_warmup, 0, -1, 1000, CFGFLAG_SAVE|CFGFLAG_SERVER, "Number of seconds to do warmup before match starts (0 disables, -1 all players ready)")
 MACRO_CONFIG_STR(SvMotd, sv_motd, 900, "", CFGFLAG_SAVE|CFGFLAG_SERVER, "Message of the day to display for the clients")


### PR DESCRIPTION
This is a first attempt at implementing a statboard, by porting the scoreboard from [0.5 Teecomp](https://www.teeworlds.com/forum/viewtopic.php?id=3913).
It adapts to 64 players the same way the scoreboard does.

It works well as far as I can tell, but the code may need some improvements. The large code chunks in stats.cpp (that is `Stats::OnMessage` and `Stats::OnRender`) are completely unchanged from Teecomp afaik, so that part should be robust.

![screenshot_2019-04-18_19-39-13](https://user-images.githubusercontent.com/355114/56380476-84e45280-6212-11e9-8772-4aa623164559.png)
![screenshot_2019-04-18_19-39-18](https://user-images.githubusercontent.com/355114/56380478-84e45280-6212-11e9-85df-5869b88228a5.png)
![screenshot_2019-04-18_19-40-23](https://user-images.githubusercontent.com/355114/56380479-84e45280-6212-11e9-97ab-90e072e47b64.png)

`+stats` defaults on "e", I was uninspired and it's easy to hit