### PR TITLE
Add helper annotation when whispering

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -919,6 +919,7 @@ void CChat::OnRender()
 
 				char aInfoText[128];
 				str_format(aInfoText, sizeof(aInfoText), Localize("Press Tab to cycle chat recipients"));
+				TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.5f);
 				TextRender()->TextEx(&InfoCursor, aInfoText, -1);
 			}
 		}

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -910,6 +910,17 @@ void CChat::OnRender()
 
 			TextRender()->TextEx(&Marker, "|", -1);
 			TextRender()->TextEx(&Cursor, m_Input.GetString()+m_Input.GetCursorOffset(), -1);
+
+			if(ChatMode == CHAT_WHISPER)
+			{
+				//render helper annotation
+				CTextCursor InfoCursor;
+				TextRender()->SetCursor(&InfoCursor, 2.0f, y+12.0f, CategoryFontSize*0.75, TEXTFLAG_RENDER);
+
+				char aInfoText[128];
+				str_format(aInfoText, sizeof(aInfoText), Localize("Press Tab to cycle chat recipients"));
+				TextRender()->TextEx(&InfoCursor, aInfoText, -1);
+			}
 		}
 	}
 


### PR DESCRIPTION
I suggest to add a helper annotation similarly to the "Press %s to resume chatting" that we do. I think it is not quite intuitive.

![image](https://user-images.githubusercontent.com/355114/70393273-20177b80-19e0-11ea-8cea-2149024d3d72.png)

Might want to make it gray? Not sure.