### PR TITLE
Bam: add DLLs to download job output, fix first-time build fails

### DIFF
--- a/bam.lua
+++ b/bam.lua
@@ -391,8 +391,8 @@ function BuildContent(settings, arch, conf)
 		end
 		-- dependencies
 		dl = Python("scripts/download.py")
-		AddJob("other/sdl/include/SDL.h", "Downloading SDL2", dl .. " sdl")
-		AddJob("other/freetype/include/ft2build.h", "Downloading freetype", dl .. " freetype")
+		AddJob({"other/sdl/include/SDL.h", "other/sdl/windows/lib64/SDL2.dll"}, "Downloading SDL2", dl .. " sdl")
+		AddJob({"other/freetype/include/ft2build.h", "other/freetype/windows/lib64/freetype.dll"}, "Downloading freetype", dl .. " freetype")
 		table.insert(content, CopyFile(settings.link.Output(settings, "") .. "/SDL2.dll", "other/sdl/windows/lib" .. _arch .. "/SDL2.dll"))
 		table.insert(content, CopyFile(settings.link.Output(settings, "") .. "/freetype.dll", "other/freetype/windows/lib" .. _arch .. "/freetype.dll"))
 		AddDependency(settings.link.Output(settings, "") .. "/SDL2.dll", "other/sdl/include/SDL.h")

--- a/bam.lua
+++ b/bam.lua
@@ -391,8 +391,8 @@ function BuildContent(settings, arch, conf)
 		end
 		-- dependencies
 		dl = Python("scripts/download.py")
-		AddJob({"other/sdl/include/SDL.h", "other/sdl/windows/lib64/SDL2.dll"}, "Downloading SDL2", dl .. " sdl")
-		AddJob({"other/freetype/include/ft2build.h", "other/freetype/windows/lib64/freetype.dll"}, "Downloading freetype", dl .. " freetype")
+		AddJob({"other/sdl/include/SDL.h", "other/sdl/windows/lib" .. _arch .. "/SDL2.dll"}, "Downloading SDL2", dl .. " sdl")
+		AddJob({"other/freetype/include/ft2build.h", "other/freetype/windows/lib" .. _arch .. "/freetype.dll"}, "Downloading freetype", dl .. " freetype")
 		table.insert(content, CopyFile(settings.link.Output(settings, "") .. "/SDL2.dll", "other/sdl/windows/lib" .. _arch .. "/SDL2.dll"))
 		table.insert(content, CopyFile(settings.link.Output(settings, "") .. "/freetype.dll", "other/freetype/windows/lib" .. _arch .. "/freetype.dll"))
 		AddDependency(settings.link.Output(settings, "") .. "/SDL2.dll", "other/sdl/include/SDL.h")


### PR DESCRIPTION
```
git pull https://github.com/teeworlds/teeworlds/
bam\bam
```
should work, yet it never has. This adds a target `libs` and finally fixes https://github.com/teeworlds/teeworlds/issues/2136