### PR TITLE
Hide killmessages when cl_show_hud is off

### DIFF
--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -137,6 +137,9 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 
 void CInfoMessages::OnRender()
 {
+	if(!g_Config.m_ClShowhud)
+		return;
+
 	float Width = 400*3.0f*Graphics()->ScreenAspect();
 	float Height = 400*3.0f;
 


### PR DESCRIPTION
> > I guess we should add that to the no-hud option. Would be nice not to make another option just for that.
>
> good idea :)

_Originally posted by @zooom7z in https://github.com/teeworlds/teeworlds/issues/2390#issuecomment-573221504_


tested ingame. fixes #2390