### PR TITLE
Split demo recordings per game, client-side

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -925,7 +925,10 @@ void CGameClient::OnEnterGame() {}
 void CGameClient::OnGameOver()
 {
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && g_Config.m_ClEditor == 0)
+	{
 		Client()->AutoScreenshot_Start();
+		Client()->DemoRecorder_Stop();
+	}
 }
 
 void CGameClient::OnStartGame()


### PR DESCRIPTION
Fix #2050
I think it's a bug. There was this already:

https://github.com/Dune-jr/teeworlds/blob/0fcb3f7f631192536a6c56eba8bf35e6c28f7197/src/game/client/gameclient.cpp#L934-L938

and it already works server side (even does it a bit too much, if you `change_map`, you will get an empty demo...)