### PR TITLE
Use OpenSSL md5 if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,7 +482,10 @@ add_library(md5 EXCLUDE_FROM_ALL OBJECT ${DEP_MD5_SRC})
 
 list(APPEND TARGETS_DEP json md5)
 set(DEP_JSON $<TARGET_OBJECTS:json>)
-set(DEP_MD5 $<TARGET_OBJECTS:md5>)
+set(DEP_MD5)
+if(NOT CRYPTO_FOUND)
+  set(DEP_MD5 $<TARGET_OBJECTS:md5>)
+endif()
 
 ########################################################################
 # DATA
@@ -1173,6 +1176,7 @@ set_src(BASE GLOB_RECURSE src/base
   detect.h
   hash.c
   hash.h
+  hash_bundled.c
   hash_ctxt.h
   hash_libtomcrypt.c
   hash_openssl.c

--- a/src/base/hash.c
+++ b/src/base/hash.c
@@ -3,6 +3,30 @@
 
 #include "system.h"
 
+static void digest_str(const unsigned char *digest, size_t digest_len, char *str, size_t max_len)
+{
+	unsigned i;
+	if(max_len > digest_len * 2 + 1)
+	{
+		max_len = digest_len * 2 + 1;
+	}
+	str[max_len - 1] = 0;
+	max_len -= 1;
+	for(i = 0; i < max_len; i++)
+	{
+		static const char HEX[] = "0123456789abcdef";
+		int index = i / 2;
+		if(i % 2 == 0)
+		{
+			str[i] = HEX[digest[index] >> 4];
+		}
+		else
+		{
+			str[i] = HEX[digest[index] & 0xf];
+		}
+	}
+}
+
 SHA256_DIGEST sha256(const void *message, size_t message_len)
 {
 	SHA256_CTX ctxt;
@@ -13,29 +37,28 @@ SHA256_DIGEST sha256(const void *message, size_t message_len)
 
 void sha256_str(SHA256_DIGEST digest, char *str, size_t max_len)
 {
-	unsigned i;
-	if(max_len > SHA256_MAXSTRSIZE)
-	{
-		max_len = SHA256_MAXSTRSIZE;
-	}
-	str[max_len - 1] = 0;
-	max_len -= 1;
-	for(i = 0; i < max_len; i++)
-	{
-		static const char HEX[] = "0123456789abcdef";
-		int index = i / 2;
-		if(i % 2 == 0)
-		{
-			str[i] = HEX[digest.data[index] >> 4];
-		}
-		else
-		{
-			str[i] = HEX[digest.data[index] & 0xf];
-		}
-	}
+	digest_str(digest.data, sizeof(digest.data), str, max_len);
 }
 
 int sha256_comp(SHA256_DIGEST digest1, SHA256_DIGEST digest2)
+{
+	return mem_comp(digest1.data, digest2.data, sizeof(digest1.data));
+}
+
+MD5_DIGEST md5(const void *message, size_t message_len)
+{
+	MD5_CTX ctxt;
+	md5_init(&ctxt);
+	md5_update(&ctxt, message, message_len);
+	return md5_finish(&ctxt);
+}
+
+void md5_str(MD5_DIGEST digest, char *str, size_t max_len)
+{
+	digest_str(digest.data, sizeof(digest.data), str, max_len);
+}
+
+int md5_comp(MD5_DIGEST digest1, MD5_DIGEST digest2)
 {
 	return mem_comp(digest1.data, digest2.data, sizeof(digest1.data));
 }

--- a/src/base/hash.h
+++ b/src/base/hash.h
@@ -11,6 +11,8 @@ enum
 {
 	SHA256_DIGEST_LENGTH=256/8,
 	SHA256_MAXSTRSIZE=2*SHA256_DIGEST_LENGTH+1,
+	MD5_DIGEST_LENGTH=128/8,
+	MD5_MAXSTRSIZE=2*MD5_DIGEST_LENGTH+1,
 };
 
 typedef struct
@@ -18,12 +20,23 @@ typedef struct
 	unsigned char data[SHA256_DIGEST_LENGTH];
 } SHA256_DIGEST;
 
+typedef struct
+{
+	unsigned char data[MD5_DIGEST_LENGTH];
+} MD5_DIGEST;
+
 SHA256_DIGEST sha256(const void *message, size_t message_len);
 void sha256_str(SHA256_DIGEST digest, char *str, size_t max_len);
 int sha256_from_str(SHA256_DIGEST *out, const char *str);
 int sha256_comp(SHA256_DIGEST digest1, SHA256_DIGEST digest2);
 
+MD5_DIGEST md5(const void *message, size_t message_len);
+void md5_str(MD5_DIGEST digest, char *str, size_t max_len);
+int md5_from_str(MD5_DIGEST *out, const char *str);
+int md5_comp(MD5_DIGEST digest1, MD5_DIGEST digest2);
+
 static const SHA256_DIGEST SHA256_ZEROED = {{0}};
+static const MD5_DIGEST MD5_ZEROED = {{0}};
 
 #ifdef __cplusplus
 }
@@ -35,6 +48,14 @@ inline bool operator==(const SHA256_DIGEST &that, const SHA256_DIGEST &other)
 	return sha256_comp(that, other) == 0;
 }
 inline bool operator!=(const SHA256_DIGEST &that, const SHA256_DIGEST &other)
+{
+	return !(that == other);
+}
+inline bool operator==(const MD5_DIGEST &that, const MD5_DIGEST &other)
+{
+	return md5_comp(that, other) == 0;
+}
+inline bool operator!=(const MD5_DIGEST &that, const MD5_DIGEST &other)
 {
 	return !(that == other);
 }

--- a/src/base/hash_bundled.c
+++ b/src/base/hash_bundled.c
@@ -1,0 +1,19 @@
+#if !defined(CONF_OPENSSL)
+
+#include "hash_ctxt.h"
+
+#include <engine/external/md5/md5.h>
+
+void md5_update(MD5_CTX *ctxt, const void *data, size_t data_len)
+{
+    md5_append(ctxt, data, data_len);
+}
+
+MD5_DIGEST md5_finish(MD5_CTX *ctxt)
+{
+    MD5_DIGEST result;
+    md5_finish_(ctxt, result.data);
+    return result;
+}
+
+#endif

--- a/src/base/hash_ctxt.h
+++ b/src/base/hash_ctxt.h
@@ -5,7 +5,10 @@
 #include <stdint.h>
 
 #if defined(CONF_OPENSSL)
+#include <openssl/md5.h>
 #include <openssl/sha.h>
+#else
+#include <engine/external/md5/md5.h>
 #endif
 
 #ifdef __cplusplus
@@ -22,11 +25,16 @@ typedef struct
     uint32_t curlen;
     unsigned char buf[64];
 } SHA256_CTX;
+typedef md5_state_t MD5_CTX;
 #endif
 
 void sha256_init(SHA256_CTX *ctxt);
 void sha256_update(SHA256_CTX *ctxt, const void *data, size_t data_len);
 SHA256_DIGEST sha256_finish(SHA256_CTX *ctxt);
+
+void md5_init(MD5_CTX *ctxt);
+void md5_update(MD5_CTX *ctxt, const void *data, size_t data_len);
+MD5_DIGEST md5_finish(MD5_CTX *ctxt);
 
 #ifdef __cplusplus
 }

--- a/src/base/hash_openssl.c
+++ b/src/base/hash_openssl.c
@@ -17,4 +17,21 @@ SHA256_DIGEST sha256_finish(SHA256_CTX *ctxt)
 	SHA256_Final(result.data, ctxt);
 	return result;
 }
+
+void md5_init(MD5_CTX *ctxt)
+{
+	MD5_Init(ctxt);
+}
+
+void md5_update(MD5_CTX *ctxt, const void *data, size_t data_len)
+{
+	MD5_Update(ctxt, data, data_len);
+}
+
+MD5_DIGEST md5_finish(MD5_CTX *ctxt)
+{
+	MD5_DIGEST result;
+	MD5_Final(result.data, ctxt);
+	return result;
+}
 #endif

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1489,10 +1489,10 @@ int fs_storage_path(const char *appname, char *path, int max)
 	int i;
 	char *xdgdatahome = getenv("XDG_DATA_HOME");
 	char xdgpath[max];
-	
+
 	if(!home)
 		return -1;
-	
+
 #if defined(CONF_PLATFORM_MACOSX)
 	str_format(path, max, "%s/Library/Application Support/%s", home, appname);
 	return 0;
@@ -1516,7 +1516,7 @@ int fs_storage_path(const char *appname, char *path, int max)
 		for(i = strlen(xdgdatahome)+1; xdgpath[i]; i++)
 			xdgpath[i] = tolower(xdgpath[i]);
 	}
-	
+
 	/* check for old location / backward compatibility */
 	if(fs_is_dir(path))
 	{
@@ -1524,7 +1524,7 @@ int fs_storage_path(const char *appname, char *path, int max)
 		/* for backward compatibility */
 		return 0;
 	}
-	
+
 	str_format(path, max, "%s", xdgpath);
 
 	return 0;
@@ -2487,6 +2487,11 @@ int pid()
 #else
 	return getpid();
 #endif
+}
+
+unsigned bytes_be_to_uint(const unsigned char *bytes)
+{
+	return bytes[0] << 0x18 & bytes[1] << 0x10 & bytes[2] << 0x8 & bytes[3];
 }
 
 #if defined(__cplusplus)

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2491,7 +2491,7 @@ int pid()
 
 unsigned bytes_be_to_uint(const unsigned char *bytes)
 {
-	return bytes[0] << 0x18 & bytes[1] << 0x10 & bytes[2] << 0x8 & bytes[3];
+	return (bytes[0]<<24) | (bytes[1]<<16) | (bytes[2]<<8) | bytes[3];
 }
 
 #if defined(__cplusplus)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1526,6 +1526,19 @@ void secure_random_fill(void *bytes, unsigned length);
 */
 int pid();
 
+/*
+	Function: bytes_be_to_uint
+		Packs 4 big endian bytes into an unsigned
+
+	Returns:
+		The packed unsigned
+
+	Remarks:
+		- Assumes the passed array is 4 bytes
+		- Assumes unsigned is 4 bytes
+*/
+unsigned bytes_be_to_uint(const unsigned char *bytes);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/engine/external/md5/md5.c
+++ b/src/engine/external/md5/md5.c
@@ -358,7 +358,7 @@ md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes)
 }
 
 void
-md5_finish(md5_state_t *pms, md5_byte_t digest[16])
+md5_finish_(md5_state_t *pms, md5_byte_t digest[16])
 {
     static const md5_byte_t pad[64] = {
 	0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/engine/external/md5/md5.h
+++ b/src/engine/external/md5/md5.h
@@ -71,7 +71,7 @@ typedef struct md5_state_s {
 } md5_state_t;
 
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 {
 #endif
 
@@ -82,7 +82,7 @@ void md5_init(md5_state_t *pms);
 void md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes);
 
 /* Finish the message and return the digest. */
-void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
+void md5_finish_(md5_state_t *pms, md5_byte_t digest[16]);
 
 #ifdef __cplusplus
 }  /* end extern "C" */

--- a/src/engine/shared/network_token.cpp
+++ b/src/engine/shared/network_token.cpp
@@ -1,23 +1,17 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include <base/hash_ctxt.h>
 #include <base/math.h>
 #include <base/system.h>
-
-#include <engine/external/md5/md5.h>
 
 #include "network.h"
 
 static unsigned int Hash(char *pData, int Size)
 {
-	md5_state_t State;
-	unsigned int aDigest[4]; // make sure this is 16 byte
+	MD5_DIGEST Digest = md5(pData, Size);
 
-	md5_init(&State);
-	md5_append(&State, (const md5_byte_t *)pData, Size);
-	md5_finish(&State, (md5_byte_t *)aDigest);
-
-	return (aDigest[0] ^ aDigest[1] ^ aDigest[2] ^ aDigest[3]);
+	return (Digest.data[0] ^ Digest.data[1] ^ Digest.data[2] ^ Digest.data[3]);
 }
 
 int CNetTokenCache::CConnlessPacketInfo::m_UniqueID = 0;
@@ -220,7 +214,7 @@ void CNetTokenCache::PurgeStoredPacket(int TrackID)
 			if(pInfo == m_pConnlessPacketList)
 				m_pConnlessPacketList = pNext;
 			delete pInfo;
-			
+
 			break;
 		}
 		else

--- a/src/engine/shared/network_token.cpp
+++ b/src/engine/shared/network_token.cpp
@@ -9,10 +9,12 @@
 
 static unsigned int Hash(char *pData, int Size)
 {
+	unsigned aDigest[4];
 	MD5_DIGEST Digest = md5(pData, Size);
-	unsigned *pDigest = (unsigned *)&Digest.data;
+	for(int i = 0; i < 4; i++)
+		aDigest[i] = bytes_be_to_uint(&Digest.data[i * 4]);
 
-	return (pDigest[0] ^ pDigest[1] ^ pDigest[2] ^ pDigest[3]);
+	return (aDigest[0] ^ aDigest[1] ^ aDigest[2] ^ aDigest[3]);
 }
 
 int CNetTokenCache::CConnlessPacketInfo::m_UniqueID = 0;

--- a/src/engine/shared/network_token.cpp
+++ b/src/engine/shared/network_token.cpp
@@ -10,8 +10,9 @@
 static unsigned int Hash(char *pData, int Size)
 {
 	MD5_DIGEST Digest = md5(pData, Size);
+	unsigned *pDigest = (unsigned *)&Digest.data;
 
-	return (Digest.data[0] ^ Digest.data[1] ^ Digest.data[2] ^ Digest.data[3]);
+	return (pDigest[0] ^ pDigest[1] ^ pDigest[2] ^ pDigest[3]);
 }
 
 int CNetTokenCache::CConnlessPacketInfo::m_UniqueID = 0;


### PR DESCRIPTION
The change is originally by @heinrich5991, I also included the 2 helper functions but they are unused in teeworlds. I could remove those if you prefer.