### PR TITLE
add missing policy for legacy opengl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ else()
   message(FATAL_ERROR "Couldn't parse version from src/game/version.h")
 endif()
 
+if(POLICY CMP0072)
+  cmake_policy(SET CMP0072 OLD)
+endif()
+
 if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW)
 endif()


### PR DESCRIPTION
Without this policy you can't compile with cmake when a newer opengl is installed.
Teeworlds uses LEGACY OpenGL code. See cmake policy [CMP0072](https://cmake.org/cmake/help/git-stage/policy/CMP0072.html)