### PR TITLE
Map fixes

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2856,11 +2856,16 @@ static void ModifySortedIndex(int *pIndex)
 		*pIndex = gs_pSortedIndex[*pIndex];
 }
 
+static int CompareImage(const CEditorImage *pImage1, const CEditorImage *pImage2)
+{
+	return *pImage1 < *pImage2;
+}
+
 void CEditor::SortImages()
 {
 	bool Sorted = true;
 	for(int i = 1; i < m_Map.m_lImages.size(); i++)
-		if( str_comp(m_Map.m_lImages[i]->m_aName, m_Map.m_lImages[i-1]->m_aName) < 0 )
+		if(*m_Map.m_lImages[i] < *m_Map.m_lImages[i-1])
 		{
 			Sorted = false;
 			break;
@@ -2871,7 +2876,7 @@ void CEditor::SortImages()
 		array<CEditorImage*> lTemp = array<CEditorImage*>(m_Map.m_lImages);
 		gs_pSortedIndex = new int[lTemp.size()];
 
-		std::stable_sort(&m_Map.m_lImages[0], &m_Map.m_lImages[m_Map.m_lImages.size()]);
+		std::stable_sort(&m_Map.m_lImages[0], &m_Map.m_lImages[m_Map.m_lImages.size()], CompareImage);
 
 		for(int OldIndex = 0; OldIndex < lTemp.size(); OldIndex++)
 			for(int NewIndex = 0; NewIndex < m_Map.m_lImages.size(); NewIndex++)

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -286,7 +286,7 @@ public:
 	char m_aName[128];
 	unsigned char m_aTileFlags[256];
 	class IAutoMapper *m_pAutoMapper;
-	bool operator<(const CEditorImage &Other) const { return str_comp(m_aName, Other.m_aName); }
+	bool operator<(const CEditorImage &Other) const { return str_comp(m_aName, Other.m_aName) < 0; }
 };
 
 class CEditorMap

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -128,6 +128,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				CMapItemLayerTilemap Item;
 				Item.m_Version = CMapItemLayerTilemap::CURRENT_VERSION;
 
+				Item.m_Layer.m_Version = 0; // unused
 				Item.m_Layer.m_Flags = pLayer->m_Flags;
 				Item.m_Layer.m_Type = pLayer->m_Type;
 
@@ -157,6 +158,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				{
 					CMapItemLayerQuads Item;
 					Item.m_Version = CMapItemLayerQuads::CURRENT_VERSION;
+					Item.m_Layer.m_Version = 0; // unused
 					Item.m_Layer.m_Flags = pLayer->m_Flags;
 					Item.m_Layer.m_Type = pLayer->m_Type;
 					Item.m_Image = pLayer->m_Image;
@@ -488,6 +490,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 					{
 						// backwards compatibility
 						CEnvPoint_v1 *pEnvPoint_v1 = &((CEnvPoint_v1 *)pEnvPoints)[pItem->m_StartPoint + n];
+						mem_zero((void*)&pEnv->m_lPoints[n], sizeof(CEnvPoint));
 
 						pEnv->m_lPoints[n].m_Time = pEnvPoint_v1->m_Time;
 						pEnv->m_lPoints[n].m_Curvetype = pEnvPoint_v1->m_Curvetype;
@@ -495,10 +498,6 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						for(int c = 0; c < pItem->m_Channels; c++)
 						{
 							pEnv->m_lPoints[n].m_aValues[c] = pEnvPoint_v1->m_aValues[c];
-							pEnv->m_lPoints[n].m_aInTangentdx[c] = 0;
-							pEnv->m_lPoints[n].m_aInTangentdy[c] = 0;
-							pEnv->m_lPoints[n].m_aOutTangentdx[c] = 0;
-							pEnv->m_lPoints[n].m_aOutTangentdy[c] = 0;
 						}
 					}
 				}


### PR DESCRIPTION
- Initialize the data items of the map files before saving them
- Fix the sorting of map images

When you just resave a map without modifying it, you will get the same hash now. Until now it was rather random.