### PR TITLE
Optimise CClient::SnapFindItem

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -614,7 +614,7 @@ static const int* SnapSearchKey(const int* pKeysStart, const int* pKeysEnd, int 
 	int MiddleIndex = (pKeysEnd - pKeysStart) / 2;
 	int Middle = pKeysStart[MiddleIndex];
 	if(MiddleIndex == 0)
-		return Middle == Key ? pKeysStart + MiddleIndex : 0x0;
+		return Middle == Key ? pKeysStart : 0x0;
 	if(Middle > Key)
 		return SnapSearchKey(pKeysStart, pKeysStart+MiddleIndex, Key);
 	if(Middle < Key)

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2039,19 +2039,21 @@ void CClient::Run()
 		}
 
 		// panic quit button
-		if(Input()->KeyIsPressed(KEY_LCTRL) && Input()->KeyIsPressed(KEY_LSHIFT) && Input()->KeyPress(KEY_Q, true))
+		bool IsCtrlPressed = Input()->KeyIsPressed(KEY_LCTRL);
+		bool IsLShiftPressed = Input()->KeyIsPressed(KEY_LSHIFT);
+		if(IsCtrlPressed && IsLShiftPressed && Input()->KeyPress(KEY_Q, true))
 		{
 			Quit();
 			break;
 		}
 
-		if(Input()->KeyIsPressed(KEY_LCTRL) && Input()->KeyIsPressed(KEY_LSHIFT) && Input()->KeyPress(KEY_D, true))
+		if(IsCtrlPressed && IsLShiftPressed && Input()->KeyPress(KEY_D, true))
 			g_Config.m_Debug ^= 1;
 
-		if(Input()->KeyIsPressed(KEY_LCTRL) && Input()->KeyIsPressed(KEY_LSHIFT) && Input()->KeyPress(KEY_G, true))
+		if(IsCtrlPressed && IsLShiftPressed && Input()->KeyPress(KEY_G, true))
 			g_Config.m_DbgGraphs ^= 1;
 
-		if(Input()->KeyIsPressed(KEY_LCTRL) && Input()->KeyIsPressed(KEY_LSHIFT) && Input()->KeyPress(KEY_E, true))
+		if(IsCtrlPressed && IsLShiftPressed && Input()->KeyPress(KEY_E, true))
 		{
 			g_Config.m_ClEditor = g_Config.m_ClEditor^1;
 			Input()->MouseModeRelative();

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -1,5 +1,6 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <base/tl/base.h>
 #include "snapshot.h"
 #include "compression.h"
 
@@ -550,12 +551,47 @@ int CSnapshotBuilder::Finish(void *pSpnapData)
 	int KeySize = sizeof(int)*m_NumItems;
 	pSnap->m_DataSize = m_DataSize;
 	pSnap->m_NumItems = m_NumItems;
-	mem_copy(pSnap->Offsets(), m_aOffsets, OffsetSize);
-	mem_copy(pSnap->DataStart(), m_aData, m_DataSize);
 
-	for(int i = 0; i < m_NumItems; i++)
+	const int NumItems = m_NumItems;
+	for(int i = 0; i < NumItems; i++)
 	{
 		pSnap->Keys()[i] = GetItem(i)->Key();
+	}
+
+	// get full item sizes
+	int aItemSizes[CSnapshotBuilder::MAX_ITEMS];
+
+	for(int i = 0; i < NumItems-1; i++)
+	{
+		aItemSizes[i] = m_aOffsets[i+1] - m_aOffsets[i];
+	}
+	aItemSizes[NumItems-1] = m_DataSize - m_aOffsets[NumItems-1];
+
+	// bubble sort by keys
+	bool Sorting = true;
+	while(Sorting)
+	{
+		Sorting = false;
+
+		for(int i = 1; i < NumItems; i++)
+		{
+			if(pSnap->Keys()[i-1] > pSnap->Keys()[i])
+			{
+				Sorting = true;
+				tl_swap(pSnap->Keys()[i], pSnap->Keys()[i-1]);
+				tl_swap(m_aOffsets[i], m_aOffsets[i-1]);
+				tl_swap(aItemSizes[i], aItemSizes[i-1]);
+			}
+		}
+	}
+
+	// copy sorted items
+	int OffsetCur = 0;
+	for(int i = 0; i < NumItems; i++)
+	{
+		pSnap->Offsets()[i] = OffsetCur;
+		mem_copy(pSnap->DataStart()+OffsetCur, m_aData + m_aOffsets[i], aItemSizes[i]);
+		OffsetCur += aItemSizes[i];
 	}
 
 	return sizeof(CSnapshot) + KeySize + OffsetSize + m_DataSize;

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -25,7 +25,8 @@ class CSnapshot
 	int m_DataSize;
 	int m_NumItems;
 
-	int *Offsets() const { return (int *)(this+1); }
+	int *Keys() const { return (int *)(this+1); }
+	int *Offsets() const { return (int *)(Keys()+m_NumItems); }
 	char *DataStart() const { return (char*)(Offsets()+m_NumItems); }
 
 public:
@@ -40,6 +41,8 @@ public:
 	CSnapshotItem *GetItem(int Index);
 	int GetItemSize(int Index);
 	int GetItemIndex(int Key);
+	const int* GetItemKeys() const;
+	void InvalidateItem(int Index);
 
 	int Crc();
 	void DebugDump();


### PR DESCRIPTION
So I was doing some test with a lot of dummies and ran into performances issues. Naturally I did some profiling and **SnapFindItem** was among the top culprits (it is called twice per client every frame to render players for example). And indeed it was searching linearly into data that wasn't structured to be searched that way (as pointed by the TODO comment inside the function).

I'm doing two things here to optimise the search.
* Packing the keys together at the top of the snapshot (Keys | Offsets | Data)
* Sorting objects by key and binary searching

I'm getting 8x-10x improved performance on average in release mode.