### PR TITLE
Experimental extended browser view

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1348,32 +1348,6 @@ void CMenus::RenderMenubar(CUIRect Rect)
 			Box.VSplitRight(20.0f, &Box, 0);
 			Box.VSplitRight(60.0f, 0, &Right);
 			Right.HSplitBottom(20.0f, 0, &Button);
-			
-			// do fading button with two icons for browser view
-			{
-				static CButtonContainer s_SwitchViewButton;
-				float Seconds = 0.6f; //  for fade
-				float FadeVal = ButtonFade(&s_SwitchViewButton, Seconds, 0) / Seconds;
-
-				RenderTools()->DrawUIRect(&Button, vec4(0.0f + FadeVal, 0.0f + FadeVal, 0.0f + FadeVal, 0.25f + FadeVal * 0.5f), CUI::CORNER_ALL, 5.0f);
-
-				for(int IconId = 0; IconId < 2; IconId++)
-				{
-					// rewrites CMenus::DoButton_SpriteID
-					CUIRect Icon = Button;
-					Icon.VMargin(Icon.w/4.0f, &Icon);
-					Icon.x += IconId*Icon.w*0.50f;
-					Icon.w *= 0.50f;
-					if(Icon.w > Icon.h)
-						Icon.VMargin((Icon.w - Icon.h) / 2, &Icon);
-					else if(Icon.w < Icon.h)
-						Icon.HMargin((Icon.h - Icon.w) / 2, &Icon);
-					Icon.Margin(2.0f, &Icon);
-					DoIcon(IMAGE_ARROWICONS, (IconId ^ g_Config.m_UiWideview) ? SPRITE_ARROW_RIGHT_A:SPRITE_ARROW_LEFT_A, &Icon);
-				}
-				if(UI()->DoButtonLogic(s_SwitchViewButton.GetID(), "", 0, &Button))
-					g_Config.m_UiWideview ^= 1;
-			}
 		}
 	}
 	else if(Client()->State() == IClient::STATE_OFFLINE)

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1786,7 +1786,7 @@ int CMenus::Render()
 				Row.VSplitRight(5.0f, &Row, 0);
 				Row.VSplitRight(TopOffset, &Row, &Button);
 				static CButtonContainer s_WideButton;
-				if(DoButton_MenuTabTop(&s_WideButton, g_Config.m_UiWideview ? "\xe2\x96\xaa" : "\xe2\x96\xac", false, &Button, 1.0f, 1.0f, CUI::CORNER_B))
+				if((m_MenuPage == PAGE_INTERNET || m_MenuPage == PAGE_LAN || m_MenuPage == PAGE_DEMOS) && DoButton_MenuTabTop(&s_WideButton, g_Config.m_UiWideview ? "\xe2\x96\xaa" : "\xe2\x96\xac", false, &Button, 1.0f, 1.0f, CUI::CORNER_B))
 					g_Config.m_UiWideview ^= 1;
 			}
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1786,7 +1786,7 @@ int CMenus::Render()
 				Row.VSplitRight(5.0f, &Row, 0);
 				Row.VSplitRight(TopOffset, &Row, &Button);
 				static CButtonContainer s_WideButton;
-				if(DoButton_MenuTabTop(&s_WideButton, g_Config.m_UiWideview ? "\xe2\x97\xbe" : "\xe2\x96\xac", false, &Button, 1.0f, 1.0f, CUI::CORNER_B))
+				if(DoButton_MenuTabTop(&s_WideButton, g_Config.m_UiWideview ? "\xe2\x96\xaa" : "\xe2\x96\xac", false, &Button, 1.0f, 1.0f, CUI::CORNER_B))
 					g_Config.m_UiWideview ^= 1;
 			}
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -617,6 +617,8 @@ private:
 	void RenderMenubar(CUIRect r);
 	void RenderNews(CUIRect MainView);
 	void RenderBackButton(CUIRect MainView);
+	inline float GetListHeaderHeight() const { return ms_ListheaderHeight + (g_Config.m_UiWideview ? 3.0f : 0.0f); }
+	inline float GetListHeaderHeightFactor() const { return 1.0f + (g_Config.m_UiWideview ? (3.0f/ms_ListheaderHeight) : 0.0f); }
 
 	// found in menus_demo.cpp
 	void RenderDemoPlayer(CUIRect MainView);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -435,7 +435,14 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 			if(pEntry->m_FriendState != CContactInfo::CONTACT_NO)
 			{
 				Icon.Margin(2.0f, &Icon);
-				DoIcon(IMAGE_BROWSEICONS, Selected ? SPRITE_BROWSE_HEART_B : SPRITE_BROWSE_HEART_A, &Icon);
+				Graphics()->TextureSet(g_pData->m_aImages[IMAGE_BROWSEICONS].m_Id);
+				Graphics()->QuadsBegin();
+				Graphics()->SetColor(1.0f, 0.75f, 1.0f, 1.0f);
+				RenderTools()->SelectSprite(Selected ? SPRITE_BROWSE_HEART_B : SPRITE_BROWSE_HEART_A);
+				IGraphics::CQuadItem QuadItem(Icon.x, Icon.y, Icon.w, Icon.h);
+				Graphics()->QuadsDrawTL(&QuadItem, 1);
+				Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+				Graphics()->QuadsEnd();
 			}
 		}
 		else if(ID == COL_BROWSER_NAME)
@@ -947,7 +954,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		View.VSplitRight(20.0f, &View, &Scroll);
 	}
 
-	View.HSplitTop(ms_ListheaderHeight, &Headers, &View);
+	View.HSplitTop(GetListHeaderHeight(), &Headers, &View);
 	View.HSplitBottom(ButtonHeight*3.0f+SpacingH*2.0f, &View, &Status);
 
 	Headers.VSplitRight(2.f, &Headers, 0); // some margin on the right
@@ -957,7 +964,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	{
 		if(ms_aBrowserCols[i].m_Direction == -1)
 		{
-			Headers.VSplitLeft(ms_aBrowserCols[i].m_Width, &ms_aBrowserCols[i].m_Rect, &Headers);
+			Headers.VSplitLeft(ms_aBrowserCols[i].m_Width*GetListHeaderHeightFactor(), &ms_aBrowserCols[i].m_Rect, &Headers);
 
 			if(i+1 < NUM_BROWSER_COLS)
 			{
@@ -971,7 +978,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	{
 		if(ms_aBrowserCols[i].m_Direction == 1)
 		{
-			Headers.VSplitRight(ms_aBrowserCols[i].m_Width, &Headers, &ms_aBrowserCols[i].m_Rect);
+			Headers.VSplitRight(ms_aBrowserCols[i].m_Width*GetListHeaderHeightFactor(), &Headers, &ms_aBrowserCols[i].m_Rect);
 			Headers.VSplitRight(2, &Headers, &ms_aBrowserCols[i].m_Spacer);
 		}
 	}
@@ -1155,9 +1162,9 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 				bool IsSelected = m_SelectedServer.m_Filter == s && m_SelectedServer.m_Index == i;
 				if(!m_SidebarActive && IsSelected && m_ShowServerDetails)
-					View.HSplitTop(ms_ListheaderHeight*6, &Row, &View);
+					View.HSplitTop(GetListHeaderHeight()*6, &Row, &View);
 				else
-					View.HSplitTop(ms_ListheaderHeight, &Row, &View);
+					View.HSplitTop(GetListHeaderHeight(), &Row, &View);
 
 				ScrollRegionAddRect(&s_ScrollRegion, Row);
 				if(IsSelected && NewSelection) // new selection (hotkeys or address input)
@@ -1314,7 +1321,7 @@ void CMenus::RenderServerbrowserSidebar(CUIRect View)
 	}
 
 	// header
-	View.HSplitTop(ms_ListheaderHeight, &Header, &View);
+	View.HSplitTop(GetListHeaderHeight(), &Header, &View);
 	float Width = Header.w;
 	Header.VSplitLeft(Width*0.30f, &Button, &Header);
 	static CButtonContainer s_TabInfo;
@@ -1355,7 +1362,7 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 	const float FontSize = 10.0f;
 	static bool s_ListExtended[NUM_FRIEND_TYPES] = { 1, 1, 0 };
 
-	View.HSplitBottom(3*ms_ListheaderHeight, &View, &BottomArea);
+	View.HSplitBottom(3*GetListHeaderHeight(), &View, &BottomArea);
 
 	// calculate friends
 	// todo: optimize this
@@ -1426,13 +1433,13 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 	{
 		CUIRect Header;
 		char aBuf[64] = { 0 };
-		View.HSplitTop(ms_ListheaderHeight, &Header, &View);
+		View.HSplitTop(GetListHeaderHeight(), &Header, &View);
 		if(s_ListExtended[i])
 		{
 			// entries
 			for(int f = 0; f < m_lFriendList[i].size(); ++f, ++ButtonId)
 			{
-				View.HSplitTop(20.0f + ms_ListheaderHeight, &Rect, &View);
+				View.HSplitTop(20.0f + GetListHeaderHeight(), &Rect, &View);
 				ScrollRegionAddRect(&s_ScrollRegion, Rect);
 
 				RenderTools()->DrawUIRect(&Rect, vec4(0.5f, 0.5f, 0.5f, 0.5f), CUI::CORNER_ALL, 5.0f);
@@ -1455,7 +1462,7 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 				// info
 				if(m_lFriendList[i][f].m_pServerInfo)
 				{
-					Rect.HSplitTop(ms_ListheaderHeight, &Button, &Rect);
+					Rect.HSplitTop(GetListHeaderHeight(), &Button, &Rect);
 					Button.VSplitLeft(2.0f, 0, &Button);
 					if(m_lFriendList[i][f].m_IsPlayer)
 						str_format(aBuf, sizeof(aBuf), Localize("Playing '%s' on '%s'", "Playing '(gametype)' on '(map)'"), m_lFriendList[i][f].m_pServerInfo->m_aGameType, m_lFriendList[i][f].m_pServerInfo->m_aMap);
@@ -1475,7 +1482,7 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 				// join button
 				if(m_lFriendList[i][f].m_pServerInfo)
 				{
-					Button.Margin((Button.h - ms_ListheaderHeight + 2.0f) / 2, &Button);
+					Button.Margin((Button.h - GetListHeaderHeight() + 2.0f) / 2, &Button);
 					if(DoButton_Menu(&(s_FriendJoinButtons[ButtonId%20]), Localize("Join", "Join a server"), 0, &Button) )
 					{
 						str_copy(g_Config.m_UiServerAddress, m_lFriendList[i][f].m_pServerInfo->m_aAddress, sizeof(g_Config.m_UiServerAddress));
@@ -1511,21 +1518,21 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 	EndScrollRegion(&s_ScrollRegion);
 
 	// add friend
-	BottomArea.HSplitTop(ms_ListheaderHeight, &Button, &BottomArea);
+	BottomArea.HSplitTop(GetListHeaderHeight(), &Button, &BottomArea);
 	Button.VSplitLeft(50.0f, &Label, &Button);
 	UI()->DoLabel(&Label, Localize("Name"), FontSize, CUI::ALIGN_LEFT);
 	static char s_aName[MAX_NAME_LENGTH] = { 0 };
 	static float s_OffsetName = 0.0f;
 	DoEditBox(&s_aName, &Button, s_aName, sizeof(s_aName), Button.h*ms_FontmodHeight*0.8f, &s_OffsetName);
 
-	BottomArea.HSplitTop(ms_ListheaderHeight, &Button, &BottomArea);
+	BottomArea.HSplitTop(GetListHeaderHeight(), &Button, &BottomArea);
 	Button.VSplitLeft(50.0f, &Label, &Button);
 	UI()->DoLabel(&Label, Localize("Clan"), FontSize, CUI::ALIGN_LEFT);
 	static char s_aClan[MAX_CLAN_LENGTH] = { 0 };
 	static float s_OffsetClan = 0.0f;
 	DoEditBox(&s_aClan, &Button, s_aClan, sizeof(s_aClan), Button.h*ms_FontmodHeight*0.8f, &s_OffsetClan);
 
-	BottomArea.HSplitTop(ms_ListheaderHeight, &Button, &BottomArea);
+	BottomArea.HSplitTop(GetListHeaderHeight(), &Button, &BottomArea);
 	RenderTools()->DrawUIRect(&Button, vec4(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 	if(s_aName[0] || s_aClan[0])
 		Button.VSplitLeft(Button.h, &Icon, &Label);
@@ -1597,7 +1604,7 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 	pFilter->GetFilter(&FilterInfo);
 
 	// server filter
-	ServerFilter.HSplitTop(ms_ListheaderHeight, &FilterHeader, &ServerFilter);
+	ServerFilter.HSplitTop(GetListHeaderHeight(), &FilterHeader, &ServerFilter);
 	RenderTools()->DrawUIRect(&FilterHeader, vec4(1, 1, 1, 0.25f), CUI::CORNER_T, 4.0f);
 	RenderTools()->DrawUIRect(&ServerFilter, vec4(0, 0, 0, 0.15f), CUI::CORNER_B, 4.0f);
 	FilterHeader.HMargin(2.0f, &FilterHeader);
@@ -1859,7 +1866,7 @@ void CMenus::RenderDetailInfo(CUIRect View, const CServerInfo *pInfo)
 {
 	CUIRect ServerHeader;
 	const float FontSize = 10.0f;
-	View.HSplitTop(ms_ListheaderHeight, &ServerHeader, &View);
+	View.HSplitTop(GetListHeaderHeight(), &ServerHeader, &View);
 	RenderTools()->DrawUIRect(&ServerHeader, vec4(1, 1, 1, 0.25f), CUI::CORNER_T, 4.0f);
 	RenderTools()->DrawUIRect(&View, vec4(0, 0, 0, 0.15f), CUI::CORNER_B, 4.0f);
 	ServerHeader.HMargin(2.0f, &ServerHeader);
@@ -2102,7 +2109,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View, const CServerInfo *pI
 	RenderDetailInfo(ServerDetails, pInfo);
 
 	// server scoreboard
-	ServerScoreboard.HSplitTop(ms_ListheaderHeight, &ServerHeader, &ServerScoreboard);
+	ServerScoreboard.HSplitTop(GetListHeaderHeight(), &ServerHeader, &ServerScoreboard);
 	RenderTools()->DrawUIRect(&ServerHeader, vec4(1, 1, 1, 0.25f), CUI::CORNER_T, 4.0f);
 	//RenderTools()->DrawUIRect(&View, vec4(0, 0, 0, 0.15f), CUI::CORNER_B, 4.0f);
 	ServerHeader.HMargin(2.0f, &ServerHeader);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2143,7 +2143,7 @@ void CMenus::RenderSettings(CUIRect MainView)
 		// background
 		CUIRect RestartWarning;
 		MainView.HSplitTop(25.0f, &RestartWarning, 0);
-		RestartWarning.VMargin(140.0f, &RestartWarning);
+		RestartWarning.VMargin(g_Config.m_UiWideview ? 210.0f : 140.0f, &RestartWarning);
 		RenderTools()->DrawUIRect(&RestartWarning, vec4(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
 		// text

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -82,6 +82,7 @@ MACRO_CONFIG_INT(UiSettingsPage, ui_settings_page, 0, 0, 5, CFGFLAG_CLIENT|CFGFL
 MACRO_CONFIG_STR(UiServerAddress, ui_server_address, 64, "localhost:8303", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface server address")
 MACRO_CONFIG_INT(UiMousesens, ui_mousesens, 100, 1, 100000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Mouse sensitivity for menus/editor")
 MACRO_CONFIG_INT(UiAutoswitchInfotab, ui_autoswitch_infotab, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Switch to the info tab when clicking on a server")
+MACRO_CONFIG_INT(UiWideview, ui_wideview, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Extended menus GUI")
 
 MACRO_CONFIG_INT(GfxNoclip, gfx_noclip, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Disable clipping")
 


### PR DESCRIPTION
Closes #2276 

Code is not final, bad variable name, and the button to switch between modes should probably go away (?)
Thoughts?

> the zoom in makes the name column tight on 4:3 resolutions, although I believe the expanded view (the arrow on the right) was engineered for this use case
not sure if adaptive zoom in would be better

# 16:9
![screenshot_2019-12-14_13-02-19](https://user-images.githubusercontent.com/355114/70849100-0360c500-1e72-11ea-9de4-5f618b27ebe8.png)
![screenshot_2019-12-14_13-02-23](https://user-images.githubusercontent.com/355114/70849101-0360c500-1e72-11ea-98b3-cbe0551df026.png)
# 4:3
### With sidebar
![screenshot_2019-12-14_13-01-55](https://user-images.githubusercontent.com/355114/70849105-06f44c00-1e72-11ea-98db-beecfd53380a.png)
![screenshot_2019-12-14_13-01-57](https://user-images.githubusercontent.com/355114/70849106-06f44c00-1e72-11ea-86ed-cbaa1abd6f1f.png)
### Collapsed sidebar
![screenshot_2019-12-14_13-01-45](https://user-images.githubusercontent.com/355114/70849103-06f44c00-1e72-11ea-8cd1-952542bdf715.png)
![screenshot_2019-12-14_13-01-50](https://user-images.githubusercontent.com/355114/70849104-06f44c00-1e72-11ea-8b52-05b2ec75e69f.png)