### PR TITLE
Fix marking alpha UI overlapping (while in game)

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -160,13 +160,6 @@ void CMenus::RenderHSLPicker(CUIRect MainView)
 	float Spacing = 2.0f;
 	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
-	// color header
-	float HeaderHeight = 20.0f;
-	MainView.HSplitTop(HeaderHeight, &Label, &MainView);
-	Label.y += 2.0f;
-	UI()->DoLabel(&Label, Localize("Color"), HeaderHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
-	MainView.HSplitTop(Spacing, 0, &MainView);
-
 	// use custom color checkbox
 	float ButtonHeight = 20.0f;
 	MainView.HSplitTop(ButtonHeight, &Button, &MainView);


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/294603/70434324-337c2280-1a84-11ea-94bf-9e4c58158ae4.png)

After:
![image](https://user-images.githubusercontent.com/294603/70434370-50185a80-1a84-11ea-93ea-1f08ca7be13b.png)
