### PR TITLE
Fix snap item invalidation

### DIFF
--- a/src/base/tl/algorithm.h
+++ b/src/base/tl/algorithm.h
@@ -70,7 +70,7 @@ R find_linear(R range, T value)
 template<class R, class T>
 R find_binary(R range, T value)
 {
-	range = partition_linear(range, value);
+	range = partition_binary(range, value);
 	if(range.empty()) return range;
 	if(range.front() == value) return range;
 	return R();

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -586,20 +586,18 @@ int CClient::LoadData()
 
 const void *CClient::SnapGetItem(int SnapID, int Index, CSnapItem *pItem) const
 {
-	CSnapshotItem *i;
 	dbg_assert(SnapID >= 0 && SnapID < NUM_SNAPSHOT_TYPES, "invalid SnapID");
-	i = m_aSnapshots[SnapID]->m_pAltSnap->GetItem(Index);
+	const CSnapshotItem *i = m_aSnapshots[SnapID]->m_pAltSnap->GetItem(Index);
 	pItem->m_DataSize = m_aSnapshots[SnapID]->m_pAltSnap->GetItemSize(Index);
 	pItem->m_Type = i->Type();
 	pItem->m_ID = i->ID();
-	return (void *)i->Data();
+	return i->Data();
 }
 
 void CClient::SnapInvalidateItem(int SnapID, int Index)
 {
-	CSnapshotItem *i;
 	dbg_assert(SnapID >= 0 && SnapID < NUM_SNAPSHOT_TYPES, "invalid SnapID");
-	i = m_aSnapshots[SnapID]->m_pAltSnap->GetItem(Index);
+	const CSnapshotItem *i = m_aSnapshots[SnapID]->m_pAltSnap->GetItem(Index);
 	if(i)
 	{
 		if((char *)i < (char *)m_aSnapshots[SnapID]->m_pAltSnap || (char *)i > (char *)m_aSnapshots[SnapID]->m_pAltSnap + m_aSnapshots[SnapID]->m_SnapSize)
@@ -610,33 +608,16 @@ void CClient::SnapInvalidateItem(int SnapID, int Index)
 	}
 }
 
-static const int* SnapSearchKey(const int* pKeysStart, const int* pKeysEnd, int Key)
-{
-	int MiddleIndex = (pKeysEnd - pKeysStart) / 2;
-	int Middle = pKeysStart[MiddleIndex];
-	if(MiddleIndex == 0)
-		return Middle == Key ? pKeysStart : 0x0;
-	if(Middle > Key)
-		return SnapSearchKey(pKeysStart, pKeysStart+MiddleIndex, Key);
-	if(Middle < Key)
-		return SnapSearchKey(pKeysStart+MiddleIndex, pKeysEnd, Key);
-	// ==
-	return pKeysStart + MiddleIndex;
-}
-
 const void *CClient::SnapFindItem(int SnapID, int Type, int ID) const
 {
 	if(!m_aSnapshots[SnapID])
 		return 0x0;
 
-	const int NumItems = m_aSnapshots[SnapID]->m_pSnap->NumItems();
 	CSnapshot* pAltSnap = m_aSnapshots[SnapID]->m_pAltSnap;
-	const int* pItemKeys = pAltSnap->GetItemKeys();
-
 	int Key = (Type<<16)|(ID&0xffff);
-	int Index = SnapSearchKey(pItemKeys, pItemKeys+NumItems, Key) - pItemKeys;
-	if(Index >= 0 && Index < NumItems)
-		return (void *)pAltSnap->GetItem(Index)->Data();
+	int Index = pAltSnap->GetItemIndex(Key);
+	if(Index != -1)
+		return pAltSnap->GetItem(Index)->Data();
 
 	return 0x0;
 }

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -1,56 +1,50 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <base/tl/base.h>
+#include <base/tl/algorithm.h>
 #include "snapshot.h"
 #include "compression.h"
 
 // CSnapshot
 
-CSnapshotItem *CSnapshot::GetItem(int Index)
+const CSnapshotItem *CSnapshot::GetItem(int Index) const
 {
-	return (CSnapshotItem *)(DataStart() + Offsets()[Index]);
+	return (const CSnapshotItem *)(DataStart() + Offsets()[Index]);
 }
 
-int CSnapshot::GetItemSize(int Index)
+int CSnapshot::GetItemSize(int Index) const
 {
 	if(Index == m_NumItems-1)
 		return (m_DataSize - Offsets()[Index]) - sizeof(CSnapshotItem);
 	return (Offsets()[Index+1] - Offsets()[Index]) - sizeof(CSnapshotItem);
 }
 
-int CSnapshot::GetItemIndex(int Key)
+int CSnapshot::GetItemIndex(int Key) const
 {
-	// TODO: OPT: this should not be a linear search. very bad
-	const int* pKeys = Keys();
-	const int NumItems = m_NumItems;
+	plain_range_sorted<int> Keys(SortedKeys(), SortedKeys() + m_NumItems);
+	plain_range_sorted<int> r = ::find_binary(Keys, Key);
 
-	for(int i = 0; i < NumItems; i++)
-	{
-		if(pKeys[i] == Key)
-			return i;
-	}
-	return -1;
-}
+	if(r.empty())
+		return -1;
 
-const int* CSnapshot::GetItemKeys() const
-{
-	return Keys();
+	int Index = &r.front() - SortedKeys();
+	if(GetItem(Index)->Key() != Key)
+		return -1; // deleted
+	return Index;
 }
 
 void CSnapshot::InvalidateItem(int Index)
 {
-	CSnapshotItem* pItem = GetItem(Index);
-	pItem->m_TypeAndID = -1;
-	Keys()[Index] = -1;
+	((CSnapshotItem *)(DataStart() + Offsets()[Index]))->Invalidate();
 }
 
-int CSnapshot::Crc()
+int CSnapshot::Crc() const
 {
 	int Crc = 0;
 
 	for(int i = 0; i < m_NumItems; i++)
 	{
-		CSnapshotItem *pItem = GetItem(i);
+		const CSnapshotItem *pItem = GetItem(i);
 		int Size = GetItemSize(i);
 
 		for(int b = 0; b < Size/4; b++)
@@ -59,12 +53,12 @@ int CSnapshot::Crc()
 	return Crc;
 }
 
-void CSnapshot::DebugDump()
+void CSnapshot::DebugDump() const
 {
 	dbg_msg("snapshot", "data_size=%d num_items=%d", m_DataSize, m_NumItems);
 	for(int i = 0; i < m_NumItems; i++)
 	{
-		CSnapshotItem *pItem = GetItem(i);
+		const CSnapshotItem *pItem = GetItem(i);
 		int Size = GetItemSize(i);
 		dbg_msg("snapshot", "\ttype=%d id=%d", pItem->Type(), pItem->ID());
 		for(int b = 0; b < Size/4; b++)
@@ -87,7 +81,7 @@ enum
 	HASHLIST_SIZE = 256,
 };
 
-static void GenerateHash(CItemList *pHashlist, CSnapshot *pSnapshot)
+static void GenerateHash(CItemList *pHashlist, const CSnapshot *pSnapshot)
 {
 	for(int i = 0; i < HASHLIST_SIZE; i++)
 		pHashlist[i].m_Num = 0;
@@ -117,7 +111,7 @@ static int GetItemIndexHashed(int Key, const CItemList *pHashlist)
 	return -1;
 }
 
-static int DiffItem(int *pPast, int *pCurrent, int *pOut, int Size)
+static int DiffItem(const int *pPast, const int *pCurrent, int *pOut, int Size)
 {
 	int Needed = 0;
 	while(Size)
@@ -133,7 +127,7 @@ static int DiffItem(int *pPast, int *pCurrent, int *pOut, int Size)
 	return Needed;
 }
 
-void CSnapshotDelta::UndiffItem(int *pPast, int *pDiff, int *pOut, int Size)
+void CSnapshotDelta::UndiffItem(const int *pPast, const int *pDiff, int *pOut, int Size)
 {
 	while(Size)
 	{
@@ -175,14 +169,14 @@ CSnapshotDelta::CData *CSnapshotDelta::EmptyDelta()
 }
 
 // TODO: OPT: this should be made much faster
-int CSnapshotDelta::CreateDelta(CSnapshot *pFrom, CSnapshot *pTo, void *pDstData)
+int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, CSnapshot *pTo, void *pDstData)
 {
 	CData *pDelta = (CData *)pDstData;
 	int *pData = (int *)pDelta->m_pData;
 	int i, ItemSize, PastIndex;
-	CSnapshotItem *pFromItem;
-	CSnapshotItem *pCurItem;
-	CSnapshotItem *pPastItem;
+	const CSnapshotItem *pFromItem;
+	const CSnapshotItem *pCurItem;
+	const CSnapshotItem *pPastItem;
 	int SizeCount = 0;
 
 	pDelta->m_NumDeletedItems = 0;
@@ -233,7 +227,7 @@ int CSnapshotDelta::CreateDelta(CSnapshot *pFrom, CSnapshot *pTo, void *pDstData
 			if(m_aItemSizes[pCurItem->Type()])
 				pItemDataDst = pData+2;
 
-			if(DiffItem((int*)pPastItem->Data(), (int*)pCurItem->Data(), pItemDataDst, ItemSize/4))
+			if(DiffItem(pPastItem->Data(), (int*)pCurItem->Data(), pItemDataDst, ItemSize/4))
 			{
 
 				*pData++ = pCurItem->Type();
@@ -283,23 +277,23 @@ int CSnapshotDelta::CreateDelta(CSnapshot *pFrom, CSnapshot *pTo, void *pDstData
 	return (int)((char*)pData-(char*)pDstData);
 }
 
-static int RangeCheck(void *pEnd, void *pPtr, int Size)
+static int RangeCheck(const void *pEnd, const void *pPtr, int Size)
 {
 	if((const char *)pPtr + Size > (const char *)pEnd)
 		return -1;
 	return 0;
 }
 
-int CSnapshotDelta::UnpackDelta(CSnapshot *pFrom, CSnapshot *pTo, void *pSrcData, int DataSize)
+int CSnapshotDelta::UnpackDelta(const CSnapshot *pFrom, CSnapshot *pTo, const void *pSrcData, int DataSize)
 {
 	CSnapshotBuilder Builder;
-	CData *pDelta = (CData *)pSrcData;
-	int *pData = (int *)pDelta->m_pData;
-	int *pEnd = (int *)(((char *)pSrcData + DataSize));
+	const CData *pDelta = (const CData *)pSrcData;
+	const int *pData = (const int *)pDelta->m_pData;
+	const int *pEnd = (const int *)(((const char *)pSrcData + DataSize));
 
-	CSnapshotItem *pFromItem;
+	const CSnapshotItem *pFromItem;
 	int Keep, ItemSize;
-	int *pDeleted;
+	const int *pDeleted;
 	int ID, Type, Key;
 	int FromIndex;
 	int *pNewData;
@@ -359,7 +353,7 @@ int CSnapshotDelta::UnpackDelta(CSnapshot *pFrom, CSnapshot *pTo, void *pSrcData
 
 		if(RangeCheck(pEnd, pData, ItemSize) || ItemSize < 0) return -3;
 
-		Key = (Type<<16)|ID;
+		Key = (Type<<16)|(ID&0xffff);
 
 		// create the item if needed
 		pNewData = Builder.GetItemData(Key);
@@ -372,7 +366,7 @@ int CSnapshotDelta::UnpackDelta(CSnapshot *pFrom, CSnapshot *pTo, void *pSrcData
 		if(FromIndex != -1)
 		{
 			// we got an update so we need to apply the diff
-			UndiffItem((int *)pFrom->GetItem(FromIndex)->Data(), pData, pNewData, ItemSize/4);
+			UndiffItem(pFrom->GetItem(FromIndex)->Data(), pData, pNewData, ItemSize/4);
 			m_aSnapshotDataUpdates[m_SnapshotCurrent]++;
 		}
 		else // no previous, just copy the pData
@@ -538,15 +532,15 @@ int *CSnapshotBuilder::GetItemData(int Key)
 	for(i = 0; i < m_NumItems; i++)
 	{
 		if(GetItem(i)->Key() == Key)
-			return (int *)GetItem(i)->Data();
+			return GetItem(i)->Data();
 	}
 	return 0;
 }
 
-int CSnapshotBuilder::Finish(void *pSpnapData)
+int CSnapshotBuilder::Finish(void *pSnapdata)
 {
 	// flattern and make the snapshot
-	CSnapshot *pSnap = (CSnapshot *)pSpnapData;
+	CSnapshot *pSnap = (CSnapshot *)pSnapdata;
 	int OffsetSize = sizeof(int)*m_NumItems;
 	int KeySize = sizeof(int)*m_NumItems;
 	pSnap->m_DataSize = m_DataSize;
@@ -555,7 +549,7 @@ int CSnapshotBuilder::Finish(void *pSpnapData)
 	const int NumItems = m_NumItems;
 	for(int i = 0; i < NumItems; i++)
 	{
-		pSnap->Keys()[i] = GetItem(i)->Key();
+		pSnap->SortedKeys()[i] = GetItem(i)->Key();
 	}
 
 	// get full item sizes
@@ -575,10 +569,10 @@ int CSnapshotBuilder::Finish(void *pSpnapData)
 
 		for(int i = 1; i < NumItems; i++)
 		{
-			if(pSnap->Keys()[i-1] > pSnap->Keys()[i])
+			if(pSnap->SortedKeys()[i-1] > pSnap->SortedKeys()[i])
 			{
 				Sorting = true;
-				tl_swap(pSnap->Keys()[i], pSnap->Keys()[i-1]);
+				tl_swap(pSnap->SortedKeys()[i], pSnap->SortedKeys()[i-1]);
 				tl_swap(m_aOffsets[i], m_aOffsets[i-1]);
 				tl_swap(aItemSizes[i], aItemSizes[i-1]);
 			}
@@ -610,7 +604,7 @@ void *CSnapshotBuilder::NewItem(int Type, int ID, int Size)
 	CSnapshotItem *pObj = (CSnapshotItem *)(m_aData + m_DataSize);
 
 	mem_zero(pObj, sizeof(CSnapshotItem) + Size);
-	pObj->m_TypeAndID = (Type<<16)|ID;
+	pObj->SetKey(Type, ID);
 	m_aOffsets[m_NumItems] = m_DataSize;
 	m_DataSize += sizeof(CSnapshotItem) + Size;
 	m_NumItems++;

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -9,13 +9,18 @@
 
 class CSnapshotItem
 {
-public:
+	friend class CSnapshotBuilder;
 	int m_TypeAndID;
 
 	int *Data() { return (int *)(this+1); }
-	int Type() { return m_TypeAndID>>16; }
-	int ID() { return m_TypeAndID&0xffff; }
-	int Key() { return m_TypeAndID; }
+
+public:
+	const int *Data() const { return (int *)(this+1); }
+	int Type() const { return m_TypeAndID>>16; }
+	int ID() const { return m_TypeAndID&0xffff; }
+	int Key() const { return m_TypeAndID; }
+	void SetKey(int Type, int ID) { m_TypeAndID = (Type<<16)|(ID&0xffff); }
+	void Invalidate() { m_TypeAndID = -1; }
 };
 
 
@@ -25,8 +30,8 @@ class CSnapshot
 	int m_DataSize;
 	int m_NumItems;
 
-	int *Keys() const { return (int *)(this+1); }
-	int *Offsets() const { return (int *)(Keys()+m_NumItems); }
+	int *SortedKeys() const { return (int *)(this+1); }
+	int *Offsets() const { return (int *)(SortedKeys()+m_NumItems); }
 	char *DataStart() const { return (char*)(Offsets()+m_NumItems); }
 
 public:
@@ -38,14 +43,13 @@ public:
 
 	void Clear() { m_DataSize = 0; m_NumItems = 0; }
 	int NumItems() const { return m_NumItems; }
-	CSnapshotItem *GetItem(int Index);
-	int GetItemSize(int Index);
-	int GetItemIndex(int Key);
-	const int* GetItemKeys() const;
+	const CSnapshotItem *GetItem(int Index) const;
+	int GetItemSize(int Index) const;
+	int GetItemIndex(int Key) const;
 	void InvalidateItem(int Index);
 
-	int Crc();
-	void DebugDump();
+	int Crc() const;
+	void DebugDump() const;
 };
 
 
@@ -71,16 +75,16 @@ private:
 	int m_SnapshotCurrent;
 	CData m_Empty;
 
-	void UndiffItem(int *pPast, int *pDiff, int *pOut, int Size);
+	void UndiffItem(const int *pPast, const int *pDiff, int *pOut, int Size);
 
 public:
 	CSnapshotDelta();
-	int GetDataRate(int Index) { return m_aSnapshotDataRate[Index]; }
-	int GetDataUpdates(int Index) { return m_aSnapshotDataUpdates[Index]; }
+	int GetDataRate(int Index) const { return m_aSnapshotDataRate[Index]; }
+	int GetDataUpdates(int Index) const { return m_aSnapshotDataUpdates[Index]; }
 	void SetStaticsize(int ItemType, int Size);
 	CData *EmptyDelta();
-	int CreateDelta(class CSnapshot *pFrom, class CSnapshot *pTo, void *pData);
-	int UnpackDelta(class CSnapshot *pFrom, class CSnapshot *pTo, void *pData, int DataSize);
+	int CreateDelta(const class CSnapshot *pFrom, class CSnapshot *pTo, void *pData);
+	int UnpackDelta(const class CSnapshot *pFrom, class CSnapshot *pTo, const void *pData, int DataSize);
 };
 
 


### PR DESCRIPTION
When a snapitem is invalidated, its entry in the list of keys is set to -1.
This breaks the binary search, introduced by https://github.com/teeworlds/teeworlds/pull/2129.
Instead of modifying the list itself, I only modify the key value inside the item.

Meanwhile I marked some things in the snapshot code as `const`.