### PR TITLE
Fix demo compatibility

### DIFF
--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -238,31 +238,31 @@ void CDemoRecorder::Write(int Type, const void *pData, int Size)
 
 void CDemoRecorder::RecordSnapshot(int Tick, const void *pData, int Size)
 {
+	char aTmpData[CSnapshot::MAX_SIZE];
+
 	if(m_LastKeyFrame == -1 || (Tick-m_LastKeyFrame) > SERVER_TICK_SPEED*5)
 	{
 		// write full tickmarker
 		WriteTickMarker(Tick, 1);
 
 		// write snapshot
-		Write(CHUNKTYPE_SNAPSHOT, pData, Size);
+		int SnapSize = ((CSnapshot*)pData)->Serialize(aTmpData);
+		Write(CHUNKTYPE_SNAPSHOT, aTmpData, SnapSize);
 
 		m_LastKeyFrame = Tick;
 		mem_copy(m_aLastSnapshotData, pData, Size);
 	}
 	else
 	{
-		// create delta, prepend tick
-		char aDeltaData[CSnapshot::MAX_SIZE+sizeof(int)];
-		int DeltaSize;
-
 		// write tickmarker
 		WriteTickMarker(Tick, 0);
 
-		DeltaSize = m_pSnapshotDelta->CreateDelta((CSnapshot*)m_aLastSnapshotData, (CSnapshot*)pData, &aDeltaData);
+		// create delta
+		int DeltaSize = m_pSnapshotDelta->CreateDelta((CSnapshot*)m_aLastSnapshotData, (CSnapshot*)pData, &aTmpData);
 		if(DeltaSize)
 		{
 			// record delta
-			Write(CHUNKTYPE_DELTA, aDeltaData, DeltaSize);
+			Write(CHUNKTYPE_DELTA, aTmpData, DeltaSize);
 			mem_copy(m_aLastSnapshotData, pData, Size);
 		}
 	}
@@ -468,6 +468,7 @@ void CDemoPlayer::DoTick()
 	static char aCompresseddata[CSnapshot::MAX_SIZE];
 	static char aDecompressed[CSnapshot::MAX_SIZE];
 	static char aData[CSnapshot::MAX_SIZE];
+	static char aNewsnap[CSnapshot::MAX_SIZE];
 	int ChunkType, ChunkTick, ChunkSize;
 	int DataSize = 0;
 	int GotSnapshot = 0;
@@ -479,6 +480,7 @@ void CDemoPlayer::DoTick()
 
 	while(1)
 	{
+		DataSize = 0;
 		if(ReadChunkHeader(&ChunkType, &ChunkSize, &ChunkTick))
 		{
 			// stop on error or eof
@@ -526,9 +528,11 @@ void CDemoPlayer::DoTick()
 		if(ChunkType == CHUNKTYPE_DELTA)
 		{
 			// process delta snapshot
-			static char aNewsnap[CSnapshot::MAX_SIZE];
-
 			GotSnapshot = 1;
+
+			// only unpack the delta if we have a valid snapshot
+			if(m_LastSnapshotDataSize == -1)
+				continue;
 
 			DataSize = m_pSnapshotDelta->UnpackDelta((CSnapshot*)m_aLastSnapshotData, (CSnapshot*)aNewsnap, aData, DataSize);
 
@@ -550,12 +554,27 @@ void CDemoPlayer::DoTick()
 		else if(ChunkType == CHUNKTYPE_SNAPSHOT)
 		{
 			// process full snapshot
+			CSnapshotBuilder Builder;
 			GotSnapshot = 1;
 
-			m_LastSnapshotDataSize = DataSize;
-			mem_copy(m_aLastSnapshotData, aData, DataSize);
-			if(m_pListner)
-				m_pListner->OnDemoPlayerSnapshot(aData, DataSize);
+			if(Builder.UnserializeSnap(aData, DataSize))
+				DataSize = Builder.Finish(aNewsnap);
+			else
+				DataSize = -1;
+			
+			if(DataSize >= 0)
+			{
+				m_LastSnapshotDataSize = DataSize;
+				mem_copy(m_aLastSnapshotData, aNewsnap, DataSize);
+				if(m_pListner)
+					m_pListner->OnDemoPlayerSnapshot(aNewsnap, DataSize);
+			}
+			else
+			{
+				char aBuf[256];
+				str_format(aBuf, sizeof(aBuf), "error during unpacking of snapshot, err=%d", DataSize);
+				m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "demo_player", aBuf);
+			}
 		}
 		else
 		{

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -38,6 +38,18 @@ void CSnapshot::InvalidateItem(int Index)
 	((CSnapshotItem *)(DataStart() + Offsets()[Index]))->Invalidate();
 }
 
+int CSnapshot::Serialize(char *pDstData)
+{
+	int *pData = (int*)pDstData;
+	pData[0] = m_DataSize;
+	pData[1] = m_NumItems;
+
+	mem_copy(pData+2, Offsets(), sizeof(int)*m_NumItems);
+	mem_copy(pData+2+m_NumItems, DataStart(), m_DataSize);
+
+	return sizeof(int) * (2 + m_NumItems) + m_DataSize;
+}
+
 int CSnapshot::Crc() const
 {
 	int Crc = 0;
@@ -520,6 +532,40 @@ void CSnapshotBuilder::Init(const CSnapshot *pSnapshot)
 	m_NumItems = pSnapshot->m_NumItems;
 	mem_copy(m_aOffsets, pSnapshot->Offsets(), sizeof(int)*m_NumItems);
 	mem_copy(m_aData, pSnapshot->DataStart(), m_DataSize);
+}
+
+bool CSnapshotBuilder::UnserializeSnap(const char *pSrcData, int SrcSize)
+{
+	m_DataSize = 0;
+	m_NumItems = 0;
+
+	const int *pData = (const int*)pSrcData;
+	if(SrcSize < (int)sizeof(int)*2)
+		return false;
+
+	int DataSize = pData[0];
+	int NumItems = pData[1];
+	int CompleteSize = DataSize + sizeof(int) * (2 + NumItems);
+	int NewSnapSize = DataSize + sizeof(CSnapshot) + NumItems * sizeof(int)*2;
+	if(NewSnapSize > CSnapshot::MAX_SIZE || NumItems > MAX_ITEMS || CompleteSize != SrcSize)
+		return false;
+
+	// check offsets
+	const int *pOffsets = pData+2;
+	int LastOffset = DataSize;
+	for(int i = NumItems-1; i >= 0; i--)
+	{
+		int ItemSize = LastOffset - pOffsets[i];
+		LastOffset = pOffsets[i];
+		if(pOffsets[i] < 0 || ItemSize < (int)sizeof(CSnapshotItem))
+			return false;
+	}
+
+	m_DataSize = DataSize;
+	m_NumItems = NumItems;
+	mem_copy(m_aOffsets, pOffsets, sizeof(int)*m_NumItems);
+	mem_copy(m_aData, pOffsets+m_NumItems, m_DataSize);
+	return true;
 }
 
 CSnapshotItem *CSnapshotBuilder::GetItem(int Index)

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -505,9 +505,10 @@ void CSnapshotBuilder::Init()
 
 void CSnapshotBuilder::Init(const CSnapshot *pSnapshot)
 {
-	if(pSnapshot->m_DataSize > CSnapshot::MAX_SIZE || pSnapshot->m_NumItems > MAX_ITEMS)
+	if(pSnapshot->m_DataSize + sizeof(CSnapshot) + pSnapshot->m_NumItems * sizeof(int)*2 > CSnapshot::MAX_SIZE || pSnapshot->m_NumItems > MAX_ITEMS)
 	{
-		dbg_assert(m_DataSize < CSnapshot::MAX_SIZE, "too much data");
+		// key and offset per item
+		dbg_assert(m_DataSize + sizeof(CSnapshot) + m_NumItems * sizeof(int)*2 < CSnapshot::MAX_SIZE, "too much data");
 		dbg_assert(m_NumItems < MAX_ITEMS, "too many items");
 		dbg_msg("snapshot", "invalid snapshot"); // remove me
 		m_DataSize = 0;
@@ -593,10 +594,11 @@ int CSnapshotBuilder::Finish(void *pSnapdata)
 
 void *CSnapshotBuilder::NewItem(int Type, int ID, int Size)
 {
-	if(m_DataSize + sizeof(CSnapshotItem) + Size >= CSnapshot::MAX_SIZE ||
+	if(m_DataSize + sizeof(CSnapshot) + sizeof(CSnapshotItem) + Size + (m_NumItems+1) * sizeof(int)*2 >= CSnapshot::MAX_SIZE ||
 		m_NumItems+1 >= MAX_ITEMS)
 	{
-		dbg_assert(m_DataSize < CSnapshot::MAX_SIZE, "too much data");
+		// key and offset per item
+		dbg_assert(m_DataSize + sizeof(CSnapshot) + m_NumItems * sizeof(int)*2 < CSnapshot::MAX_SIZE, "too much data");
 		dbg_assert(m_NumItems < MAX_ITEMS, "too many items");
 		return 0;
 	}

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -48,6 +48,8 @@ public:
 	int GetItemIndex(int Key) const;
 	void InvalidateItem(int Index);
 
+	int Serialize(char *pDstData);
+
 	int Crc() const;
 	void DebugDump() const;
 };
@@ -134,6 +136,7 @@ class CSnapshotBuilder
 public:
 	void Init();
 	void Init(const CSnapshot *pSnapshot);
+	bool UnserializeSnap(const char *pSrcData, int SrcSize);
 
 	void *NewItem(int Type, int ID, int Size);
 


### PR DESCRIPTION
This fixes #2230 
The internal snapshot format is now independent from the format used in the demo files. I also added some checks so the client does not crash (so easily) if the demo contains malformed data.