### PR TITLE
Fix motd clipping

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -901,6 +901,7 @@ public:
 					{
 						DrawX = pCursor->m_StartX;
 						DrawY += Size;
+						GotNewLine = 1;
 						DrawX = (int)(DrawX * FakeToScreenX) / FakeToScreenX; // realign
 						DrawY = (int)(DrawY * FakeToScreenY) / FakeToScreenY;
 						++LineCount;

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -471,7 +471,22 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	RenderTools()->DrawUIRect(&Motd, vec4(0.0, 0.0, 0.0, 0.25f), CUI::CORNER_ALL, 5.0f);
 	Motd.Margin(5.0f, &Motd);
 
-	TextRender()->Text(0, Motd.x, Motd.y, ButtonHeight*ms_FontmodHeight*0.8f, m_pClient->m_pMotd->GetMotd(), Motd.w);
+	static CScrollRegion s_ScrollRegion;
+	vec2 ScrollOffset(0, 0);
+	BeginScrollRegion(&s_ScrollRegion, &Motd, &ScrollOffset);
+	Motd.y += ScrollOffset.y;
+
+	CTextCursor Cursor;
+	TextRender()->SetCursor(&Cursor, Motd.x, Motd.y, ButtonHeight*ms_FontmodHeight*0.8f, TEXTFLAG_RENDER);
+	Cursor.m_LineWidth = Motd.w;
+	TextRender()->TextEx(&Cursor, m_pClient->m_pMotd->GetMotd(), -1);
+
+	// define the MOTD text area and make it scrollable
+	CUIRect MotdTextArea;
+	Motd.HSplitTop(Cursor.m_Y-Motd.y+5.0f, &MotdTextArea, &Motd);
+	ScrollRegionAddRect(&s_ScrollRegion, MotdTextArea);
+
+	EndScrollRegion(&s_ScrollRegion);
 }
 
 bool CMenus::RenderServerControlServer(CUIRect MainView)

--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -50,7 +50,13 @@ void CMotd::OnRender()
 	Graphics()->BlendNormal();
 	RenderTools()->DrawRoundRect(&Rect, vec4(0.0f, 0.0f, 0.0f, 0.5f), 40.0f);
 
-	TextRender()->Text(0, x+40.0f, y+40.0f, 32.0f, m_aServerMotd, w-80.0f);
+	Rect.Margin(40.0f, &Rect);
+	float TextSize = 32.0f;
+	CTextCursor Cursor;
+	TextRender()->SetCursor(&Cursor, Rect.x, Rect.y, TextSize, TEXTFLAG_RENDER);
+	Cursor.m_LineWidth = Rect.w;
+	Cursor.m_MaxLines = Rect.h/TextSize;
+	TextRender()->TextEx(&Cursor, m_aServerMotd, -1);
 }
 
 void CMotd::OnMessage(int MsgType, void *pRawMsg)


### PR DESCRIPTION
Closes #2196 

- Fix `TextEx`'s `m_Y` calculation (!). 
  - When all new lines are triggered by a `'\n'` instead of line breaks, `GotNewLine` stays at false and `m_Y` doesn't change! Hours of head scratching on that one...
- Clip MOTD in Server Info tab of the ingame menus:
![screenshot_2019-08-22_14-25-42](https://user-images.githubusercontent.com/355114/63514620-4b399600-c4e9-11e9-83b4-d094622fee42.png)
- ("Soft") Clip the MOTD popup:
  - I'm not using `ClipEnable` on that one, something was really messy with the MapScreen and the TextRender call and I could not figure out why. So I decided to cut the head scratching there and use `Cursor.m_MaxLines = Rect.h/TextSize;`. Because of that, text can overflow horizontally if there is no whitespace character for a while:
![screenshot_2019-08-22_14-19-16](https://user-images.githubusercontent.com/355114/63514738-9489e580-c4e9-11e9-8ed2-7423392f8c2a.png)
 