### PR TITLE
Add support for multiple joysticks, some refactoring

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -42,11 +42,12 @@ CInput::CInput()
 	mem_zero(m_aInputCount, sizeof(m_aInputCount));
 	mem_zero(m_aInputState, sizeof(m_aInputState));
 
-	m_pJoystick = 0;
-
 	m_InputCounter = 1;
 	m_InputGrabbed = 0;
 	m_pClipboardText = 0;
+
+	m_SelectedJoystickIndex = -1;
+	m_aSelectedJoystickGUID[0] = '\0';
 
 	m_PreviousHat = 0;
 
@@ -61,6 +62,7 @@ CInput::~CInput()
 	{
 		SDL_free(m_pClipboardText);
 	}
+	CloseJoysticks();
 }
 
 void CInput::Init()
@@ -71,6 +73,11 @@ void CInput::Init()
 
 	MouseModeRelative();
 
+	InitJoysticks();
+}
+
+void CInput::InitJoysticks()
+{
 	if(!SDL_WasInit(SDL_INIT_JOYSTICK))
 	{
 		if(SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0)
@@ -80,20 +87,27 @@ void CInput::Init()
 		}
 	}
 
-	if(SDL_NumJoysticks() > 0)
+	int NumJoysticks = SDL_NumJoysticks();
+	if(NumJoysticks > 0)
 	{
-		m_pJoystick = SDL_JoystickOpen(0);
+		dbg_msg("joystick", "%d joystick(s) found", NumJoysticks);
 
-		if(!m_pJoystick) {
-			dbg_msg("joystick", "Could not open 0th joystick: %s", SDL_GetError());
-			return;
+		for(int i = 0; i < NumJoysticks; i++)
+		{
+			SDL_Joystick *pJoystick = SDL_JoystickOpen(i);
+
+			if(!pJoystick) {
+				dbg_msg("joystick", "Could not open joystick %d: %s", i, SDL_GetError());
+				return;
+			}
+			m_apJoysticks.add(pJoystick);
+
+			dbg_msg("joystick", "Opened Joystick %d", i);
+			dbg_msg("joystick", "Name: %s", SDL_JoystickNameForIndex(i));
+			dbg_msg("joystick", "Number of Axes: %d", SDL_JoystickNumAxes(pJoystick));
+			dbg_msg("joystick", "Number of Buttons: %d", SDL_JoystickNumButtons(pJoystick));
+			dbg_msg("joystick", "Number of Balls: %d", SDL_JoystickNumBalls(pJoystick));
 		}
-
-		dbg_msg("joystick", "Opened Joystick 0");
-		dbg_msg("joystick", "Name: %s", SDL_JoystickNameForIndex(0));
-		dbg_msg("joystick", "Number of Axes: %d", SDL_JoystickNumAxes(m_pJoystick));
-		dbg_msg("joystick", "Number of Buttons: %d", SDL_JoystickNumButtons(m_pJoystick));
-		dbg_msg("joystick", "Number of Balls: %d", SDL_JoystickNumBalls(m_pJoystick));
 	}
 	else
 	{
@@ -101,10 +115,82 @@ void CInput::Init()
 	}
 }
 
-float CInput::GetJoystickAxisValue(int Axis) const
+SDL_Joystick* CInput::GetActiveJoystick()
 {
-	dbg_assert((bool)m_pJoystick, "Requesting joystic axis value, but no joysticks were initialized");
-	return static_cast<float>(SDL_JoystickGetAxis(m_pJoystick, Axis)) / (float)(SDL_JOYSTICK_AXIS_MAX+1);
+	if(m_apJoysticks.size() == 0)
+	{
+		return NULL;
+	}
+	if(m_aSelectedJoystickGUID[0] && str_comp(m_aSelectedJoystickGUID, g_Config.m_JoystickGUID) != 0)
+	{
+		// Refresh if cached GUID differs from configured GUID
+		m_SelectedJoystickIndex = -1;
+	}
+	if(m_SelectedJoystickIndex == -1)
+	{
+		for(int i = 0; i < m_apJoysticks.size(); i++)
+		{
+			char aGUID[sizeof(m_aSelectedJoystickGUID)];
+			SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(m_apJoysticks[i]), aGUID, sizeof(aGUID));
+			if(str_comp(g_Config.m_JoystickGUID, aGUID) == 0)
+			{
+				m_SelectedJoystickIndex = i;
+				str_copy(m_aSelectedJoystickGUID, g_Config.m_JoystickGUID, sizeof(m_aSelectedJoystickGUID));
+				break;
+			}
+		}
+		// could not find configured joystick, falling back to first available
+		if(m_SelectedJoystickIndex == -1)
+		{
+			m_SelectedJoystickIndex = 0;
+			SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(m_apJoysticks[0]), g_Config.m_JoystickGUID, sizeof(g_Config.m_JoystickGUID));
+			str_copy(m_aSelectedJoystickGUID, g_Config.m_JoystickGUID, sizeof(m_aSelectedJoystickGUID));
+		}
+	}
+	return m_apJoysticks[m_SelectedJoystickIndex];
+}
+
+void CInput::CloseJoysticks()
+{
+	for(sorted_array<SDL_Joystick*>::range r = m_apJoysticks.all(); !r.empty(); r.pop_front())
+	{
+		if (SDL_JoystickGetAttached(r.front()))
+		{
+			SDL_JoystickClose(r.front());
+		}
+	}
+	m_apJoysticks.clear();
+}
+
+void CInput::SelectNextJoystick()
+{
+	const int Num = m_apJoysticks.size();
+	if(Num > 1)
+	{
+		const int NextIndex = (m_SelectedJoystickIndex + 1) % Num;
+		SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(m_apJoysticks[NextIndex]), g_Config.m_JoystickGUID, sizeof(g_Config.m_JoystickGUID));
+	}
+}
+
+const char* CInput::GetJoystickName()
+{
+	SDL_Joystick* pJoystick = GetActiveJoystick();
+	dbg_assert((bool)pJoystick, "Requesting joystick name, but no joysticks were initialized");
+	return SDL_JoystickName(pJoystick);
+}
+
+float CInput::GetJoystickAxisValue(int Axis)
+{
+	SDL_Joystick* pJoystick = GetActiveJoystick();
+	dbg_assert((bool)pJoystick, "Requesting joystick axis value, but no joysticks were initialized");
+	return static_cast<float>(SDL_JoystickGetAxis(pJoystick, Axis)) / (float)(SDL_JOYSTICK_AXIS_MAX+1);
+}
+
+int CInput::GetJoystickNumAxes()
+{
+	SDL_Joystick* pJoystick = GetActiveJoystick();
+	dbg_assert((bool)pJoystick, "Requesting joystick axes count, but no joysticks were initialized");
+	return SDL_JoystickNumAxes(pJoystick);
 }
 
 void CInput::MouseRelative(float *x, float *y)
@@ -120,7 +206,7 @@ void CInput::MouseRelative(float *x, float *y)
 
 	vec2 j = vec2(0.0f, 0.0f);
 
-	if(g_Config.m_JoystickEnable && m_pJoystick)
+	if(g_Config.m_JoystickEnable && GetActiveJoystick())
 	{
 		const float Max = 50.0f;
 		j = vec2(GetJoystickAxisValue(g_Config.m_JoystickX), GetJoystickAxisValue(g_Config.m_JoystickY)) * Max;

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -3,11 +3,19 @@
 #ifndef ENGINE_CLIENT_INPUT_H
 #define ENGINE_CLIENT_INPUT_H
 
+#include <base/tl/sorted_array.h>
+
 class CInput : public IEngineInput
 {
 	IEngineGraphics *m_pGraphics;
 	IConsole *m_pConsole;
-	SDL_Joystick *m_pJoystick;
+
+	sorted_array<SDL_Joystick*> m_apJoysticks;
+	int m_SelectedJoystickIndex;
+	char m_aSelectedJoystickGUID[34];
+	SDL_Joystick* GetActiveJoystick();
+	void InitJoysticks();
+	void CloseJoysticks();
 
 	int m_InputGrabbed;
 	char *m_pClipboardText;
@@ -38,9 +46,13 @@ public:
 
 	bool KeyIsPressed(int Key) const { return KeyState(Key); }
 	bool KeyPress(int Key, bool CheckCounter) const { return CheckCounter ? (m_aInputCount[Key] == m_InputCounter) : m_aInputCount[Key]; }
-	
-	bool HasJoystick() const { return m_pJoystick; }
-	float GetJoystickAxisValue(int Axis) const;
+
+	int NumJoysticks() const { return m_apJoysticks.size(); }
+	int GetJoystickIndex() const { return m_SelectedJoystickIndex; };
+	void SelectNextJoystick();
+	const char* GetJoystickName();
+	int GetJoystickNumAxes();
+	float GetJoystickAxisValue(int Axis);
 
 	virtual void MouseRelative(float *x, float *y);
 	virtual void MouseModeAbsolute();

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -7,6 +7,7 @@
 
 const int g_MaxKeys = 512;
 extern const char g_aaKeyStrings[g_MaxKeys][20];
+const int g_MaxJoystickAxes = 12;
 
 class IInput : public IInterface
 {
@@ -58,10 +59,14 @@ public:
 	virtual bool KeyPress(int Key, bool CheckCounter=false) const = 0;
 	const char *KeyName(int Key) const { return (Key >= 0 && Key < g_MaxKeys) ? g_aaKeyStrings[Key] : g_aaKeyStrings[0]; }
 	virtual void Clear() = 0;
-	
+
 	// joystick
-	virtual bool HasJoystick() const = 0;
-	virtual float GetJoystickAxisValue(int Axis) const = 0;
+	virtual int NumJoysticks() const = 0;
+	virtual int GetJoystickIndex() const = 0;
+	virtual void SelectNextJoystick() = 0;
+	virtual const char* GetJoystickName() = 0;
+	virtual int GetJoystickNumAxes() = 0;
+	virtual float GetJoystickAxisValue(int Axis) = 0;
 
 	// mouse
 	virtual void MouseModeRelative() = 0;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -69,9 +69,10 @@ MACRO_CONFIG_INT(InpGrab, inp_grab, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Disab
 MACRO_CONFIG_INT(InpMousesens, inp_mousesens, 100, 1, 100000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Ingame mouse sensitivity")
 
 MACRO_CONFIG_INT(JoystickEnable , joystick_enable, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Enable joystick")
+MACRO_CONFIG_STR(JoystickGUID, joystick_guid, 34, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick GUID which uniquely identifies the active joystick")
 MACRO_CONFIG_INT(JoystickSens, joystick_sens, 100, 1, 100000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick sensitivity")
-MACRO_CONFIG_INT(JoystickX, joystick_x, 0, 0, 6, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick axis that controls X axis of cursor")
-MACRO_CONFIG_INT(JoystickY, joystick_y, 1, 0, 6, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick axis that controls Y axis of cursor")
+MACRO_CONFIG_INT(JoystickX, joystick_x, 0, 0, 12, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick axis that controls X axis of cursor")
+MACRO_CONFIG_INT(JoystickY, joystick_y, 1, 0, 12, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick axis that controls Y axis of cursor")
 MACRO_CONFIG_INT(JoystickTolerance, joystick_tolerance, 5, 0, 50, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick Axis tolerance to account for jitter")
 
 MACRO_CONFIG_STR(SvName, sv_name, 128, "unnamed server", CFGFLAG_SAVE|CFGFLAG_SERVER, "Server name")

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -918,13 +918,13 @@ void CMenus::DoJoystickBar(const CUIRect *pRect, float Current, float Tolerance,
 	CUIRect ToleranceArea = Rail;
 	ToleranceArea.w *= Tolerance;
 	ToleranceArea.x += (Rail.w-ToleranceArea.w)/2.0f;
-	vec4 Color = Active ? vec4(0.8f, 0.35f, 0.35f, 1.0f) : vec4(0.7f, 0.5f, 0.5f, 1.0f);
-	RenderTools()->DrawUIRect(&ToleranceArea, Color, CUI::CORNER_ALL, ToleranceArea.h/2.0f);
+	vec4 ToleranceColor = Active ? vec4(0.8f, 0.35f, 0.35f, 1.0f) : vec4(0.7f, 0.5f, 0.5f, 1.0f);
+	RenderTools()->DrawUIRect(&ToleranceArea, ToleranceColor, CUI::CORNER_ALL, ToleranceArea.h/2.0f);
 
 	CUIRect Slider = Handle;
 	Slider.HMargin(4.0f, &Slider);
-	Color = Active ? vec4(0.95f, 0.95f, 0.95f, 1.0f) : vec4(0.8f, 0.8f, 0.8f, 1.0f);
-	RenderTools()->DrawUIRect(&Slider, Color, CUI::CORNER_ALL, Slider.h/2.0f);
+	vec4 SliderColor = Active ? vec4(0.95f, 0.95f, 0.95f, 1.0f) : vec4(0.8f, 0.8f, 0.8f, 1.0f);
+	RenderTools()->DrawUIRect(&Slider, SliderColor, CUI::CORNER_ALL, Slider.h/2.0f);
 }
 
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1550,13 +1550,13 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 	static int s_MouseDropdown = 0;
 	static bool s_MouseActive = true;
 	float Split = DoIndependentDropdownMenu(&s_MouseDropdown, &MainView, Localize("Mouse"), HeaderHeight, RenderSettingsControlsMouse, &s_MouseActive);
-	
+
 	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
 	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
 	static int s_JoystickDropdown = 0;
-	static bool s_JoystickActive = m_pClient->Input()->HasJoystick(); // hide by default if no joystick found
+	static bool s_JoystickActive = m_pClient->Input()->NumJoysticks() > 0; // hide by default if no joystick found
 	Split = DoIndependentDropdownMenu(&s_JoystickDropdown, &MainView, Localize("Joystick"), HeaderHeight, RenderSettingsControlsJoystick, &s_JoystickActive);
-	
+
 	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
 	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
 	static int s_MovementDropdown = 0;


### PR DESCRIPTION
- Store Joystick GUID to persist the setting.
- Only show as many axes as supported in settings (up to 12).

![screenshot_2020-01-11_18-01-48](https://user-images.githubusercontent.com/23437060/72208025-893a5500-349e-11ea-8e99-744fb8bf9354.png)
![screenshot_2020-01-11_18-01-50](https://user-images.githubusercontent.com/23437060/72208026-893a5500-349e-11ea-8c3f-c5e6651a0414.png)

Should close #2056.

