### PR TITLE
Use name enum instead of magic number

### DIFF
--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -24,7 +24,7 @@ class CChat : public CComponent
 		int m_TargetID;
 		int m_Mode;
 		int m_NameColor;
-		char m_aName[64];
+		char m_aName[MAX_NAME_LENGTH];
 		char m_aText[512];
 		bool m_Highlighted;
 	};


### PR DESCRIPTION
I have no idea why it was hardcoded to 64 if the MAX_NAME_LENGTH is 16. I thought maybe this is used for the colon ":" in chat or something but I tested ingame and all worked fine.