### PR TITLE
Update scrollbars

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -945,9 +945,6 @@ void CMenus::UiDoListboxStart(CListBoxState* pState, const void *pID, float RowH
 		UI()->DoLabel(&Footer, pBottomText, Footer.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 	}
 
-	// list background
-	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
-
 	// setup the variables
 	pState->m_ListBoxView = View;
 	pState->m_ListBoxSelectedIndex = SelectedIndex;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2851,8 +2851,6 @@ void CMenus::EndScrollRegion(CScrollRegion* pSr)
 	if(pSr->m_WasClipped)
 		UI()->ClipEnable(&pSr->m_OldClipRect);
 
-	dbg_assert(pSr->m_ContentH > 0, "Add some rects with ScrollRegionAddRect()");
-
 	// only show scrollbar if content overflows
 	if(pSr->m_ContentH <= pSr->m_ClipRect.h)
 		return;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -918,18 +918,18 @@ void CMenus::UiDoListboxHeader(CListBoxState* pState, const CUIRect *pRect, cons
 	View.HSplitTop(Spacing, &Header, &View);
 
 	// setup the variables
-	pState->m_ListBoxOriginalView = View;
+	pState->m_ListBoxView = View;
 }
 
 void CMenus::UiDoListboxStart(CListBoxState* pState, const void *pID, float RowHeight,
 							  const char *pBottomText, int NumItems, int ItemsPerRow, int SelectedIndex,
 							  const CUIRect *pRect, bool Background)
 {
-	CUIRect View, Scroll, Row;
+	CUIRect View;
 	if(pRect)
 		View = *pRect;
 	else
-		View = pState->m_ListBoxOriginalView;
+		View = pState->m_ListBoxView;
 	CUIRect Footer;
 
 	// background
@@ -945,17 +945,11 @@ void CMenus::UiDoListboxStart(CListBoxState* pState, const void *pID, float RowH
 		UI()->DoLabel(&Footer, pBottomText, Footer.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 	}
 
-	// prepare the scroll
-	View.VSplitRight(20.0f, &View, &Scroll);
-
-	// scroll background
-	RenderTools()->DrawUIRect(&Scroll, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
-
 	// list background
 	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
 	// setup the variables
-	pState->m_ListBoxOriginalView = View;
+	pState->m_ListBoxView = View;
 	pState->m_ListBoxSelectedIndex = SelectedIndex;
 	pState->m_ListBoxNewSelected = SelectedIndex;
 	pState->m_ListBoxItemIndex = 0;
@@ -965,69 +959,27 @@ void CMenus::UiDoListboxStart(CListBoxState* pState, const void *pID, float RowH
 	pState->m_ListBoxDoneEvents = 0;
 	pState->m_ListBoxItemActivated = false;
 
-	// do the scrollbar
-	View.HSplitTop(pState->m_ListBoxRowHeight, &Row, 0);
-
-	int NumViewable = (int)(pState->m_ListBoxOriginalView.h/Row.h) + 1;
-	int Num = (NumItems+pState->m_ListBoxItemsPerRow-1)/pState->m_ListBoxItemsPerRow-NumViewable+1;
-	if(Num < 0)
-		Num = 0;
-	if(Num > 0)
-	{
-		if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP) && UI()->MouseInside(&View))
-			pState->m_ListBoxScrollValue -= 3.0f/Num;
-		if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN) && UI()->MouseInside(&View))
-			pState->m_ListBoxScrollValue += 3.0f/Num;
-
-		if(pState->m_ListBoxScrollValue < 0.0f) pState->m_ListBoxScrollValue = 0.0f;
-		if(pState->m_ListBoxScrollValue > 1.0f) pState->m_ListBoxScrollValue = 1.0f;
-	}
-
-	Scroll.HMargin(5.0f, &Scroll);
-	pState->m_ListBoxScrollValue = DoScrollbarV(pID, &Scroll, pState->m_ListBoxScrollValue);
-
-	// the list
-	pState->m_ListBoxView = pState->m_ListBoxOriginalView;
-	UI()->ClipEnable(&pState->m_ListBoxView);
-	pState->m_ListBoxView.y -= pState->m_ListBoxScrollValue*Num*Row.h;
+	// setup the scrollbar
+	pState->m_ScrollOffset = vec2(0, 0);
+	BeginScrollRegion(&pState->m_ScrollRegion, &pState->m_ListBoxView, &pState->m_ScrollOffset);
+	pState->m_ListBoxView.y += pState->m_ScrollOffset.y;
 }
 
 CMenus::CListboxItem CMenus::UiDoListboxNextRow(CListBoxState* pState)
 {
 	static CUIRect s_RowView;
 	CListboxItem Item = {0};
+
 	if(pState->m_ListBoxItemIndex%pState->m_ListBoxItemsPerRow == 0)
 		pState->m_ListBoxView.HSplitTop(pState->m_ListBoxRowHeight /*-2.0f*/, &s_RowView, &pState->m_ListBoxView);
+	ScrollRegionAddRect(&pState->m_ScrollRegion, s_RowView);
 
 	s_RowView.VSplitLeft(s_RowView.w/(pState->m_ListBoxItemsPerRow-pState->m_ListBoxItemIndex%pState->m_ListBoxItemsPerRow), &Item.m_Rect, &s_RowView);
-
-	Item.m_Visible = 1;
-	//item.rect = row;
-
-	Item.m_HitRect = Item.m_Rect;
-
-	//CUIRect select_hit_box = item.rect;
 
 	if(pState->m_ListBoxSelectedIndex == pState->m_ListBoxItemIndex)
 		Item.m_Selected = 1;
 
-	// make sure that only those in view can be selected
-	if(Item.m_Rect.y+Item.m_Rect.h > pState->m_ListBoxOriginalView.y)
-	{
-
-		if(Item.m_HitRect.y < pState->m_ListBoxOriginalView.y) // clip the selection
-		{
-			Item.m_HitRect.h -= pState->m_ListBoxOriginalView.y-Item.m_HitRect.y;
-			Item.m_HitRect.y = pState->m_ListBoxOriginalView.y;
-		}
-
-	}
-	else
-		Item.m_Visible = 0;
-
-	// check if we need to do more
-	if(Item.m_Rect.y > pState->m_ListBoxOriginalView.y+pState->m_ListBoxOriginalView.h)
-		Item.m_Visible = 0;
+	Item.m_Visible = !ScrollRegionIsRectClipped(&pState->m_ScrollRegion, Item.m_Rect);
 
 	pState->m_ListBoxItemIndex++;
 	return Item;
@@ -1046,7 +998,7 @@ CMenus::CListboxItem CMenus::UiDoListboxNextItem(CListBoxState* pState, const vo
 	CListboxItem Item = UiDoListboxNextRow(pState);
 	static bool s_ItemClicked = false;
 
-	if(Item.m_Visible && UI()->DoButtonLogic(pId, "", pState->m_ListBoxSelectedIndex == pState->m_ListBoxItemIndex, &Item.m_HitRect))
+	if(Item.m_Visible && UI()->DoButtonLogic(pId, "", pState->m_ListBoxSelectedIndex == pState->m_ListBoxItemIndex, &Item.m_Rect))
 	{
 		s_ItemClicked = true;
 		pState->m_ListBoxNewSelected = ThisItemIndex;
@@ -1070,42 +1022,8 @@ CMenus::CListboxItem CMenus::UiDoListboxNextItem(CListBoxState* pState, const vo
 				pState->m_ListBoxItemActivated = true;
 				UI()->SetActiveItem(0);
 			}
-			else
-			{
-				int NewIndex = -1;
-				if(m_DownArrowPressed) NewIndex = pState->m_ListBoxNewSelected + 1;
-				if(m_UpArrowPressed) NewIndex = pState->m_ListBoxNewSelected - 1;
-				if(NewIndex > -1 && NewIndex < pState->m_ListBoxNumItems)
-				{
-					// scroll
-					float Offset = (NewIndex/pState->m_ListBoxItemsPerRow-pState->m_ListBoxNewSelected/pState->m_ListBoxItemsPerRow)*pState->m_ListBoxRowHeight;
-					int Scroll = pState->m_ListBoxOriginalView.y > Item.m_Rect.y+Offset ? -1 :
-									pState->m_ListBoxOriginalView.y+pState->m_ListBoxOriginalView.h < Item.m_Rect.y+Item.m_Rect.h+Offset ? 1 : 0;
-					if(Scroll)
-					{
-						int NumViewable = (int)(pState->m_ListBoxOriginalView.h/pState->m_ListBoxRowHeight) + 1;
-						int ScrollNum = (pState->m_ListBoxNumItems+pState->m_ListBoxItemsPerRow-1)/pState->m_ListBoxItemsPerRow-NumViewable+1;
-						if(Scroll < 0)
-						{
-							int Num = (pState->m_ListBoxOriginalView.y-Item.m_Rect.y-Offset+pState->m_ListBoxRowHeight-1.0f)/pState->m_ListBoxRowHeight;
-							pState->m_ListBoxScrollValue -= (1.0f/ScrollNum)*Num;
-						}
-						else
-						{
-							int Num = (Item.m_Rect.y+Item.m_Rect.h+Offset-(pState->m_ListBoxOriginalView.y+pState->m_ListBoxOriginalView.h)+pState->m_ListBoxRowHeight-1.0f)/
-								pState->m_ListBoxRowHeight;
-							pState->m_ListBoxScrollValue += (1.0f/ScrollNum)*Num;
-						}
-						if(pState->m_ListBoxScrollValue < 0.0f) pState->m_ListBoxScrollValue = 0.0f;
-						if(pState->m_ListBoxScrollValue > 1.0f) pState->m_ListBoxScrollValue = 1.0f;
-					}
-
-					pState->m_ListBoxNewSelected = NewIndex;
-				}
-			}
 		}
 
-		//selected_index = i;
 		CUIRect r = Item.m_Rect;
 		RenderTools()->DrawUIRect(&r, vec4(1,1,1,ProcessInput?0.5f:0.33f), CUI::CORNER_ALL, 5.0f);
 	}
@@ -1120,7 +1038,7 @@ CMenus::CListboxItem CMenus::UiDoListboxNextItem(CListBoxState* pState, const vo
 
 int CMenus::UiDoListboxEnd(CListBoxState* pState, bool *pItemActivated)
 {
-	UI()->ClipDisable();
+	EndScrollRegion(&pState->m_ScrollRegion);
 	if(pItemActivated)
 		*pItemActivated = pState->m_ListBoxItemActivated;
 	return pState->m_ListBoxNewSelected;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -98,44 +98,6 @@ private:
 	//static int ui_do_key_reader(void *id, const CUIRect *rect, int key);
 	void UiDoGetButtons(int Start, int Stop, CUIRect View, float ButtonHeight, float Spacing);
 
-	struct CListboxItem
-	{
-		int m_Visible;
-		int m_Selected;
-		CUIRect m_Rect;
-		CUIRect m_HitRect;
-	};
-
-	struct CListBoxState
-	{
-		CUIRect m_ListBoxOriginalView;
-		CUIRect m_ListBoxView;
-		float m_ListBoxRowHeight;
-		int m_ListBoxItemIndex;
-		int m_ListBoxSelectedIndex;
-		int m_ListBoxNewSelected;
-		int m_ListBoxDoneEvents;
-		int m_ListBoxNumItems;
-		int m_ListBoxItemsPerRow;
-		float m_ListBoxScrollValue;
-		bool m_ListBoxItemActivated;
-
-		CListBoxState()
-		{
-			m_ListBoxScrollValue = 0;
-		}
-	};
-
-	void UiDoListboxHeader(CListBoxState* pState, const CUIRect *pRect, const char *pTitle, float HeaderHeight, float Spacing);
-	void UiDoListboxStart(CListBoxState* pState, const void *pID, float RowHeight, const char *pBottomText, int NumItems,
-						int ItemsPerRow, int SelectedIndex, const CUIRect *pRect=0, bool Background=true);
-	CListboxItem UiDoListboxNextItem(CListBoxState* pState, const void *pID, bool Selected = false, bool* pActive = NULL);
-	CListboxItem UiDoListboxNextRow(CListBoxState* pState);
-	int UiDoListboxEnd(CListBoxState* pState, bool *pItemActivated);
-
-	//static void demolist_listdir_callback(const char *name, int is_dir, void *user);
-	//static void demolist_list_callback(const CUIRect *rect, int index, void *user);
-
 	struct CScrollRegionParams
 	{
 		float m_ScrollbarWidth;
@@ -235,6 +197,40 @@ private:
 	void ScrollRegionAddRect(CScrollRegion* pSr, CUIRect Rect);
 	void ScrollRegionScrollHere(CScrollRegion* pSr, int Option = CScrollRegion::SCROLLHERE_KEEP_IN_VIEW);
 	bool ScrollRegionIsRectClipped(CScrollRegion* pSr, const CUIRect& Rect);
+
+	struct CListboxItem
+	{
+		int m_Visible;
+		int m_Selected;
+		CUIRect m_Rect;
+	};
+
+	struct CListBoxState
+	{
+		CUIRect m_ListBoxView;
+		float m_ListBoxRowHeight;
+		int m_ListBoxItemIndex;
+		int m_ListBoxSelectedIndex;
+		int m_ListBoxNewSelected;
+		int m_ListBoxDoneEvents;
+		int m_ListBoxNumItems;
+		int m_ListBoxItemsPerRow;
+		bool m_ListBoxItemActivated;
+		CScrollRegion m_ScrollRegion;
+		vec2 m_ScrollOffset;
+
+		CListBoxState()
+		{
+			m_ScrollOffset = vec2(0,0);
+		}
+	};
+
+	void UiDoListboxHeader(CListBoxState* pState, const CUIRect *pRect, const char *pTitle, float HeaderHeight, float Spacing);
+	void UiDoListboxStart(CListBoxState* pState, const void *pID, float RowHeight, const char *pBottomText, int NumItems,
+						int ItemsPerRow, int SelectedIndex, const CUIRect *pRect=0, bool Background=true);
+	CListboxItem UiDoListboxNextItem(CListBoxState* pState, const void *pID, bool Selected = false, bool* pActive = NULL);
+	CListboxItem UiDoListboxNextRow(CListBoxState* pState);
+	int UiDoListboxEnd(CListBoxState* pState, bool *pItemActivated);
 
 	enum
 	{

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -122,8 +122,8 @@ private:
 			m_ScrollbarMargin = 5;
 			m_SliderMinHeight = 25;
 			m_ScrollSpeed = 5;
-			m_ClipBgColor = vec4(0.0f, 0.0f, 0.0f, 0.5f);
-			m_ScrollbarBgColor = vec4(0.0f, 0.0f, 0.0f, 0.5f);
+			m_ClipBgColor = vec4(0.0f, 0.0f, 0.0f, 0.25f);
+			m_ScrollbarBgColor = vec4(0.0f, 0.0f, 0.0f, 0.25f);
 			m_RailBgColor = vec4(1.0f, 1.0f, 1.0f, 0.25f);
 			m_SliderColor = vec4(0.8f, 0.8f, 0.8f, 1.0f);
 			m_SliderColorHover = vec4(1.0f, 1.0f, 1.0f, 1.0f);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -222,8 +222,24 @@ void CMenus::RenderPlayers(CUIRect MainView)
 	UI()->DoLabel(&Label, Localize("Player options"), ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 	RenderTools()->DrawUIRect(&MainView, vec4(0.0, 0.0, 0.0, 0.25f), CUI::CORNER_ALL, 5.0f);
 
-	// headline
+	// prepare headline
 	MainView.HSplitTop(ButtonHeight, &Row, &MainView);
+
+	// background
+	RenderTools()->DrawUIRect(&MainView, vec4(0.0, 0.0, 0.0, 0.25f), CUI::CORNER_ALL, 5.0f);
+	MainView.Margin(5.0f, &MainView);
+
+	// prepare scroll
+	static CScrollRegion s_ScrollRegion;
+	vec2 ScrollOffset(0, 0);
+	CScrollRegionParams ScrollParams;
+	ScrollParams.m_ClipBgColor = vec4(0,0,0,0);
+	ScrollParams.m_ScrollbarBgColor = vec4(0,0,0,0);
+	ScrollParams.m_ScrollSpeed = 15;
+	if(s_ScrollRegion.m_ContentH > s_ScrollRegion.m_ClipRect.h) // scrollbar is shown
+		Row.VSplitRight(ScrollParams.m_ScrollbarWidth, &Row, 0);
+
+	// headline
 	Row.VSplitLeft(ButtonHeight+Spacing, 0, &Row);
 	Row.VSplitLeft(NameWidth, &Label, &Row);
 	Label.y += 2.0f;
@@ -246,17 +262,10 @@ void CMenus::RenderPlayers(CUIRect MainView)
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();
 
-	// background
-	RenderTools()->DrawUIRect(&MainView, vec4(0.0, 0.0, 0.0, 0.25f), CUI::CORNER_ALL, 5.0f);
-	MainView.Margin(5.0f, &MainView);
-
-	// modern scroll
-	static CScrollRegion s_ScrollRegion;
-	vec2 ScrollOffset(0, 0);
-	CScrollRegionParams ScrollParams;
-	ScrollParams.m_ClipBgColor = vec4(0,0,0,0);
-	ScrollParams.m_ScrollSpeed = 15;
+	// scroll, ignore margins
+	MainView.Margin(-5.0f, &MainView);
 	BeginScrollRegion(&s_ScrollRegion, &MainView, &ScrollOffset, &ScrollParams);
+	MainView.Margin(5.0f, &MainView);
 	MainView.y += ScrollOffset.y;
 
 	// options

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -253,7 +253,8 @@ void CMenus::RenderPlayers(CUIRect MainView)
 	// modern scroll
 	static CScrollRegion s_ScrollRegion;
 	vec2 ScrollOffset(0, 0);
-	bool ScrollRegionHasBegun = false;
+	BeginScrollRegion(&s_ScrollRegion, &MainView, &ScrollOffset);
+	MainView.y += ScrollOffset.y;
 
 	// options
 	static int s_aPlayerIDs[MAX_CLIENTS][2] = {{0}};
@@ -265,12 +266,6 @@ void CMenus::RenderPlayers(CUIRect MainView)
 			if(i == m_pClient->m_LocalClientID || !m_pClient->m_aClients[i].m_Active || m_pClient->m_aClients[i].m_Team != Teams[Team])
 				continue;
 
-			if(!ScrollRegionHasBegun)
-			{
-				ScrollRegionHasBegun = true;
-				BeginScrollRegion(&s_ScrollRegion, &MainView, &ScrollOffset);
-				MainView.y += ScrollOffset.y;
-			}
 			MainView.HSplitTop(ButtonHeight, &Row, &MainView);
 			ScrollRegionAddRect(&s_ScrollRegion, Row);
 
@@ -326,9 +321,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 			}
 		}
 	}
-
-	if(ScrollRegionHasBegun)
-		EndScrollRegion(&s_ScrollRegion);
+	EndScrollRegion(&s_ScrollRegion);
 }
 
 void CMenus::RenderServerInfo(CUIRect MainView)

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -253,7 +253,10 @@ void CMenus::RenderPlayers(CUIRect MainView)
 	// modern scroll
 	static CScrollRegion s_ScrollRegion;
 	vec2 ScrollOffset(0, 0);
-	BeginScrollRegion(&s_ScrollRegion, &MainView, &ScrollOffset);
+	CScrollRegionParams ScrollParams;
+	ScrollParams.m_ClipBgColor = vec4(0,0,0,0);
+	ScrollParams.m_ScrollSpeed = 15;
+	BeginScrollRegion(&s_ScrollRegion, &MainView, &ScrollOffset, &ScrollParams);
 	MainView.y += ScrollOffset.y;
 
 	// options

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1442,7 +1442,9 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 
 	static CScrollRegion s_ScrollRegion;
 	vec2 ScrollOffset(0, 0);
-	BeginScrollRegion(&s_ScrollRegion, &MainView, &ScrollOffset);
+	CScrollRegionParams ScrollParams;
+	ScrollParams.m_ClipBgColor = vec4(0,0,0,0);
+	BeginScrollRegion(&s_ScrollRegion, &MainView, &ScrollOffset, &ScrollParams);
 	MainView.y += ScrollOffset.y;
 
 	static int s_MovementDropdown = 0;


### PR DESCRIPTION
This covers https://github.com/teeworlds/teeworlds/issues/1857 except for the server browser, which is pretty tricky because of the layout and arrow keys navigation. I'll look into that one later.

- Changed default values of the background for the scrollbar API (50% -> 25% alpha) to be consistent with the Teeworlds UI
- Fixed too high background alpha in the controls menus
- Updated list boxes to use the new scroll regions
  - this affects a lot of places
- Updated the side bar in the server browser (friends and detail)
  - uses the new scroll regions
  - made the scrollbars larger / more consistent
  - side-effect: fixed a bug with the rounding of the scrollbar (it had negative width iirc)
- Updated the ingame menus players tab to use the new scroll regions


Screenshots:
![screenshot_2019-08-21_21-29-53](https://user-images.githubusercontent.com/355114/63458629-d0766980-c45b-11e9-8dac-dda36594189e.png)
![screenshot_2019-08-21_21-29-56](https://user-images.githubusercontent.com/355114/63458630-d10f0000-c45b-11e9-809a-2aca30b80ac2.png)
![screenshot_2019-08-21_21-29-59](https://user-images.githubusercontent.com/355114/63458632-d10f0000-c45b-11e9-8c0c-eeb22317a480.png)
![screenshot_2019-08-21_21-31-21](https://user-images.githubusercontent.com/355114/63458637-d2402d00-c45b-11e9-821f-fbd016a14a69.png)

![image](https://user-images.githubusercontent.com/355114/63458713-f6037300-c45b-11e9-8eec-2b1782ee862d.png) ![image](https://user-images.githubusercontent.com/355114/63458693-eb48de00-c45b-11e9-8aff-f4eb208e9e9c.png)

![screenshot_2019-08-21_21-30-28](https://user-images.githubusercontent.com/355114/63458636-d1a79680-c45b-11e9-8d13-970c99b0b4ed.png)
