### PR TITLE
Make offline friendlist boxes smaller and adjust some margins

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1491,14 +1491,15 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 					UI()->DoLabel(&Button, aBuf, FontSize - 2, CUI::ALIGN_LEFT);
 				}
 				// delete button
-				Icon.HSplitTop(20.0f, &Rect, 0);
-				Rect.VSplitRight(10.0f, &Button, &Icon);
+				Icon.HSplitTop(14.0f, &Rect, 0);
+				Rect.VSplitRight(12.0f, 0, &Icon);
 				Icon.HMargin((Icon.h - Icon.w) / 2, &Icon);
 				if(DoButton_SpriteClean(IMAGE_TOOLICONS, SPRITE_TOOL_X_B, &Icon))
 				{
 					m_pDeleteFriend = &m_lFriendList[i][f];
 				}
 				// join button
+				Rect.VSplitRight(15.0f, &Button, 0);
 				if(m_lFriendList[i][f].m_pServerInfo)
 				{
 					Button.Margin((Button.h - GetListHeaderHeight() + 2.0f) / 2, &Button);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1455,7 +1455,10 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 			// entries
 			for(int f = 0; f < m_lFriendList[i].size(); ++f, ++ButtonId)
 			{
-				View.HSplitTop(20.0f + GetListHeaderHeight(), &Rect, &View);
+				if(i == FRIEND_OFF)
+					View.HSplitTop(8.0f + GetListHeaderHeight(), &Rect, &View);
+				else
+					View.HSplitTop(20.0f + GetListHeaderHeight(), &Rect, &View);
 				ScrollRegionAddRect(&s_ScrollRegion, Rect);
 				if(i == FRIEND_PLAYER_ON)
 					RenderTools()->DrawUIRect(&Rect, vec4(0.5f, 1.0f, 0.5f, 0.30f), CUI::CORNER_ALL, 5.0f);
@@ -1464,6 +1467,7 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 				else
 					RenderTools()->DrawUIRect(&Rect, vec4(1.0f, 0.5f, 0.5f, 0.30f), CUI::CORNER_ALL, 5.0f);
 				Rect.VMargin(2.0f, &Rect);
+				Rect.HMargin(2.0f, &Rect);
 				Rect.VSplitRight(45.0f, &Rect, &Icon);
 				Rect.HSplitTop(20.0f, &Button, 0);
 				// name


### PR DESCRIPTION
This PR improves a bit further the friendlist boxes:
- now the offline list boxes are smaller and take up less space
- made the remove friend button a bit bigger
- added some top margin inside the rect as the text was on its edge

Before:
![before_boxes](https://user-images.githubusercontent.com/2030615/72210254-cf041700-34b8-11ea-88fb-958e086986df.png)
Now:
![now_boxes](https://user-images.githubusercontent.com/2030615/72210255-d2979e00-34b8-11ea-9876-7698d57facd8.png)

