### PR TITLE
Replace max. ping editbox with scrollbar option (closes #2267)

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -793,7 +793,7 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 {
 	CUIRect Handle;
 	static float OffsetY;
-	pRect->HSplitTop(pRect->h/8.0f, &Handle, 0);
+	pRect->HSplitTop(min(pRect->h/8.0f, 33.0f), &Handle, 0);
 
 	Handle.y += (pRect->h-Handle.h)*Current;
 
@@ -850,7 +850,7 @@ float CMenus::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current)
 {
 	CUIRect Handle;
 	static float OffsetX;
-	pRect->VSplitLeft(pRect->w/8.0f, &Handle, 0);
+	pRect->VSplitLeft(min(pRect->w/8.0f, 33.0f), &Handle, 0);
 
 	Handle.x += (pRect->w-Handle.w)*Current;
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -636,12 +636,6 @@ void CMenus::DoEditBoxOption(void *pID, char *pOption, int OptionLength, const C
 
 void CMenus::DoScrollbarOption(void *pID, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, bool Infinite)
 {
-	RenderTools()->DrawUIRect(pRect, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
-
-	CUIRect Label, ScrollBar;
-
-	char aBufMax[128];
-	str_format(aBufMax, sizeof(aBufMax), "%s: %i", pStr, Max);
 	int Value = *pOption;
 	if(Infinite)
 	{
@@ -651,21 +645,27 @@ void CMenus::DoScrollbarOption(void *pID, int *pOption, const CUIRect *pRect, co
 			Value = Max;
 	}
 
+	char aBufMax[128];
+	str_format(aBufMax, sizeof(aBufMax), "%s: %i", pStr, Max);
 	char aBuf[128];
 	if(!Infinite || Value != Max)
-		str_format(aBuf, sizeof(aBuf), "%s: %i", pStr, *pOption);
+		str_format(aBuf, sizeof(aBuf), "%s: %i", pStr, Value);
 	else
 		str_format(aBuf, sizeof(aBuf), "%s: \xe2\x88\x9e", pStr);
+
 	float FontSize = pRect->h*ms_FontmodHeight*0.8f;
 	float VSplitVal = max(TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f), TextRender()->TextWidth(0, FontSize, aBufMax, -1, -1.0f));
 
+	RenderTools()->DrawUIRect(pRect, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
+
+	CUIRect Label, ScrollBar;
 	pRect->VSplitLeft(pRect->h+10.0f+VSplitVal, &Label, &ScrollBar);
 	Label.VSplitLeft(Label.h+5.0f, 0, &Label);
 	Label.y += 2.0f;
 	UI()->DoLabel(&Label, aBuf, FontSize, CUI::ALIGN_LEFT);
 
 	ScrollBar.VMargin(4.0f, &ScrollBar);
-	Value = round_to_int(DoScrollbarH(pOption, &ScrollBar, (float)(Value - Min) / (float)(Max - Min))*(float)(Max - Min) + (float)Min + 0.1f);
+	Value = round_to_int(DoScrollbarH(pID, &ScrollBar, (float)(Value - Min) / (float)(Max - Min))*(float)(Max - Min) + (float)Min + 0.1f);
 	if(Infinite && Value == Max)
 		Value = 0;
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -793,7 +793,7 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 {
 	CUIRect Handle;
 	static float OffsetY;
-	pRect->HSplitTop(33, &Handle, 0);
+	pRect->HSplitTop(pRect->h/8.0f, &Handle, 0);
 
 	Handle.y += (pRect->h-Handle.h)*Current;
 
@@ -850,7 +850,7 @@ float CMenus::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current)
 {
 	CUIRect Handle;
 	static float OffsetX;
-	pRect->VSplitLeft(33, &Handle, 0);
+	pRect->VSplitLeft(pRect->w/8.0f, &Handle, 0);
 
 	Handle.x += (pRect->w-Handle.w)*Current;
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1760,11 +1760,20 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 		ServerFilter.HSplitTop(LineSize - 4.f, &Button, &ServerFilter);
 
 	{
+		int Value = FilterInfo.m_Ping, Min = 20, Max = 999;
+
+		char aBuf[64];
+		str_format(aBuf, sizeof(aBuf), "%s %d", Localize("Maximum ping:"), Value);
+		UI()->DoLabel(&Button, aBuf, FontSize, CUI::ALIGN_LEFT);
+
+		ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
+
+		RenderTools()->DrawUIRect(&Button, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
+		Button.VMargin(4.0f, &Button);
 		static int s_BrFilterPing = 0;
-		int currentVal = FilterInfo.m_Ping;
-		DoScrollbarOption(&s_BrFilterPing, &currentVal, &Button, Localize("Max. ping"), 20, 999);
-		if(currentVal != FilterInfo.m_Ping) {
-			FilterInfo.m_Ping = currentVal;
+		Value = round_to_int(DoScrollbarH(&s_BrFilterPing, &Button, (float)(Value - Min) / (float)(Max - Min))*(float)(Max - Min) + (float)Min + 0.1f);
+		if(Value != FilterInfo.m_Ping) {
+			FilterInfo.m_Ping = Value;
 			pFilter->SetFilter(&FilterInfo);
 		}
 	}

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1760,21 +1760,11 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 		ServerFilter.HSplitTop(LineSize - 4.f, &Button, &ServerFilter);
 
 	{
-		ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
-		CUIRect EditBox;
-		Button.VSplitRight(60.0f, &Button, &EditBox);
-
-		UI()->DoLabel(&Button, Localize("Maximum ping:"), FontSize, CUI::ALIGN_LEFT);
-
-		char aBuf[5];
-		str_format(aBuf, sizeof(aBuf), "%d", FilterInfo.m_Ping);
-		static float Offset = 0.0f;
 		static int s_BrFilterPing = 0;
-		DoEditBox(&s_BrFilterPing, &EditBox, aBuf, sizeof(aBuf), FontSize, &Offset);
-		int NewPing = clamp(str_toint(aBuf), 0, 999);
-		if(NewPing != FilterInfo.m_Ping)
-		{
-			FilterInfo.m_Ping = NewPing;
+		int currentVal = FilterInfo.m_Ping;
+		DoScrollbarOption(&s_BrFilterPing, &currentVal, &Button, Localize("Max. ping"), 20, 999);
+		if(currentVal != FilterInfo.m_Ping) {
+			FilterInfo.m_Ping = currentVal;
 			pFilter->SetFilter(&FilterInfo);
 		}
 	}


### PR DESCRIPTION
![asdsadsadsad](https://user-images.githubusercontent.com/23437060/71765869-d6945080-2ef9-11ea-80b8-bb168b71a6ae.JPG)

Also adds support for smaller scrollbars by making the handle size relative to the slider size.

Closes #2267.

The translation string "Maximum ping:" needs to be replaced by "Max. ping".