### PR TITLE
Allow slightly more text to be displayed by the motd.

### DIFF
--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -48,14 +48,14 @@ void CMotd::OnRender()
 	CUIRect Rect = {x, y, w, h};
 
 	Graphics()->BlendNormal();
-	RenderTools()->DrawRoundRect(&Rect, vec4(0.0f, 0.0f, 0.0f, 0.5f), 40.0f);
+	RenderTools()->DrawRoundRect(&Rect, vec4(0.0f, 0.0f, 0.0f, 0.5f), 30.0f);
 
-	Rect.Margin(40.0f, &Rect);
+	Rect.Margin(30.0f, &Rect);
 	float TextSize = 32.0f;
 	CTextCursor Cursor;
 	TextRender()->SetCursor(&Cursor, Rect.x, Rect.y, TextSize, TEXTFLAG_RENDER);
 	Cursor.m_LineWidth = Rect.w;
-	Cursor.m_MaxLines = Rect.h/TextSize;
+	Cursor.m_MaxLines = ceil(Rect.h/TextSize);
 	TextRender()->TextEx(&Cursor, m_aServerMotd, -1);
 }
 


### PR DESCRIPTION
Fix #2258 .

![image](https://user-images.githubusercontent.com/294603/66225321-757d9680-e6d8-11e9-9eca-bfd820d11e46.png)

It was not really a bug since the first screenshot in the issue shows a clearly overflowing text at the bottom and @Dune-jr PR fixes overflowing. However it was a bit aggressive in cutting the last line.
Since the mapped screen height is constant, it should always look like the screenshot in the maximum line case.
