### PR TITLE
Add scrollbar scale interface and logarithmic scale (closes #2226)

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -634,7 +634,7 @@ void CMenus::DoEditBoxOption(void *pID, char *pOption, int OptionLength, const C
 	DoEditBox(pID, &EditBox, pOption, OptionLength, pRect->h*ms_FontmodHeight*0.8f, pOffset, Hidden);
 }
 
-void CMenus::DoScrollbarOption(void *pID, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, bool Infinite)
+void CMenus::DoScrollbarOption(void *pID, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, IScrollbarScale *pScale, bool Infinite)
 {
 	int Value = *pOption;
 	if(Infinite)
@@ -665,7 +665,7 @@ void CMenus::DoScrollbarOption(void *pID, int *pOption, const CUIRect *pRect, co
 	UI()->DoLabel(&Label, aBuf, FontSize, CUI::ALIGN_LEFT);
 
 	ScrollBar.VMargin(4.0f, &ScrollBar);
-	Value = round_to_int(DoScrollbarH(pID, &ScrollBar, (float)(Value - Min) / (float)(Max - Min))*(float)(Max - Min) + (float)Min + 0.1f);
+	Value = pScale->ToAbsolute(DoScrollbarH(pID, &ScrollBar, pScale->ToRelative(Value, Min, Max)), Min, Max);
 	if(Infinite && Value == Max)
 		Value = 0;
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -53,10 +53,18 @@ static class : public IScrollbarScale
 public:
 	float ToRelative(int AbsoluteValue, int Min, int Max)
 	{
+		if(Min == 0)
+		{
+			return ToRelative(AbsoluteValue+1, Min+1, Max+1);
+		}
 		return (log(AbsoluteValue) - log(Min)) / (float)(log(Max) - log(Min));
 	}
 	int ToAbsolute(float RelativeValue, int Min, int Max)
 	{
+		if(Min == 0)
+		{
+			return ToAbsolute(RelativeValue, Min+1, Max+1)-1;
+		}
 		return round_to_int(exp(RelativeValue*(log(Max) - log(Min)) + log(Min)));
 	}
 } LogarithmicScrollbarScale;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -30,6 +30,37 @@ public:
 	virtual bool OnInput(IInput::CEvent Event);
 };
 
+class IScrollbarScale
+{
+public:
+	virtual float ToRelative(int AbsoluteValue, int Min, int Max) = 0;
+	virtual int ToAbsolute(float RelativeValue, int Min, int Max) = 0;
+};
+static class : public IScrollbarScale
+{
+public:
+	float ToRelative(int AbsoluteValue, int Min, int Max)
+	{
+		return (AbsoluteValue - Min) / (float)(Max - Min);
+	}
+	int ToAbsolute(float RelativeValue, int Min, int Max)
+	{
+		return round_to_int(RelativeValue*(Max - Min) + Min + 0.1f);
+	}
+} LinearScrollbarScale;
+static class : public IScrollbarScale
+{
+public:
+	float ToRelative(int AbsoluteValue, int Min, int Max)
+	{
+		return (log(AbsoluteValue) - log(Min)) / (float)(log(Max) - log(Min));
+	}
+	int ToAbsolute(float RelativeValue, int Min, int Max)
+	{
+		return round_to_int(exp(RelativeValue*(log(Max) - log(Min)) + log(Min)));
+	}
+} LogarithmicScrollbarScale;
+
 class CMenus : public CComponent
 {
 public:
@@ -84,7 +115,7 @@ private:
 	*/
 	int DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden=false, int Corners=CUI::CORNER_ALL);
 	void DoEditBoxOption(void *pID, char *pOption, int OptionLength, const CUIRect *pRect, const char *pStr, float VSplitVal, float *pOffset, bool Hidden=false);
-	void DoScrollbarOption(void *pID, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, bool Infinite=false);
+	void DoScrollbarOption(void *pID, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, IScrollbarScale *pScale = &LinearScrollbarScale, bool Infinite=false);
 	float DoDropdownMenu(void *pID, const CUIRect *pRect, const char *pStr, float HeaderHeight, FDropdownCallback pfnCallback);
 	float DoIndependentDropdownMenu(void *pID, const CUIRect *pRect, const char *pStr, float HeaderHeight, FDropdownCallback pfnCallback, bool* pActive);
 	void DoInfoBox(const CUIRect *pRect, const char *pLable, const char *pValue);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -36,7 +36,7 @@ public:
 	virtual float ToRelative(int AbsoluteValue, int Min, int Max) = 0;
 	virtual int ToAbsolute(float RelativeValue, int Min, int Max) = 0;
 };
-static class : public IScrollbarScale
+static class CLinearScrollbarScale : public IScrollbarScale
 {
 public:
 	float ToRelative(int AbsoluteValue, int Min, int Max)
@@ -48,26 +48,32 @@ public:
 		return round_to_int(RelativeValue*(Max - Min) + Min + 0.1f);
 	}
 } LinearScrollbarScale;
-static class : public IScrollbarScale
+static class CLogarithmicScrollbarScale : public IScrollbarScale
 {
+private:
+	int m_MinAdjustment;
 public:
+	CLogarithmicScrollbarScale(int MinAdjustment)
+	{
+		m_MinAdjustment = max(MinAdjustment, 1); // must be at least 1 to support Min == 0 with logarithm
+	}
 	float ToRelative(int AbsoluteValue, int Min, int Max)
 	{
-		if(Min == 0)
+		if(Min < m_MinAdjustment)
 		{
-			return ToRelative(AbsoluteValue+1, Min+1, Max+1);
+			return ToRelative(AbsoluteValue+m_MinAdjustment, Min+m_MinAdjustment, Max+m_MinAdjustment);
 		}
 		return (log(AbsoluteValue) - log(Min)) / (float)(log(Max) - log(Min));
 	}
 	int ToAbsolute(float RelativeValue, int Min, int Max)
 	{
-		if(Min == 0)
+		if(Min < m_MinAdjustment)
 		{
-			return ToAbsolute(RelativeValue, Min+1, Max+1)-1;
+			return ToAbsolute(RelativeValue, Min+m_MinAdjustment, Max+m_MinAdjustment)-m_MinAdjustment;
 		}
 		return round_to_int(exp(RelativeValue*(log(Max) - log(Min)) + log(Min)));
 	}
-} LogarithmicScrollbarScale;
+} LogarithmicScrollbarScale(25);
 
 class CMenus : public CComponent
 {

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1771,7 +1771,7 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 		RenderTools()->DrawUIRect(&Button, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 		Button.VMargin(4.0f, &Button);
 		static int s_BrFilterPing = 0;
-		Value = round_to_int(DoScrollbarH(&s_BrFilterPing, &Button, (float)(Value - Min) / (float)(Max - Min))*(float)(Max - Min) + (float)Min + 0.1f);
+		Value = LogarithmicScrollbarScale.ToAbsolute(DoScrollbarH(&s_BrFilterPing, &Button, LogarithmicScrollbarScale.ToRelative(Value, Min, Max)), Min, Max);
 		if(Value != FilterInfo.m_Ping) {
 			FilterInfo.m_Ping = Value;
 			pFilter->SetFilter(&FilterInfo);

--- a/src/game/client/components/menus_callback.cpp
+++ b/src/game/client/components/menus_callback.cpp
@@ -146,10 +146,10 @@ float CMenus::RenderSettingsControlsMouse(CUIRect View, void *pUser)
 	}
 	View.HSplitTop(Spaceing, 0, &View);
 	View.HSplitTop(ButtonHeight, &Button, &View);
-	pSelf->DoScrollbarOption(&g_Config.m_InpMousesens, &g_Config.m_InpMousesens, &Button, Localize("Ingame mouse sens."), 1, 500);
+	pSelf->DoScrollbarOption(&g_Config.m_InpMousesens, &g_Config.m_InpMousesens, &Button, Localize("Ingame mouse sens."), 1, 500, &LogarithmicScrollbarScale);
 	View.HSplitTop(Spaceing, 0, &View);
 	View.HSplitTop(ButtonHeight, &Button, &View);
-	pSelf->DoScrollbarOption(&g_Config.m_UiMousesens, &g_Config.m_UiMousesens, &Button, Localize("Menu mouse sens."), 1, 500);
+	pSelf->DoScrollbarOption(&g_Config.m_UiMousesens, &g_Config.m_UiMousesens, &Button, Localize("Menu mouse sens."), 1, 500, &LogarithmicScrollbarScale);
 
 	return BackgroundHeight;
 }
@@ -182,7 +182,7 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View, void *pUser)
 		{
 			View.HSplitTop(Spaceing, 0, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);
-			pSelf->DoScrollbarOption(&g_Config.m_JoystickSens, &g_Config.m_JoystickSens, &Button, Localize("Joystick sens."), 1, 500);
+			pSelf->DoScrollbarOption(&g_Config.m_JoystickSens, &g_Config.m_JoystickSens, &Button, Localize("Joystick sens."), 1, 500, &LogarithmicScrollbarScale);
 
 			View.HSplitTop(Spaceing, 0, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1086,7 +1086,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 
 	Client.HSplitTop(Spacing, 0, &Client);
 	Client.HSplitTop(ButtonHeight, &Button, &Client);
-	DoScrollbarOption(&g_Config.m_ClMenuAlpha, &g_Config.m_ClMenuAlpha, &Button, Localize("Menu background transparency"), 0, 75, false);
+	DoScrollbarOption(&g_Config.m_ClMenuAlpha, &g_Config.m_ClMenuAlpha, &Button, Localize("Menu background transparency"), 0, 75);
 
 	Client.HSplitTop(Spacing, 0, &Client);
 	Client.HSplitTop(ButtonHeight, &Button, &Client);
@@ -1099,7 +1099,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		Client.HSplitTop(Spacing, 0, &Client);
 		Client.HSplitTop(ButtonHeight, &Button, &Client);
 		Button.VSplitLeft(ButtonHeight, 0, &Button);
-		DoScrollbarOption(&g_Config.m_ClAutoDemoMax, &g_Config.m_ClAutoDemoMax, &Button, Localize("Max"), 0, 1000, true);
+		DoScrollbarOption(&g_Config.m_ClAutoDemoMax, &g_Config.m_ClAutoDemoMax, &Button, Localize("Max"), 0, 1000, &LogarithmicScrollbarScale, true);
 	}
 
 	Client.HSplitTop(Spacing, 0, &Client);
@@ -1113,7 +1113,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		Client.HSplitTop(Spacing, 0, &Client);
 		Client.HSplitTop(ButtonHeight, &Button, &Client);
 		Button.VSplitLeft(ButtonHeight, 0, &Button);
-		DoScrollbarOption(&g_Config.m_ClAutoScreenshotMax, &g_Config.m_ClAutoScreenshotMax, &Button, Localize("Max"), 0, 1000, true);
+		DoScrollbarOption(&g_Config.m_ClAutoScreenshotMax, &g_Config.m_ClAutoScreenshotMax, &Button, Localize("Max"), 0, 1000, &LogarithmicScrollbarScale, true);
 	}
 
 	MainView.HSplitTop(10.0f, 0, &MainView);
@@ -2108,7 +2108,7 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 		}
 
 		Right.HSplitTop(ButtonHeight, &Button, &Right);
-		DoScrollbarOption(&g_Config.m_SndVolume, &g_Config.m_SndVolume, &Button, Localize("Volume"), 0, 100);
+		DoScrollbarOption(&g_Config.m_SndVolume, &g_Config.m_SndVolume, &Button, Localize("Volume"), 0, 100, &LogarithmicScrollbarScale);
 	}
 	else
 	{


### PR DESCRIPTION
Using linear scrollbars for

- Max. FPS
- Menu background transparency
- Nameplate size

and logarithmic ones for

- Menu/Ingame mouse sens.
- Joystick sens.
- Auto. screenshots/demos
- Sound volume
- Max. ping

Closes #2226.