### PR TITLE
Fix issue where contextualized string would erase non-contextualized string

### DIFF
--- a/src/game/client/localization.h
+++ b/src/game/client/localization.h
@@ -16,7 +16,7 @@ class CLocalizationDatabase
 		// TODO: do this as an const char * and put everything on a incremental heap
 		string m_Replacement;
 
-		bool operator <(const CString &Other) const { return m_Hash < Other.m_Hash; }
+		bool operator <(const CString &Other) const { return m_Hash < Other.m_Hash || (m_Hash == Other.m_Hash && m_ContextHash < Other.m_ContextHash); }
 		bool operator <=(const CString &Other) const { return m_Hash <= Other.m_Hash; }
 		bool operator ==(const CString &Other) const { return m_Hash == Other.m_Hash; }
 	};


### PR DESCRIPTION
[5:41:13 PM] <Dune> The problem is there: https://github.com/teeworlds/teeworlds/blob/fd97717a37db63ce76fcd4a1b77d8061d38bc2da/src/game/client/localization.h#L18-L21
[5:42:03 PM] <Dune> when this is called: https://github.com/teeworlds/teeworlds/blob/fd97717a37db63ce76fcd4a1b77d8061d38bc2da/src/game/client/localization.cpp#L46 it erases previous entries

so I changed the `operator<`. I'm not sure about side effects, though, so since it fixed it for me (tested with French), I did not change anything else