### PR TITLE
Chat fixes

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -636,10 +636,6 @@ void CChat::OnRender()
 		--m_PendingChatCounter;
 	}
 
-	// dont render chat if the menu is active
-	if(m_pClient->m_pMenus->IsActive())
-		return;
-
 	const float Height = 300.0f;
 	const float Width = Height*Graphics()->ScreenAspect();
 	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -621,6 +621,9 @@ void CChat::AddLine(int ClientID, int Mode, const char *pLine, int TargetID)
 
 void CChat::OnRender()
 {
+	if(Client()->State() == Client()->STATE_LOADING)
+		return;
+		
 	// send pending chat messages
 	if(m_PendingChatCounter > 0 && m_LastChatSend+time_freq() < time_get())
 	{


### PR DESCRIPTION
I never heard someone say they liked not seeing chat when they pressed escape but maybe there are some benefits Im missing. Feel free to discuss that.

Rendering chat when loading a map is obviously bad in my opinion though. (and it was caused because of me :sweat_smile: )