### PR TITLE
add team info to projectile

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -276,7 +276,7 @@ Messages = [
 	]),
 
 	NetMessage("Sv_KillMsg", [
-		NetIntRange("m_Killer", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_Killer", -2, 'MAX_CLIENTS-1'),
 		NetIntRange("m_Victim", 0, 'MAX_CLIENTS-1'),
 		NetIntRange("m_Weapon", -3, 'NUM_WEAPONS-1'),
 		NetIntAny("m_ModeSpecial"),

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -10,6 +10,8 @@
 #include <game/client/animstate.h>
 #include "killmessages.h"
 
+#include "skins.h"
+
 void CKillMessages::OnReset()
 {
 	m_KillmsgCurrent = 0;
@@ -31,9 +33,36 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 		Kill.m_VictimRenderInfo = m_pClient->m_aClients[Kill.m_VictimID].m_RenderInfo;
 
 		Kill.m_KillerID = pMsg->m_Killer;
-		Kill.m_KillerTeam = m_pClient->m_aClients[Kill.m_KillerID].m_Team;
-		str_format(Kill.m_aKillerName, sizeof(Kill.m_aKillerName), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[Kill.m_KillerID].m_aName : "");
-		Kill.m_KillerRenderInfo = m_pClient->m_aClients[Kill.m_KillerID].m_RenderInfo;
+		if (Kill.m_KillerID >= 0)
+		{
+			Kill.m_KillerTeam = m_pClient->m_aClients[Kill.m_KillerID].m_Team;
+			str_format(Kill.m_aKillerName, sizeof(Kill.m_aKillerName), "%s", g_Config.m_ClShowsocial ? m_pClient->m_aClients[Kill.m_KillerID].m_aName : "");
+			Kill.m_KillerRenderInfo = m_pClient->m_aClients[Kill.m_KillerID].m_RenderInfo;
+		}
+		else
+		{
+			bool IsTeamplay = (m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS) != 0;
+			Kill.m_KillerTeam = - 1 - Kill.m_KillerID;
+			Kill.m_aKillerName[0] = 0;
+			int Skin = m_pClient->m_pSkins->Find("dummy", false);
+			if (Skin != -1)
+			{
+				const CSkins::CSkin *pDummy = m_pClient->m_pSkins->Get(Skin);
+				for(int p = 0; p < NUM_SKINPARTS; p++)
+				{
+					Kill.m_KillerRenderInfo.m_aTextures[p] = pDummy->m_apParts[p]->m_OrgTexture;
+					if(IsTeamplay)
+					{
+						int ColorVal = m_pClient->m_pSkins->GetTeamColor(0, 0x000000, Kill.m_KillerTeam, p);
+						Kill.m_KillerRenderInfo.m_aColors[p] = m_pClient->m_pSkins->GetColorV4(ColorVal, p==SKINPART_MARKING);
+					}
+					else
+						Kill.m_KillerRenderInfo.m_aColors[p] = m_pClient->m_pSkins->GetColorV4(0x000000, p==SKINPART_MARKING);
+					Kill.m_KillerRenderInfo.m_aColors[p].a *= .5f;
+				}
+				Kill.m_KillerRenderInfo.m_Size = 64.0f;
+			}
+		}
 
 		Kill.m_Weapon = pMsg->m_Weapon;
 		Kill.m_ModeSpecial = pMsg->m_ModeSpecial;
@@ -141,12 +170,17 @@ void CKillMessages::OnRender()
 			RenderTools()->RenderTee(CAnimState::GetIdle(), &m_aKillmsgs[r].m_KillerRenderInfo, EMOTE_ANGRY, vec2(1,0), vec2(x, y+28));
 			x -= 32.0f;
 
-			// render killer name
-			x -= KillerNameW;
-			TextRender()->SetCursor(&Cursor, x, y, FontSize, TEXTFLAG_RENDER);
+			if(m_aKillmsgs[r].m_KillerID >= 0)
+			{
+				// render killer name
+				x -= KillerNameW;
+				TextRender()->SetCursor(&Cursor, x, y, FontSize, TEXTFLAG_RENDER);
 
-			RenderTools()->DrawClientID(TextRender(), &Cursor, m_aKillmsgs[r].m_KillerID);
-			TextRender()->TextEx(&Cursor, m_aKillmsgs[r].m_aKillerName, -1);
+				RenderTools()->DrawClientID(TextRender(), &Cursor, m_aKillmsgs[r].m_KillerID);
+
+				TextRender()->TextEx(&Cursor, m_aKillmsgs[r].m_aKillerName, -1);
+			}
+
 		}
 
 		y += 46.0f;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -677,11 +677,25 @@ void CCharacter::Die(int Killer, int Weapon)
 
 	// send the kill message
 	CNetMsg_Sv_KillMsg Msg;
-	Msg.m_Killer = Killer;
 	Msg.m_Victim = m_pPlayer->GetCID();
-	Msg.m_Weapon = Weapon;
 	Msg.m_ModeSpecial = ModeSpecial;
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, -1);
+	for(int i = 0 ; i < Server()->MaxClients(); i++)
+	{
+		if(!Server()->ClientIngame(i))
+			continue;
+
+		if(Server()->GetClientVersion(i) >= MIN_KILLMESSAGE_CLIENTVERSION)
+		{
+			Msg.m_Killer = 0;
+			Msg.m_Weapon = WEAPON_WORLD;
+		}
+		else
+		{
+			Msg.m_Killer = Killer;
+			Msg.m_Weapon = Weapon;
+		}
+		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, i);
+	}
 
 	// a nice sound
 	GameServer()->CreateSound(m_Pos, SOUND_PLAYER_DIE);

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -17,6 +17,11 @@ public:
 	//character's size
 	static const int ms_PhysSize = 28;
 
+	enum
+	{
+		MIN_KILLMESSAGE_CLIENTVERSION=0x0704,   // todo 0.8: remove me
+	};
+
 	CCharacter(CGameWorld *pWorld);
 
 	virtual void Reset();

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <game/server/gamecontext.h>
+#include <game/server/player.h>
 
 #include "character.h"
 #include "projectile.h"
@@ -13,6 +14,7 @@ CProjectile::CProjectile(CGameWorld *pGameWorld, int Type, int Owner, vec2 Pos, 
 	m_Direction = Dir;
 	m_LifeSpan = Span;
 	m_Owner = Owner;
+	m_OwnerTeam = GameServer()->m_apPlayers[Owner]->GetTeam();
 	m_Force = Force;
 	m_Damage = Damage;
 	m_SoundImpact = SoundImpact;
@@ -26,6 +28,14 @@ CProjectile::CProjectile(CGameWorld *pGameWorld, int Type, int Owner, vec2 Pos, 
 void CProjectile::Reset()
 {
 	GameServer()->m_World.DestroyEntity(this);
+}
+
+void CProjectile::LoseOwner()
+{
+	if(m_OwnerTeam == TEAM_BLUE)
+		m_Owner = PLAYER_TEAM_BLUE;
+	else
+		m_Owner = PLAYER_TEAM_RED;
 }
 
 vec2 CProjectile::GetPos(float Time)

--- a/src/game/server/entities/projectile.h
+++ b/src/game/server/entities/projectile.h
@@ -3,6 +3,12 @@
 #ifndef GAME_SERVER_ENTITIES_PROJECTILE_H
 #define GAME_SERVER_ENTITIES_PROJECTILE_H
 
+enum
+{
+	PLAYER_TEAM_BLUE = -2,
+	PLAYER_TEAM_RED = -1
+};
+
 class CProjectile : public CEntity
 {
 public:
@@ -11,6 +17,9 @@ public:
 
 	vec2 GetPos(float Time);
 	void FillInfo(CNetObj_Projectile *pProj);
+
+	int GetOwner() const { return m_Owner; }
+	void LoseOwner();
 
 	virtual void Reset();
 	virtual void Tick();
@@ -21,6 +30,7 @@ private:
 	vec2 m_Direction;
 	int m_LifeSpan;
 	int m_Owner;
+	int m_OwnerTeam;
 	int m_Type;
 	int m_Damage;
 	int m_SoundImpact;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -12,6 +12,7 @@
 #include <game/version.h>
 
 #include "entities/character.h"
+#include "entities/projectile.h"
 #include "gamemodes/ctf.h"
 #include "gamemodes/dm.h"
 #include "gamemodes/lms.h"
@@ -696,6 +697,14 @@ void CGameContext::OnClientTeamChange(int ClientID)
 {
 	if(m_apPlayers[ClientID]->GetTeam() == TEAM_SPECTATORS)
 		AbortVoteOnTeamChange(ClientID);
+
+	// mark client's projectile has team projectile
+	CProjectile *p = (CProjectile *)m_World.FindFirst(CGameWorld::ENTTYPE_PROJECTILE);
+	for(; p; p = (CProjectile *)p->TypeNext())
+	{
+		if(p->GetOwner() == ClientID)
+			p->LoseOwner();
+	}
 }
 
 void CGameContext::OnClientDrop(int ClientID, const char *pReason)
@@ -721,6 +730,14 @@ void CGameContext::OnClientDrop(int ClientID, const char *pReason)
 		if(g_Config.m_SvSilentSpectatorMode && m_apPlayers[ClientID]->GetTeam() == TEAM_SPECTATORS)
 			Msg.m_Silent = true;
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL|MSGFLAG_NORECORD, -1);
+	}
+
+	// mark client's projectile has team projectile
+	CProjectile *p = (CProjectile *)m_World.FindFirst(CGameWorld::ENTTYPE_PROJECTILE);
+	for(; p; p = (CProjectile *)p->TypeNext())
+	{
+		if(p->GetOwner() == ClientID)
+			p->LoseOwner();
 	}
 
 	delete m_apPlayers[ClientID];

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -868,6 +868,11 @@ bool IGameController::IsFriendlyFire(int ClientID1, int ClientID2) const
 	return false;
 }
 
+bool IGameController::IsFriendlyTeamFire(int Team1, int Team2) const
+{
+	return IsTeamplay() && !g_Config.m_SvTeamdamage && Team1 == Team2;
+}
+
 bool IGameController::IsPlayerReadyMode() const
 {
 	return g_Config.m_SvPlayerReadyMode != 0 && (m_GameStateTimer == TIMER_INFINITE && (m_GameState == IGS_WARMUP_USER || m_GameState == IGS_GAME_PAUSED));

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -191,15 +191,16 @@ public:
 	// info
 	void CheckGameInfo();
 	bool IsFriendlyFire(int ClientID1, int ClientID2) const;
+	bool IsFriendlyTeamFire(int Team1, int Team2) const;
 	bool IsGamePaused() const { return m_GameState == IGS_GAME_PAUSED || m_GameState == IGS_START_COUNTDOWN; }
 	bool IsGameRunning() const { return m_GameState == IGS_GAME_RUNNING; }
 	bool IsPlayerReadyMode() const;
 	bool IsTeamChangeAllowed() const;
 	bool IsTeamplay() const { return m_GameFlags&GAMEFLAG_TEAMS; }
 	bool IsSurvival() const { return m_GameFlags&GAMEFLAG_SURVIVAL; }
-	
+
 	const char *GetGameType() const { return m_pGameType; }
-	
+
 	// map
 	void ChangeMap(const char *pToMap);
 


### PR DESCRIPTION
this PR changes network but old client might drop packages only meant for stats and kill messages

The projectile initial team is set up at initialisation and may be used if the owner changes team or leaves the server. Then the projectile gets a dummy owner id depending on the team.

This is used later in the function TakeDamages in order to check friendly fire.
Thus for this purpose, I add a function IsFriendlyTeamFire.