### PR TITLE
Give an explicit warning if compiling without data submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,7 @@ set(DEP_MD5 $<TARGET_OBJECTS:json> $<TARGET_OBJECTS:md5>)
 # DATA
 ########################################################################
 
-set_glob(DATA GLOB_RECURSE "json;map;png;rules;ttf;txt;wv" datasrc
+set(EXPECTED_DATA
   audio/foley_body_impact-01.wv
   audio/foley_body_impact-02.wv
   audio/foley_body_impact-03.wv
@@ -1042,6 +1042,26 @@ set_glob(DATA GLOB_RECURSE "json;map;png;rules;ttf;txt;wv" datasrc
   ui/themes/jungle_night.map
   ui/themes/none.png
 )
+
+if(NOT EXISTS ${PROJECT_SOURCE_DIR}/datasrc/languages/index.json)
+  message(WARNING "Missing datasrc/languages submodule. Please download a source release or update your git submodules with `git submodule update --init`")
+  foreach(item ${EXPECTED_DATA})
+    if(item MATCHES "^languages/")
+      list(REMOVE_ITEM EXPECTED_DATA ${item})
+    endif()
+  endforeach()
+endif()
+
+if(NOT EXISTS ${PROJECT_SOURCE_DIR}/datasrc/maps/dm1.map)
+  message(WARNING "Missing datasrc/maps submodule. Please download a source release or update your git submodules with `git submodule update --init`")
+  foreach(item ${EXPECTED_DATA})
+    if(item MATCHES "^maps/")
+      list(REMOVE_ITEM EXPECTED_DATA ${item})
+    endif()
+  endforeach()
+endif()
+
+set_glob(DATA GLOB_RECURSE "json;map;png;rules;ttf;txt;wv" datasrc ${EXPECTED_DATA})
 
 ########################################################################
 # COPY DATA AND DLLS


### PR DESCRIPTION
This replaces the opaque error messages of files not being found in
datasrc/languages and datasrc/maps. Also give instructions to the user
about what to do.