### PR TITLE
fix 'key not found' when chat is not bound to any key and find double binds, fixes #2372

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -205,25 +205,41 @@ const char *CBinds::Get(int KeyID, int Modifier)
 	return "";
 }
 
-void CBinds::GetKey(const char *pBindStr, char aKey[64], unsigned BufSize)
+void CBinds::GetKeyID(const char *pBindStr, int& KeyID, int& Modifier)
 {
-	aKey[0] = 0;
-	for(int KeyID = 0; KeyID < KEY_LAST; KeyID++)
+	for(KeyID = 0; KeyID < KEY_LAST; KeyID++)
 	{
-		for(int m = 0; m < MODIFIER_COUNT; m++)
+		for(Modifier = 0; Modifier < MODIFIER_COUNT; Modifier++)
 		{
-			const char *pBind = Get(KeyID, m);
+			const char *pBind = Get(KeyID, Modifier);
 			if(!pBind[0])
 				continue;
 
-			if(str_comp(pBind, pBindStr) == 0)
-			{
-				str_format(aKey, BufSize, "%s%s", GetModifierName(m), Input()->KeyName(KeyID));
+			if(str_find(pBind, pBindStr) != 0)
 				return;
-			}
 		}
 	}
+	
+	//this is already given by the loops above
+	KeyID = KEY_LAST;
+	Modifier = MODIFIER_COUNT;
+}
+
+void CBinds::GetKey(const char *pBindStr, char aKey[64], unsigned BufSize, int KeyID, int Modifier)
+{
+	aKey[0] = 0;
+	if(KeyID < KEY_LAST){
+		str_format(aKey, BufSize, "%s%s", GetModifierName(Modifier), Input()->KeyName(KeyID));
+		return;
+	}
 	str_copy(aKey, "key not found", BufSize);
+}
+
+void CBinds::GetKey(const char *pBindStr, char aKey[64], unsigned BufSize)
+{
+	int KeyID, Modifier;
+	GetKeyID(pBindStr, KeyID, Modifier);
+	GetKey(pBindStr, aKey, BufSize, KeyID, Modifier);
 }
 
 void CBinds::SetDefaults()

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -42,6 +42,8 @@ public:
 	void SetDefaults();
 	void UnbindAll();
 	const char *Get(int KeyID, int Modifier);
+	void GetKeyID(const char *pBindStr, int& KeyID, int& Modifier);
+	void GetKey(const char *pBindStr, char aKey[64], unsigned BufSize, int KeyID, int Modifier);
 	void GetKey(const char *pBindStr, char aKey[64], unsigned BufSize);
 	static const char *GetModifierName(int m);
 	static int GetModifierMask(IInput *i);

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -908,13 +908,20 @@ void CChat::OnRender()
 			CTextCursor InfoCursor;
 			TextRender()->SetCursor(&InfoCursor, 2.0f, y+12.0f, CategoryFontSize*0.75, TEXTFLAG_RENDER);
 
-			//find keyname and format text
-			char aKeyName[64];
-			m_pClient->m_pBinds->GetKey(GetCommandName(m_ChatBufferMode), aKeyName, sizeof(aKeyName));
+			//Check if key exists with bind
+			int KeyID, Modifier;
+			m_pClient->m_pBinds->GetKeyID(GetCommandName(m_ChatBufferMode), KeyID, Modifier);
+			
+			if(KeyID < KEY_LAST)
+			{
+				//find keyname and format text
+				char aKeyName[64];
+				m_pClient->m_pBinds->GetKey(GetCommandName(m_ChatBufferMode), aKeyName, sizeof(aKeyName), KeyID, Modifier);
 
-			char aInfoText[128];
-			str_format(aInfoText, sizeof(aInfoText), Localize("Press %s to resume chatting"), aKeyName);
-			TextRender()->TextEx(&InfoCursor, aInfoText, -1);
+				char aInfoText[128];
+				str_format(aInfoText, sizeof(aInfoText), Localize("Press %s to resume chatting"), aKeyName);
+				TextRender()->TextEx(&InfoCursor, aInfoText, -1);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
This does fix issue #2372, but doesn't fix the empty Settings

Note: this can be broken with binds like `bind o "say chat all"`, since it contains the right command