### PR TITLE
Implement auto statscreenshots

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -85,6 +85,7 @@ public:
 	virtual void DemoRecorder_HandleAutoStart() = 0;
 	virtual void DemoRecorder_Stop() = 0;
 	virtual void RecordGameMessage(bool State) = 0;
+	virtual void AutoStatScreenshot_Start() = 0;
 	virtual void AutoScreenshot_Start() = 0;
 	virtual void ServerBrowserUpdate() = 0;
 	

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -262,6 +262,7 @@ CClient::CClient() : m_DemoPlayer(&m_SnapshotDelta), m_DemoRecorder(&m_SnapshotD
 	m_WindowMustRefocus = 0;
 	m_SnapCrcErrors = 0;
 	m_AutoScreenshotRecycle = false;
+	m_AutoStatScreenshotRecycle = false;
 	m_EditorActive = false;
 
 	m_AckGameTick = -1;
@@ -2206,6 +2207,15 @@ void CClient::AutoScreenshot_Start()
 	}
 }
 
+void CClient::AutoStatScreenshot_Start()
+{
+	if(g_Config.m_ClAutoStatScreenshot)
+	{
+		Graphics()->TakeScreenshot("auto/stat");
+		m_AutoStatScreenshotRecycle = true;
+	}
+}
+
 void CClient::AutoScreenshot_Cleanup()
 {
 	if(m_AutoScreenshotRecycle)
@@ -2217,6 +2227,16 @@ void CClient::AutoScreenshot_Cleanup()
 			AutoScreens.Init(Storage(), "screenshots/auto", "autoscreen", ".png", g_Config.m_ClAutoScreenshotMax);
 		}
 		m_AutoScreenshotRecycle = false;
+	}
+	if(m_AutoStatScreenshotRecycle)
+	{
+		if(g_Config.m_ClAutoScreenshotMax)
+		{
+			// clean up auto taken stat screens
+			CFileCollection AutoScreens;
+			AutoScreens.Init(Storage(), "screenshots/auto", "stat", ".png", g_Config.m_ClAutoScreenshotMax);
+		}
+		m_AutoStatScreenshotRecycle = false;
 	}
 }
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -98,6 +98,7 @@ class CClient : public IClient, public CDemoPlayer::IListner
 	int m_WindowMustRefocus;
 	int m_SnapCrcErrors;
 	bool m_AutoScreenshotRecycle;
+	bool m_AutoStatScreenshotRecycle;
 	bool m_EditorActive;
 	bool m_SoundInitFailed;
 	bool m_ResortServerBrowser;
@@ -315,6 +316,7 @@ public:
 	void RecordGameMessage(bool State) { m_RecordGameMessage = State; }
 
 	void AutoScreenshot_Start();
+	void AutoStatScreenshot_Start();
 	void AutoScreenshot_Cleanup();
 
 	void ServerBrowserUpdate();

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -24,6 +24,7 @@ MACRO_CONFIG_INT(ClLoadCountryFlags, cl_load_country_flags, 1, 0, 1, CFGFLAG_SAV
 MACRO_CONFIG_INT(ClAutoDemoRecord, cl_auto_demo_record, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Automatically record demos")
 MACRO_CONFIG_INT(ClAutoDemoMax, cl_auto_demo_max, 10, 0, 1000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Maximum number of automatically recorded demos (0 = no limit)")
 MACRO_CONFIG_INT(ClAutoScreenshot, cl_auto_screenshot, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Automatically take game over screenshot")
+MACRO_CONFIG_INT(ClAutoStatScreenshot, cl_auto_statscreenshot, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Automatically take screenshot of game statistics")
 MACRO_CONFIG_INT(ClAutoScreenshotMax, cl_auto_screenshot_max, 10, 0, 1000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Maximum number of automatically created screenshots (0 = no limit)")
 
 MACRO_CONFIG_INT(ClShowServerBroadcast, cl_show_server_broadcast, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Show server broadcast")

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -20,6 +20,7 @@
 #include "menus.h"
 #include "stats.h"
 #include "scoreboard.h"
+#include "stats.h"
 
 
 CScoreboard::CScoreboard()
@@ -644,6 +645,10 @@ void CScoreboard::OnRender()
 	// close the motd if we actively wanna look on the scoreboard
 	if(m_Active)
 		m_pClient->m_pMotd->Clear();
+
+	// if statboard active don't show scoreboard
+	if(m_pClient->m_pStats->IsActive())
+		return;
 
 	if(!Active())
 		return;

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -103,10 +103,6 @@ void CStats::OnRender()
 		if(m_ScreenshotTime < 0 && m_pClient->m_Snap.m_pGameData && m_pClient->m_Snap.m_pGameData->m_GameStateFlags&GAMESTATEFLAG_GAMEOVER)
 			m_ScreenshotTime = time_get()+time_freq()*3;
 
-		// switch to statboard
-		// if(m_ScreenshotTime > -1 && m_ScreenshotTime < time_get())
-		// 	m_Active = true;
-
 		// when rendered, take screenshot once
 		if(!m_ScreenshotTaken && m_ScreenshotTime > -1 && m_ScreenshotTime+time_freq()/5 < time_get())
 		{
@@ -399,7 +395,6 @@ void CStats::OnPlayerLeave(int ClientID)
 
 void CStats::AutoStatScreenshot()
 {
-	dbg_msg("test", "autostatscreenshot");
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		Client()->AutoStatScreenshot_Start();
 }

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -11,6 +11,8 @@
 CStats::CStats()
 {
 	m_Active = false;
+	m_ScreenshotTaken = false;
+	m_ScreenshotTime = -1;
 }
 
 void CStats::CPlayerStats::Reset()
@@ -38,6 +40,17 @@ void CStats::OnReset()
 	for(int i = 0; i < MAX_CLIENTS; i++)
 		m_aStats[i].Reset();
 	m_Active = false;
+	m_ScreenshotTaken = false;
+	m_ScreenshotTime = -1;
+}
+
+bool CStats::IsActive()
+{
+	// force statboard after three seconds of game over if autostatscreenshot is on
+	if(g_Config.m_ClAutoStatScreenshot && m_ScreenshotTime > -1 && m_ScreenshotTime < time_get())
+		return true;
+
+	return m_Active;
 }
 
 void CStats::ConKeyStats(IConsole::IResult *pResult, void *pUserData)
@@ -83,7 +96,26 @@ void CStats::OnMessage(int MsgType, void *pRawMsg)
 
 void CStats::OnRender()
 {
-	if(!m_Active)
+	// auto stat screenshot stuff
+	if(g_Config.m_ClAutoStatScreenshot)
+	{
+		// on game over, wait three seconds
+		if(m_ScreenshotTime < 0 && m_pClient->m_Snap.m_pGameData && m_pClient->m_Snap.m_pGameData->m_GameStateFlags&GAMESTATEFLAG_GAMEOVER)
+			m_ScreenshotTime = time_get()+time_freq()*3;
+
+		// switch to statboard
+		// if(m_ScreenshotTime > -1 && m_ScreenshotTime < time_get())
+		// 	m_Active = true;
+
+		// when rendered, take screenshot once
+		if(!m_ScreenshotTaken && m_ScreenshotTime > -1 && m_ScreenshotTime+time_freq()/5 < time_get())
+		{
+			AutoStatScreenshot();
+			m_ScreenshotTaken = true;
+		}
+	}
+
+	if(!IsActive())
 		return;
 
 	float Width = 400*3.0f*Graphics()->ScreenAspect();
@@ -342,8 +374,7 @@ void CStats::UpdatePlayTime(int Ticks)
 
 void CStats::OnMatchStart()
 {
-	for(int i = 0; i < MAX_CLIENTS; i++)
-		m_aStats[i].Reset();
+	OnReset();
 }
 
 void CStats::OnFlagGrab(int ClientID)
@@ -364,4 +395,11 @@ void CStats::OnPlayerEnter(int ClientID, int Team)
 void CStats::OnPlayerLeave(int ClientID)
 {
 	m_aStats[ClientID].Reset();
+}
+
+void CStats::AutoStatScreenshot()
+{
+	dbg_msg("test", "autostatscreenshot");
+	if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		Client()->AutoStatScreenshot_Start();
 }

--- a/src/game/client/components/stats.h
+++ b/src/game/client/components/stats.h
@@ -49,11 +49,16 @@ private:
 	CPlayerStats m_aStats[MAX_CLIENTS];
 
 	int m_Active;
+	bool m_ScreenshotTaken;
+	int64 m_ScreenshotTime;
 	static void ConKeyStats(IConsole::IResult *pResult, void *pUserData);
+	void AutoStatScreenshot();
 
 public:
 	CStats();
+	bool IsActive();
 	virtual void OnReset();
+	void OnStartGame();
 	virtual void OnConsoleInit();
 	virtual void OnRender();
 	virtual void OnMessage(int MsgType, void *pRawMsg);


### PR DESCRIPTION
Closes https://github.com/teeworlds/teeworlds/issues/2134

When `cl_autostatscreenshot` is activated:

- On game over, the scoreboard will switch to statboard after 3 seconds, and a screenshot will be taken
  - This stat screenshot shares the same max as the normal screenshot
  - It will be placed in the same folder, but named `autostat_***` instead of `autoscreen_***`

Example:
![stat_2019-07-16_21-44-12](https://user-images.githubusercontent.com/355114/61326564-56791200-a817-11e9-9f36-ccaae5554b71.png)
