### PR TITLE
Add server difficulty level enum and accessor methods with validation, closes #2274

### DIFF
--- a/src/engine/client/serverbrowser_filter.cpp
+++ b/src/engine/client/serverbrowser_filter.cpp
@@ -124,7 +124,7 @@ void CServerBrowserFilter::CServerFilter::Filter()
 			Filtered = 1;
 		else if(m_FilterInfo.m_aAddress[0] && !str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aAddress, m_FilterInfo.m_aAddress))
 			Filtered = 1;
-		else if(m_FilterInfo.m_ServerLevel & (1 << m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_ServerLevel))
+		else if(m_FilterInfo.IsLevelFiltered(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_ServerLevel))
 			Filtered = 1;
 		else
 		{

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -35,6 +35,14 @@ public:
 		};
 	};
 
+	enum
+	{
+		LEVEL_CASUAL = 0,
+		LEVEL_NORMAL = 1,
+		LEVEL_COMPETITIVE = 2,
+		NUM_SERVER_LEVELS = 3
+	};
+
 	//int m_SortedIndex;
 	int m_ServerIndex;
 
@@ -75,6 +83,21 @@ public:
 	int m_ServerLevel;
 	char m_aGametype[MAX_GAMETYPES][16];
 	char m_aAddress[NETADDR_MAXSTRSIZE];
+
+	void ToggleLevel(int Level)
+	{
+		m_ServerLevel ^= 1 << Level;
+		if(m_ServerLevel == (1 << CServerInfo::NUM_SERVER_LEVELS)-1)
+		{
+			// Prevent filter that excludes everything
+			m_ServerLevel = 0;
+		}
+	}
+
+	int IsLevelFiltered(int Level)
+	{
+		return m_ServerLevel & (1 << Level);
+	}
 };
 
 class IServerBrowser : public IInterface

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1820,23 +1820,23 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 	Button.y -= 2.0f;
 	Button.VSplitLeft(Button.h, &Icon, &Button);
 	static CButtonContainer s_LevelButton1;
-	if(DoButton_SpriteID(&s_LevelButton1, IMAGE_LEVELICONS, (FilterInfo.m_ServerLevel & 1) ? SPRITE_LEVEL_A_B : SPRITE_LEVEL_A_ON, false, &Icon, CUI::CORNER_L, 5.0f, true))
+	if(DoButton_SpriteID(&s_LevelButton1, IMAGE_LEVELICONS, FilterInfo.IsLevelFiltered(CServerInfo::LEVEL_CASUAL) ? SPRITE_LEVEL_A_B : SPRITE_LEVEL_A_ON, false, &Icon, CUI::CORNER_L, 5.0f, true))
 	{
-		FilterInfo.m_ServerLevel ^= 1;
+		FilterInfo.ToggleLevel(CServerInfo::LEVEL_CASUAL);
 		pFilter->SetFilter(&FilterInfo);
 	}
 	Button.VSplitLeft(Button.h, &Icon, &Button);
 	static CButtonContainer s_LevelButton2;
-	if(DoButton_SpriteID(&s_LevelButton2, IMAGE_LEVELICONS, (FilterInfo.m_ServerLevel & 2) ? SPRITE_LEVEL_B_B : SPRITE_LEVEL_B_ON, false, &Icon, 0, 5.0f, true))
+	if(DoButton_SpriteID(&s_LevelButton2, IMAGE_LEVELICONS, FilterInfo.IsLevelFiltered(CServerInfo::LEVEL_NORMAL) ? SPRITE_LEVEL_B_B : SPRITE_LEVEL_B_ON, false, &Icon, 0, 5.0f, true))
 	{
-		FilterInfo.m_ServerLevel ^= 2;
+		FilterInfo.ToggleLevel(CServerInfo::LEVEL_NORMAL);
 		pFilter->SetFilter(&FilterInfo);
 	}
 	Button.VSplitLeft(Button.h, &Icon, &Button);
 	static CButtonContainer s_LevelButton3;
-	if(DoButton_SpriteID(&s_LevelButton3, IMAGE_LEVELICONS, (FilterInfo.m_ServerLevel & 4) ? SPRITE_LEVEL_C_B : SPRITE_LEVEL_C_ON, false, &Icon, CUI::CORNER_R, 5.0f, true))
+	if(DoButton_SpriteID(&s_LevelButton3, IMAGE_LEVELICONS, FilterInfo.IsLevelFiltered(CServerInfo::LEVEL_COMPETITIVE) ? SPRITE_LEVEL_C_B : SPRITE_LEVEL_C_ON, false, &Icon, CUI::CORNER_R, 5.0f, true))
 	{
-		FilterInfo.m_ServerLevel ^= 4;
+		FilterInfo.ToggleLevel(CServerInfo::LEVEL_COMPETITIVE);
 		pFilter->SetFilter(&FilterInfo);
 	}
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -442,8 +442,20 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 
 	GameInfo.HSplitTop(ButtonHeight, &Label, &GameInfo);
 	Label.y += 2.0f;
-	str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Difficulty"), (CurrentServerInfo.m_ServerLevel == 0) ? Localize("Casual", "Server difficulty") : 
-		(CurrentServerInfo.m_ServerLevel == 1 ? Localize("Normal", "Server difficulty") : Localize("Competitive", "Server difficulty")));
+	const char *pLevelName;
+	switch(CurrentServerInfo.m_ServerLevel)
+	{
+		case CServerInfo::LEVEL_CASUAL:
+			pLevelName = Localize("Casual", "Server difficulty");
+			break;
+		case CServerInfo::LEVEL_NORMAL:
+			pLevelName = Localize("Normal", "Server difficulty");
+			break;
+		case CServerInfo::LEVEL_COMPETITIVE:
+			pLevelName = Localize("Competitive", "Server difficulty");
+			break;
+	}
+	str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Difficulty"), pLevelName);
 	UI()->DoLabel(&Label, aBuf, ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 
 	GameInfo.HSplitTop(ButtonHeight, &Label, &GameInfo);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -442,7 +442,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 
 	GameInfo.HSplitTop(ButtonHeight, &Label, &GameInfo);
 	Label.y += 2.0f;
-	const char *pLevelName;
+	const char *pLevelName = "";
 	switch(CurrentServerInfo.m_ServerLevel)
 	{
 		case CServerInfo::LEVEL_CASUAL:


### PR DESCRIPTION
Adds enum constants for the previously hardcoded difficulty levels to CServerInfo.

Adds methods to work with the filter flags to CServerFilterInfo. The ToggleLevel method makes sure that not all levels are filtered simultaneously (#2274), by resetting to unfiltered in that case.

Refactors usage of the hardcoded magic numbers and bitoperations to use the new methods and constants and replaces cascading tenary operator with switch statement.

I think the implementation of the methods should probably not reside in the serverbrowser.h file thou. Should they be implemented in a new shared/serverbrowser.cpp file?