### PR TITLE
Fix emote gameover

### DIFF
--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -101,7 +101,7 @@ void CEmoticon::OnRender()
 		return;
 	}
 
-	if(m_pClient->m_Snap.m_SpecInfo.m_Active)
+	if(m_pClient->m_Snap.m_SpecInfo.m_Active || (m_pClient->m_Snap.m_pGameData && m_pClient->m_Snap.m_pGameData->m_GameStateFlags&GAMESTATEFLAG_GAMEOVER))
 	{
 		m_Active = false;
 		m_WasActive = false;


### PR DESCRIPTION
Fix https://github.com/teeworlds/teeworlds/issues/2169

No emote selection during game over screen