### PR TITLE
left player does not deal damage

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -692,6 +692,10 @@ bool CCharacter::TakeDamage(vec2 Force, vec2 Source, int Dmg, int From, int Weap
 {
 	m_Core.m_Vel += Force;
 
+	// a left player does not deal damage
+	if(From == PLAYER_LEFT)
+		return false;
+
 	if(GameServer()->m_pController->IsFriendlyFire(m_pPlayer->GetCID(), From))
 		return false;
 

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -28,6 +28,12 @@ void CProjectile::Reset()
 	GameServer()->m_World.DestroyEntity(this);
 }
 
+void CProjectile::LoseOwner(int Owner)
+{
+	if(m_Owner == Owner)
+		m_Owner = PLAYER_LEFT;
+}
+
 vec2 CProjectile::GetPos(float Time)
 {
 	float Curvature = 0;

--- a/src/game/server/entities/projectile.h
+++ b/src/game/server/entities/projectile.h
@@ -3,6 +3,11 @@
 #ifndef GAME_SERVER_ENTITIES_PROJECTILE_H
 #define GAME_SERVER_ENTITIES_PROJECTILE_H
 
+enum
+{
+	PLAYER_LEFT = -1
+};
+
 class CProjectile : public CEntity
 {
 public:
@@ -11,6 +16,8 @@ public:
 
 	vec2 GetPos(float Time);
 	void FillInfo(CNetObj_Projectile *pProj);
+
+	void LoseOwner(int Owner);
 
 	virtual void Reset();
 	virtual void Tick();

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -12,6 +12,7 @@
 #include <game/version.h>
 
 #include "entities/character.h"
+#include "entities/projectile.h"
 #include "gamemodes/ctf.h"
 #include "gamemodes/dm.h"
 #include "gamemodes/lms.h"
@@ -722,6 +723,11 @@ void CGameContext::OnClientDrop(int ClientID, const char *pReason)
 			Msg.m_Silent = true;
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL|MSGFLAG_NORECORD, -1);
 	}
+
+	// mark projectile owned by the client
+	CProjectile *p = (CProjectile *)m_World.FindFirst(CGameWorld::ENTTYPE_PROJECTILE);
+	for(; p; p = (CProjectile *)p->TypeNext())
+		p->LoseOwner(ClientID);
 
 	delete m_apPlayers[ClientID];
 	m_apPlayers[ClientID] = 0;


### PR DESCRIPTION
Update projectile's owner to a constant when the owner disconnect (fix #2243 )

Note: I wonder if this could apply when a player changes team (including spectator)