### PR TITLE
Improve visuals of some statboard columns

### DIFF
--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -407,12 +407,12 @@ void CStats::OnRender()
 				static const vec4 Colors[NUM_WEAPONS] =
 				{
 					// crosshair colors
-					vec4(0.792f, 0.761f, 0.815, 1.0f),
-					vec4(0.696f, 0.706f, 0.307, 1.0f),
-					vec4(0.459f, 0.341f, 0.102, 1.0f),
-					vec4(0.802f, 0.034f, 0.068, 1.0f),
-					vec4(0.113f, 0.331f, 0.774, 1.0f),
-					vec4(0.832f, 0.587f, 0.041, 1.0f),
+					vec4(0.792f, 0.761f, 0.815f, 1.0f),
+					vec4(0.696f, 0.706f, 0.307f, 1.0f),
+					vec4(0.459f, 0.341f, 0.102f, 1.0f),
+					vec4(0.802f, 0.034f, 0.068f, 1.0f),
+					vec4(0.113f, 0.331f, 0.774f, 1.0f),
+					vec4(0.832f, 0.587f, 0.041f, 1.0f),
 				};
 				if(pStats->m_aFragsWith[i])
 				{

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -361,9 +361,10 @@ void CStats::OnRender()
 		px -= 40;
 		if(g_Config.m_ClStatboardInfos & TC_STATS_WEAPS)
 		{
+			const float BarHeight = 0.3f*LineHeight;
 			const float Offset = 40.0f;
 			const float StartX = px - Offset;
-			const float RoundSize = 10.0f;
+			const float RoundSize = BarHeight/2.0f;
 			float EndX = StartX; // each bar will have its width incremented by the roundsize so this avoids that last one would overflow
 			int TotalFrags = 0;
 			int TotalDeaths = 0;
@@ -377,7 +378,7 @@ void CStats::OnRender()
 				}					
 			}
 			float ExploitableLength = (EndX-StartX) - RoundSize;
-			CUIRect Rect = {x + StartX, y+0.3f*LineHeight, 0.0f, 0.3f*LineHeight};
+			CUIRect Rect = {x + StartX, y+0.3f*LineHeight, 0.0f, BarHeight};
 			for(i=0; i<NUM_WEAPONS; i++)
 			{
 				extern int _dummy[(int)(NUM_WEAPONS == 6)]; (void)_dummy; // static assert that there are 6 weapons

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -137,6 +137,11 @@ void CStats::OnRender()
 	for(int i=0; i<9; i++)
 		if(g_Config.m_ClStatboardInfos & (1<<i))
 		{
+			if((1<<i) == (TC_STATS_DEATHS) && g_Config.m_ClStatboardInfos & TC_STATS_FRAGS)
+			{
+				w += 20;
+				continue;
+			}
 			if((1<<i) == (TC_STATS_BESTSPREE))
 			{
 				if(!(g_Config.m_ClStatboardInfos & TC_STATS_SPREE))
@@ -185,6 +190,16 @@ void CStats::OnRender()
 	for(i=0; i<9; i++)
 		if(g_Config.m_ClStatboardInfos & (1<<i))
 		{
+			const char* pText = apHeaders[i];
+			// handle K:D merge (in the frags column)
+			if(1<<i == TC_STATS_FRAGS && g_Config.m_ClStatboardInfos & TC_STATS_DEATHS)
+			{
+				pText = "K:D";
+				px += 20.0f; // some extra for the merge
+			}
+			else if(1<<i == TC_STATS_DEATHS && g_Config.m_ClStatboardInfos & TC_STATS_FRAGS)
+				continue;
+			// handle spree columns merge
 			if(1<<i == TC_STATS_BESTSPREE)
 			{
 				if(g_Config.m_ClStatboardInfos & TC_STATS_SPREE)
@@ -192,14 +207,15 @@ void CStats::OnRender()
 				px += 40.0f; // some extra for the long name
 			}
 			else if(1<<i == TC_STATS_SPREE && g_Config.m_ClStatboardInfos & TC_STATS_BESTSPREE)
-				px += 20.0f;
+				px += 20.0f; // some extra for the merge
 			if(1<<i == TC_STATS_FLAGGRABS && !(m_pClient->m_Snap.m_pGameData && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS))
 				continue;
-			tw = TextRender()->TextWidth(0, 24.0f, apHeaders[i], -1, -1.0f);
-			TextRender()->Text(0, x+px-tw, y-5, 24.0f, apHeaders[i], -1.0f);
+			tw = TextRender()->TextWidth(0, 24.0f, pText, -1, -1.0f);
+			TextRender()->Text(0, x+px-tw, y-5, 24.0f, pText, -1.0f);
 			px += 100;
 		}
 
+	// sprite headers now
 	if(g_Config.m_ClStatboardInfos & TC_STATS_WEAPS)
 	{
 		Graphics()->TextureSet(g_pData->m_aImages[IMAGE_GAME].m_Id);
@@ -286,12 +302,18 @@ void CStats::OnRender()
 		px = 325;
 		if(g_Config.m_ClStatboardInfos & TC_STATS_FRAGS)
 		{
-			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Frags);
+			if(g_Config.m_ClStatboardInfos & TC_STATS_DEATHS)
+			{
+				px += 20;
+				str_format(aBuf, sizeof(aBuf), "%d:%d", pStats->m_Frags, pStats->m_Deaths);
+			}
+			else
+				str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Frags);
 			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1.0f);
 			px += 100;
 		}
-		if(g_Config.m_ClStatboardInfos & TC_STATS_DEATHS)
+		else if(g_Config.m_ClStatboardInfos & TC_STATS_DEATHS)
 		{
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Deaths);
 			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -141,6 +141,8 @@ void CStats::OnRender()
 			{
 				if(!(g_Config.m_ClStatboardInfos & TC_STATS_SPREE))
 					w += 140; // Best spree is a long column name, add a bit more
+				else
+					w += 20; // The combined colunms are a bit long, add some extra
 			}
 			else
 				w += 100;
@@ -187,8 +189,10 @@ void CStats::OnRender()
 			{
 				if(g_Config.m_ClStatboardInfos & TC_STATS_SPREE)
 					continue;
-				px += 40.0f;
+				px += 40.0f; // some extra for the long name
 			}
+			else if(1<<i == TC_STATS_SPREE && g_Config.m_ClStatboardInfos & TC_STATS_BESTSPREE)
+				px += 20.0f;
 			if(1<<i == TC_STATS_FLAGGRABS && !(m_pClient->m_Snap.m_pGameData && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS))
 				continue;
 			tw = TextRender()->TextWidth(0, 24.0f, apHeaders[i], -1, -1.0f);
@@ -329,7 +333,10 @@ void CStats::OnRender()
 		if(g_Config.m_ClStatboardInfos & TC_STATS_SPREE)
 		{
 			if(g_Config.m_ClStatboardInfos & TC_STATS_BESTSPREE)
+			{
+				px += 20; // extra space
 				str_format(aBuf, sizeof(aBuf), "%d (%d)", pStats->m_CurrentSpree, pStats->m_BestSpree);
+			}
 			else
 				str_format(aBuf, sizeof(aBuf), "%d", pStats->m_CurrentSpree);
 			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);


### PR DESCRIPTION
- Merge spree and best spree into one column if both is selected
  - Carefully adjust column width if only one column is selected
- Frags/Deaths -> K/D to be consistent with scoreboard
- Flags are displayed as visuals instead of a number until <=5, then fallback to numbers

- Weapon bar

## TODO
- [x] Spree overlaps with FPM with 15+ players
- [x] Weird pixelization on the weapons bar
- [x] K/D could be merged
- [x] Test 5 flags with 15+ players
- [ ] Discuss order of display of grabs/capture
- [ ] Discuss width of bar (constant or proportional to K)
- [ ] Discuss Death bar?

## Screenshots
### Spree only
![image](https://user-images.githubusercontent.com/355114/70393413-4db0f480-19e1-11ea-82d6-8ad5189b71fc.png)
### Spree + best spree
![screenshot_2019-12-08_17-12-45](https://user-images.githubusercontent.com/355114/70393417-5bff1080-19e1-11ea-9089-43ca67d241b8.png)

### Flags: edge cases
![screenshot_2019-12-08_17-38-50](https://user-images.githubusercontent.com/355114/70393433-abddd780-19e1-11ea-800c-c4c6669d94a6.png)
![screenshot_2019-12-08_17-38-58](https://user-images.githubusercontent.com/355114/70393435-abddd780-19e1-11ea-8f3e-fd544320e29b.png)

I'm looking for ways to improve the readability of the weapons stats.