### PR TITLE
Don't show loading progression in LAN tab

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1236,7 +1236,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	DoEditBox(&g_Config.m_UiServerAddress, &EditBox, g_Config.m_UiServerAddress, sizeof(g_Config.m_UiServerAddress), ButtonHeight*ms_FontmodHeight*0.8f, &s_AddressOffset, false, CUI::CORNER_ALL);
 
 	// render status
-	if(ServerBrowser()->IsRefreshing())
+	if(ServerBrowser()->IsRefreshing() && m_ActivePage != PAGE_LAN)
 	{
 		char aBuf[128];
 		Status.HSplitTop(ButtonHeight + SpacingH, 0, &Status);


### PR DESCRIPTION
Fix #2228 
We don't keep track of requests to local servers anyway:
https://github.com/teeworlds/teeworlds/blob/af6f367fbbbc4e706f229f0d8a1f520435bfe324/src/engine/client/serverbrowser.cpp#L297-L301
so a progression bar doesn't make sense.