### PR TITLE
Implement chat pages

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -203,20 +203,17 @@ bool CChat::OnInput(IInput::CEvent Event)
 	// chat history scrolling
 	if(m_Show && Event.m_Flags&IInput::FLAG_PRESS && (Event.m_Key == KEY_PAGEUP || Event.m_Key == KEY_PAGEDOWN))
 	{
-		if(Event.m_Flags&IInput::FLAG_PRESS)
+		if(Event.m_Key == KEY_PAGEUP)
 		{
-			if(Event.m_Key == KEY_PAGEUP)
-			{
-				++m_BacklogPage;
-				if(m_BacklogPage >= MAX_CHAT_PAGES) // will be further capped during rendering
-					m_BacklogPage = MAX_CHAT_PAGES-1;
-			}
-			else if(Event.m_Key == KEY_PAGEDOWN)
-			{
-				--m_BacklogPage;
-				if(m_BacklogPage < 0)
-					m_BacklogPage = 0;
-			}
+			++m_BacklogPage;
+			if(m_BacklogPage >= MAX_CHAT_PAGES) // will be further capped during rendering
+				m_BacklogPage = MAX_CHAT_PAGES-1;
+		}
+		else if(Event.m_Key == KEY_PAGEDOWN)
+		{
+			--m_BacklogPage;
+			if(m_BacklogPage < 0)
+				m_BacklogPage = 0;
 		}
 		return true;
 	}

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -215,7 +215,7 @@ bool CChat::OnInput(IInput::CEvent Event)
 			if(m_BacklogPage < 0)
 				m_BacklogPage = 0;
 		}
-		return true;
+		return m_Mode != CHAT_NONE;
 	}
 	if(m_Mode == CHAT_NONE)
 		return false;

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -975,7 +975,7 @@ void CChat::OnRender()
 			break;
 
 		if(Line.m_ClientID >= 0 && m_pClient->m_aClients[Line.m_ClientID].m_ChatIgnore)
-			break;
+			continue;
 
 		if(Now > Line.m_Time+16*TimeFreq && !m_Show)
 			break;

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -60,6 +60,7 @@ void CChat::OnReset()
 		m_LastWhisperFrom = -1;
 		m_ReverseCompletion = false;
 		m_Show = false;
+		m_BacklogPage = 0;
 		m_InputUpdate = false;
 		m_ChatStringOffset = 0;
 		m_CompletionChosen = -1;

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -13,7 +13,8 @@ class CChat : public CComponent
 
 	enum
 	{
-		MAX_LINES = 50,
+		MAX_LINES = 250,
+		MAX_CHAT_PAGES = 10,
 	};
 
 	struct CLine
@@ -52,6 +53,7 @@ class CChat : public CComponent
 	int m_WhisperTarget;
 	int m_LastWhisperFrom;
 	bool m_Show;
+	int m_BacklogPage;
 	bool m_InputUpdate;
 	int m_ChatStringOffset;
 	int m_OldChatStringLength;


### PR DESCRIPTION
- Added some console-like chat `scrolling` system with pageup/pagedown. There are no scrollbars for now, but it might be better to make it a scrollable region instead of pages.

![screenshot_2019-08-19_21-35-50](https://user-images.githubusercontent.com/355114/63290247-b9077700-c2c9-11e9-8456-98415193da0e.png)
![screenshot_2019-08-19_21-35-57](https://user-images.githubusercontent.com/355114/63290248-b9a00d80-c2c9-11e9-861d-de83e18c415d.png)
![screenshot_2019-08-19_21-36-09](https://user-images.githubusercontent.com/355114/63290249-b9a00d80-c2c9-11e9-8b76-fe463dba7245.png)

- Fix some issue with chat rendering being aborted on the first message (didn't check the bug really did happen but that `break` didn't look good)
