### PR TITLE
Statboard fixes

### DIFF
--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -426,7 +426,7 @@ void CBroadcast::OnRender()
 	RenderServerBroadcast();
 
 	// client broadcast
-	if(m_pClient->m_pScoreboard->Active() || m_pClient->m_pMotd->IsActive())
+	if(m_pClient->m_pScoreboard->IsActive() || m_pClient->m_pMotd->IsActive())
 		return;
 
 	Graphics()->MapScreen(0, 0, 300*Graphics()->ScreenAspect(), 300);

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -922,7 +922,7 @@ void CChat::OnRender()
 	const int64 TimeFreq = time_freq();
 
 	// get scoreboard data
-	const bool IsScoreboardActive = m_pClient->m_pScoreboard->Active();
+	const bool IsScoreboardActive = m_pClient->m_pScoreboard->IsActive();
 	CUIRect ScoreboardRect = m_pClient->m_pScoreboard->GetScoreboardRect();
 	const CUIRect ScoreboardScreen = *UI()->Screen();
 	CUIRect ScoreboardRectFixed;

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -117,7 +117,7 @@ int CControls::SnapInput(int *pData)
 	else
 		m_InputData.m_PlayerFlags = 0;
 
-	if(m_pClient->m_pScoreboard->Active())
+	if(m_pClient->m_pScoreboard->IsActive())
 		m_InputData.m_PlayerFlags |= PLAYERFLAG_SCOREBOARD;
 
 	if(m_LastData.m_PlayerFlags != m_InputData.m_PlayerFlags)

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -25,7 +25,6 @@
 
 CScoreboard::CScoreboard()
 {
-	m_PlayerLines = 0;
 	OnReset();
 }
 
@@ -46,7 +45,6 @@ void CScoreboard::OnReset()
 {
 	m_Active = false;
 	m_Activate = false;
-	m_PlayerLines = 0;
 }
 
 void CScoreboard::OnRelease()
@@ -209,14 +207,13 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 	// count players
 	dbg_assert(Team == TEAM_RED || Team == TEAM_BLUE, "Unknown team id");
 	int NumPlayers = m_pClient->m_GameInfo.m_aTeamSize[Team];
+	int PlayerLines = NumPlayers;
 	if(m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS)
-		m_PlayerLines = max(m_pClient->m_GameInfo.m_aTeamSize[Team^1], NumPlayers);
-	else
-		m_PlayerLines = NumPlayers;
+		PlayerLines = max(m_pClient->m_GameInfo.m_aTeamSize[Team^1], PlayerLines);
 
 	// clamp to 16
-	if(m_PlayerLines > 16)
-		m_PlayerLines = 16;
+	if(PlayerLines > 16)
+		PlayerLines = 16;
 
 	char aBuf[128] = {0};
 
@@ -309,12 +306,12 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 
 	Graphics()->BlendNormal();
 	{
-		CUIRect Rect = {x, y, w, LineHeight*(m_PlayerLines+1)};
+		CUIRect Rect = {x, y, w, LineHeight*(PlayerLines+1)};
 		RenderTools()->DrawRoundRect(&Rect, vec4(0.0f, 0.0f, 0.0f, 0.25f), 5.0f);
 	}
-	if(m_PlayerLines)
+	if(PlayerLines)
 	{
-		CUIRect Rect = {x, y+LineHeight, w, LineHeight*(m_PlayerLines)};
+		CUIRect Rect = {x, y+LineHeight, w, LineHeight*(PlayerLines)};
 		RenderTools()->DrawRoundRect(&Rect, vec4(0.0f, 0.0f, 0.0f, 0.25f), 5.0f);
 	}
 
@@ -611,7 +608,7 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 	TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.3f);
 
-	return HeadlineHeight+LineHeight*(m_PlayerLines+1);
+	return HeadlineHeight+LineHeight*(PlayerLines+1);
 }
 
 void CScoreboard::RenderRecordingNotification(float x)
@@ -639,7 +636,8 @@ void CScoreboard::RenderRecordingNotification(float x)
 
 void CScoreboard::OnRender()
 {
-	if(m_pClient->m_pStats->IsActive())
+	// don't render scoreboard if menu or statboard is open
+	if(m_pClient->m_pMenus->IsActive() || m_pClient->m_pStats->IsActive())
 		return;
 
 	// postpone the active state till the render area gets updated during the rendering
@@ -653,15 +651,7 @@ void CScoreboard::OnRender()
 	if(m_Active)
 		m_pClient->m_pMotd->Clear();
 
-	// if statboard active don't show scoreboard
-	if(m_pClient->m_pStats->IsActive())
-		return;
-
-	if(!Active())
-		return;
-
-	// don't render scoreboard if menu or motd is open
-	if(m_pClient->m_pMenus->IsActive() || m_pClient->m_pMotd->IsActive())
+	if(!IsActive())
 		return;
 
 	CUIRect Screen = *UI()->Screen();
@@ -739,7 +729,7 @@ void CScoreboard::OnRender()
 	RenderRecordingNotification((Width/7)*4);
 }
 
-bool CScoreboard::Active()
+bool CScoreboard::IsActive() const
 {
 	// if we actively wanna look on the scoreboard
 	if(m_Active)
@@ -758,11 +748,6 @@ bool CScoreboard::Active()
 		return true;
 
 	return false;
-}
-
-CUIRect CScoreboard::GetScoreboardRect()
-{
-	return m_TotalRect;
 }
 
 const char *CScoreboard::GetClanName(int Team)

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -17,7 +17,6 @@ class CScoreboard : public CComponent
 
 	bool m_Active;
 	bool m_Activate;
-	int m_PlayerLines;
  	class CUIRect m_TotalRect;
 
 public:
@@ -27,9 +26,9 @@ public:
 	virtual void OnRender();
 	virtual void OnRelease();
 	
- 	bool Active();
+ 	bool IsActive() const;
 	void ResetPlayerStats(int ClientID);
- 	class CUIRect GetScoreboardRect();
+ 	class CUIRect GetScoreboardRect() const { return m_TotalRect; }
 };
 
 #endif

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -127,6 +127,8 @@ void CStats::OnRender()
 	{
 		if(!m_pClient->m_aClients[i].m_Active)
 			continue;
+		if(m_pClient->m_aClients[i].m_Team == TEAM_SPECTATORS)
+			continue;
 
 		apPlayers[NumPlayers] = i;
 		NumPlayers++;
@@ -242,11 +244,6 @@ void CStats::OnRender()
 			px += 100;
 			break;
 		}
-
-
-		// skip specs
-		if(m_pClient->m_aClients[apPlayers[j]].m_Active && m_pClient->m_aClients[apPlayers[j]].m_Team == TEAM_SPECTATORS)
-			continue;
 
 		const CPlayerStats *pStats = &m_aStats[apPlayers[j]];		
 		const bool HighlightedLine = (!m_pClient->m_Snap.m_SpecInfo.m_Active && apPlayers[j] == m_pClient->m_LocalClientID)

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -246,7 +246,7 @@ void CStats::OnRender()
 		}
 
 		const CPlayerStats *pStats = &m_aStats[apPlayers[j]];		
-		const bool HighlightedLine = (!m_pClient->m_Snap.m_SpecInfo.m_Active && apPlayers[j] == m_pClient->m_LocalClientID)
+		const bool HighlightedLine = apPlayers[j] == m_pClient->m_LocalClientID
 			|| (m_pClient->m_Snap.m_SpecInfo.m_Active && apPlayers[j] == m_pClient->m_Snap.m_SpecInfo.m_SpectatorID);
 
 		// background so it's easy to find the local player or the followed one in spectator mode

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -44,7 +44,7 @@ void CStats::OnReset()
 	m_ScreenshotTime = -1;
 }
 
-bool CStats::IsActive()
+bool CStats::IsActive() const
 {
 	// force statboard after three seconds of game over if autostatscreenshot is on
 	if(g_Config.m_ClAutoStatScreenshot && m_ScreenshotTime > -1 && m_ScreenshotTime < time_get())

--- a/src/game/client/components/stats.h
+++ b/src/game/client/components/stats.h
@@ -48,7 +48,7 @@ private:
 	};
 	CPlayerStats m_aStats[MAX_CLIENTS];
 
-	int m_Active;
+	bool m_Active;
 	bool m_ScreenshotTaken;
 	int64 m_ScreenshotTime;
 	static void ConKeyStats(IConsole::IResult *pResult, void *pUserData);
@@ -56,13 +56,12 @@ private:
 
 public:
 	CStats();
-	bool IsActive();
+	bool IsActive() const;
 	virtual void OnReset();
 	void OnStartGame();
 	virtual void OnConsoleInit();
 	virtual void OnRender();
 	virtual void OnMessage(int MsgType, void *pRawMsg);
-	bool IsActive() const { return m_Active; }
 
 	void UpdatePlayTime(int Ticks);
 	void OnMatchStart();


### PR DESCRIPTION
Fixes two issues:
- At the moment, not all players are shown if there are more than 16 players on the server, even though there are fewer than 16 players ingame.
- When you are following someone (dead spec), your own entry is not highlighted in the statboard. It should rather behave like the scoreboard and highlight both players in this case.