### PR TITLE
Remove unused stats setting function header

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -676,7 +676,6 @@ private:
 	void RenderSettingsControls(CUIRect MainView);
 	void RenderSettingsGraphics(CUIRect MainView);
 	void RenderSettingsSound(CUIRect MainView);
-	void RenderSettingsStats(CUIRect MainView);
 	void RenderSettings(CUIRect MainView);
 
 	bool DoResolutionList(CUIRect* pRect, CListBoxState* pListBoxState,


### PR DESCRIPTION
An artifact of:
https://github.com/teeworlds/teeworlds/commit/51506807b417af8a9d74d9a86c75738f6a32f8e6