### PR TITLE
Make warmups abortable, fix restart and pause when alone, allow restarting when paused

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1211,7 +1211,22 @@ void CGameContext::ConRestart(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	if(pResult->NumArguments())
-		pSelf->m_pController->DoWarmup(clamp(pResult->GetInteger(0), -1, 1000));
+	{
+		const char *pStringArg = pResult->GetString(0);
+		if(str_comp_nocase(pStringArg, "-a") == 0 || str_comp_nocase(pStringArg, "abort") == 0)
+		{
+			pSelf->m_pController->AbortWarmup();
+		}
+		else
+		{
+			int Seconds = clamp(pResult->GetInteger(0), -1, 1000);
+			if(Seconds != 0 || pStringArg[0] == '0')
+			{
+				// Only allow instant restart if zero was actually entered, not if the argument isn't a number.
+				pSelf->m_pController->DoWarmup(Seconds);
+			}
+		}
+	}
 	else
 		pSelf->m_pController->DoWarmup(0);
 }
@@ -1514,7 +1529,7 @@ void CGameContext::OnConsoleInit()
 
 	Console()->Register("pause", "?i", CFGFLAG_SERVER|CFGFLAG_STORE, ConPause, this, "Pause/unpause game");
 	Console()->Register("change_map", "?r", CFGFLAG_SERVER|CFGFLAG_STORE, ConChangeMap, this, "Change map");
-	Console()->Register("restart", "?i", CFGFLAG_SERVER|CFGFLAG_STORE, ConRestart, this, "Restart in x seconds (0 = abort)");
+	Console()->Register("restart", "?s", CFGFLAG_SERVER|CFGFLAG_STORE, ConRestart, this, "Restart in x seconds (0 = restart now, '-a' or 'abort' to abort warmup)");
 	Console()->Register("say", "r", CFGFLAG_SERVER, ConSay, this, "Say in chat");
 	Console()->Register("broadcast", "r", CFGFLAG_SERVER, ConBroadcast, this, "Broadcast message");
 	Console()->Register("set_team", "ii?i", CFGFLAG_SERVER, ConSetTeam, this, "Set team of player to team");

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -540,6 +540,7 @@ void IGameController::SetGameState(EGameState GameState, int Timer)
 						if(GameServer()->m_apPlayers[i])
 							GameServer()->m_apPlayers[i]->m_RespawnDisabled = false;
 				}
+				GameServer()->m_World.m_Paused = false;
 			}
 			else
 			{

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -510,8 +510,8 @@ void IGameController::SetGameState(EGameState GameState, int Timer)
 		}
 		break;
 	case IGS_WARMUP_USER:
-		// user based warmup is only possible when the game or a user based warmup is running
-		if(m_GameState == IGS_GAME_RUNNING || m_GameState == IGS_WARMUP_USER)
+		// user based warmup is only possible when the game or any warmup is running
+		if(m_GameState == IGS_GAME_RUNNING || m_GameState == IGS_GAME_PAUSED || m_GameState == IGS_WARMUP_GAME || m_GameState == IGS_WARMUP_USER)
 		{
 			if(Timer != 0)
 			{
@@ -582,8 +582,8 @@ void IGameController::SetGameState(EGameState GameState, int Timer)
 		}
 		break;
 	case IGS_GAME_PAUSED:
-		// only possible when game is running or paused
-		if(m_GameState == IGS_GAME_RUNNING || m_GameState == IGS_GAME_PAUSED)
+		// only possible when game is running or paused, or when game based warmup is running
+		if(m_GameState == IGS_GAME_RUNNING || m_GameState == IGS_GAME_PAUSED || m_GameState == IGS_WARMUP_GAME)
 		{
 			if(Timer != 0)
 			{
@@ -596,7 +596,7 @@ void IGameController::SetGameState(EGameState GameState, int Timer)
 				}
 				else
 				{
-					// pauses for a specific time intervall
+					// pauses for a specific time interval
 					m_GameStateTimer = Timer*Server()->TickSpeed();
 				}
 

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -789,8 +789,6 @@ void IGameController::Tick()
 				// check if player ready mode was disabled and it waits that all players are ready -> end warmup
 				if(!Config()->m_SvPlayerReadyMode && m_GameStateTimer == TIMER_INFINITE)
 					SetGameState(IGS_WARMUP_USER, 0);
-				else if(m_GameStateTimer == 3 * Server()->TickSpeed())
-					StartMatch();
 				break;
 			case IGS_START_COUNTDOWN:
 			case IGS_GAME_PAUSED:

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -188,6 +188,14 @@ public:
 		else
 			SetGameState(IGS_WARMUP_USER, Seconds);
 	}
+	void AbortWarmup()
+	{
+		if((m_GameState == IGS_WARMUP_GAME || m_GameState == IGS_WARMUP_USER)
+			&& m_GameStateTimer != TIMER_INFINITE)
+		{
+			SetGameState(IGS_GAME_RUNNING);
+		}
+	}
 	void SwapTeamscore();
 
 	// general

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -183,10 +183,7 @@ public:
 	void DoPause(int Seconds) { SetGameState(IGS_GAME_PAUSED, Seconds); }
 	void DoWarmup(int Seconds)
 	{
-		if(m_GameState==IGS_WARMUP_GAME)
-			SetGameState(IGS_WARMUP_GAME, 0);
-		else
-			SetGameState(IGS_WARMUP_USER, Seconds);
+		SetGameState(IGS_WARMUP_USER, Seconds);
 	}
 	void AbortWarmup()
 	{


### PR DESCRIPTION
- Warmup can be aborted with `restart -a` and `restart abort`. Infinite warmup cannot be aborted (closes #2153).
- Fix restart timer and pause not working when alone (closes #2154).
- Allow restarting when game is paused (closes #1809).
- Remove a hard coded 3 second timer that restarts the warmup early (related to #1690).


