### PR TITLE
ignore spectator_id when not specating a player

### DIFF
--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -368,7 +368,7 @@ void CSpectator::Spectate(int SpecMode, int SpectatorID)
 		return;
 	}
 
-	if(m_pClient->m_Snap.m_SpecInfo.m_SpecMode == SpecMode && m_pClient->m_Snap.m_SpecInfo.m_SpectatorID == SpectatorID)
+	if(m_pClient->m_Snap.m_SpecInfo.m_SpecMode == SpecMode && (SpecMode != SPEC_PLAYER || m_pClient->m_Snap.m_SpecInfo.m_SpectatorID == SpectatorID))
 		return;
 
 	CNetMsg_Cl_SetSpectatorMode Msg;


### PR DESCRIPTION
fix #2284 by extending the test that controls the message on **client** side