### PR TITLE
Make sure server selection stays in sync with server address, refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1458,7 +1458,9 @@ if(CLIENT)
     components/menus_callback.cpp
     components/menus_demo.cpp
     components/menus_ingame.cpp
+	components/menus_listbox.cpp
     components/menus_popups.cpp
+	components/menus_scrollregion.cpp
     components/menus_settings.cpp
     components/menus_start.cpp
     components/motd.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1458,9 +1458,9 @@ if(CLIENT)
     components/menus_callback.cpp
     components/menus_demo.cpp
     components/menus_ingame.cpp
-	components/menus_listbox.cpp
+    components/menus_listbox.cpp
     components/menus_popups.cpp
-	components/menus_scrollregion.cpp
+    components/menus_scrollregion.cpp
     components/menus_settings.cpp
     components/menus_start.cpp
     components/motd.cpp

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2034,7 +2034,6 @@ void CClient::Run()
 		// handle pending connects
 		if(m_aCmdConnect[0])
 		{
-			str_copy(g_Config.m_UiServerAddress, m_aCmdConnect, sizeof(g_Config.m_UiServerAddress));
 			Connect(m_aCmdConnect);
 			m_aCmdConnect[0] = 0;
 		}

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1537,6 +1537,8 @@ void CMenus::OnInit()
 	Console()->Chain("br_filter_string", ConchainServerbrowserUpdate, this);
 	Console()->Chain("add_favorite", ConchainServerbrowserUpdate, this);
 	Console()->Chain("remove_favorite", ConchainServerbrowserUpdate, this);
+	Console()->Chain("br_sort", ConchainServerbrowserSortingUpdate, this);
+	Console()->Chain("br_sort_order", ConchainServerbrowserSortingUpdate, this);
 	Console()->Chain("add_friend", ConchainFriendlistUpdate, this);
 	Console()->Chain("remove_friend", ConchainFriendlistUpdate, this);
 	Console()->Chain("snd_enable_music", ConchainToggleMusic, this);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -51,7 +51,7 @@ CMenus::CMenus()
 	m_LastBrowserType = -1;
 	m_LastServerAddress[0] = '\0';
 	for(int Type = 0; Type < IServerBrowser::NUM_TYPES; Type++)
-		m_aSelectedFilters[Type] = 0;
+		m_aSelectedFilters[Type] = -1;
 
 	m_NeedRestartGraphics = false;
 	m_NeedRestartSound = false;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -49,7 +49,6 @@ CMenus::CMenus()
 	m_SidebarActive = true;
 	m_ShowServerDetails = true;
 	m_LastBrowserType = -1;
-	m_aLastServerAddress[0] = '\0';
 	m_AddressSelection = 0;
 	for(int Type = 0; Type < IServerBrowser::NUM_TYPES; Type++)
 	{
@@ -1922,7 +1921,7 @@ int CMenus::Render()
 			static CButtonContainer s_ButtonTryAgain;
 			if(DoButton_Menu(&s_ButtonTryAgain, Localize("Try again"), 0, &TryAgain) || m_EnterPressed)
 			{
-				Client()->Connect(g_Config.m_UiServerAddress);
+				Client()->Connect(GetServerBrowserAddress());
 			}
 		}
 		else if(m_Popup == POPUP_CONNECTING)
@@ -1988,7 +1987,7 @@ int CMenus::Render()
 			else
 			{
 				Box.HSplitTop(27.0f, 0, &Box);
-				UI()->DoLabel(&Box, g_Config.m_UiServerAddress, ButtonHeight*ms_FontmodHeight*0.8f, ExtraAlign);
+				UI()->DoLabel(&Box, GetServerBrowserAddress(), ButtonHeight*ms_FontmodHeight*0.8f, ExtraAlign);
 			}
 		}
 		else if(m_Popup == POPUP_LANGUAGE)

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -49,9 +49,10 @@ CMenus::CMenus()
 	m_SidebarActive = true;
 	m_ShowServerDetails = true;
 	m_LastBrowserType = -1;
-	m_LastServerAddress[0] = '\0';
+	m_aLastServerAddress[0] = '\0';
+	m_AddressSelection = 0;
 	for(int Type = 0; Type < IServerBrowser::NUM_TYPES; Type++)
-		m_aSelectedFilters[Type] = -1;
+		m_aSelectedFilters[Type] = -2;
 
 	m_NeedRestartGraphics = false;
 	m_NeedRestartSound = false;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -276,15 +276,17 @@ void CMenus::DoButton_MenuTabTop_Dummy(const char *pText, int Checked, const CUI
 }
 
 int CMenus::DoButton_GridHeader(const void *pID, const char *pText, int Checked, CUI::EAlignment Align, const CUIRect *pRect)
-//void CMenus::ui_draw_grid_header(const void *id, const char *text, int checked, const CUIRect *r, const void *extra)
 {
 	if(Checked)
 	{
-		RenderTools()->DrawUIRect(pRect, vec4(1,1,1,0.5f), CUI::CORNER_ALL, 5.0f);
+		RenderTools()->DrawUIRect(pRect, vec4(0.9f, 0.9f, 0.9f, 0.5f), CUI::CORNER_ALL, 5.0f);
 		TextRender()->TextColor(0.0f, 0.0f, 0.0f, 1.0f);
 		TextRender()->TextOutlineColor(1.0f, 1.0f, 1.0f, 0.25f);
 	}
-
+	else if(UI()->HotItem() == pID)
+	{
+		RenderTools()->DrawUIRect(pRect, vec4(1.0f, 1.0f, 1.0f, 0.5f), CUI::CORNER_ALL, 5.0f);
+	}
 
 	CUIRect Label;
 	pRect->VMargin(2.0f, &Label);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2010,7 +2010,7 @@ int CMenus::Render()
 				s_ActSelection = FilterInfo.m_Country;
 			static CListBox s_ListBox(this);
 			int OldSelected = -1;
-			s_ListBox.DoStart(40.0f, 0, m_pClient->m_pCountryFlags->Num(), 12, OldSelected, &Box, false);
+			s_ListBox.DoStart(40.0f, m_pClient->m_pCountryFlags->Num(), 12, OldSelected, &Box, false);
 
 			for(int i = 0; i < m_pClient->m_pCountryFlags->Num(); ++i)
 			{

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1901,7 +1901,7 @@ int CMenus::Render()
 			Box.HSplitTop(2.0f, 0, &Box);
 			Box.HSplitTop(20.0f, &Save, &Box);
 			CServerInfo ServerInfo = {0};
-			str_copy(ServerInfo.m_aHostname, g_Config.m_UiServerAddress, sizeof(ServerInfo.m_aHostname));
+			str_copy(ServerInfo.m_aHostname, GetServerBrowserAddress(), sizeof(ServerInfo.m_aHostname));
 			ServerBrowser()->UpdateFavoriteState(&ServerInfo);
 			const bool Favorite = ServerInfo.m_Favorite;
 			const int OnValue = Favorite ? 1 : 2;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -52,7 +52,10 @@ CMenus::CMenus()
 	m_aLastServerAddress[0] = '\0';
 	m_AddressSelection = 0;
 	for(int Type = 0; Type < IServerBrowser::NUM_TYPES; Type++)
+	{
 		m_aSelectedFilters[Type] = -2;
+		m_aSelectedServers[Type] = -1;
+	}
 
 	m_NeedRestartGraphics = false;
 	m_NeedRestartSound = false;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1534,6 +1534,7 @@ void CMenus::OnInit()
 	if(g_Config.m_ClSkipStartMenu)
 		SetMenuPage(g_Config.m_UiBrowserPage);
 
+	Console()->Chain("br_filter_string", ConchainServerbrowserUpdate, this);
 	Console()->Chain("add_favorite", ConchainServerbrowserUpdate, this);
 	Console()->Chain("remove_favorite", ConchainServerbrowserUpdate, this);
 	Console()->Chain("add_friend", ConchainFriendlistUpdate, this);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -617,16 +617,14 @@ private:
 	{
 		const int Tab = ServerBrowser()->GetType();
 		if(m_aSelectedFilters[Tab] == -1)
-			return NULL;
+			return 0;
 		return &m_lFilters[m_aSelectedFilters[Tab]];
 	}
 
 	const CServerInfo* GetSelectedServerInfo()
 	{
 		CBrowserFilter* pSelectedFilter = GetSelectedBrowserFilter();
-		if(pSelectedFilter == NULL)
-			return NULL;
-		return pSelectedFilter->SortedGetSelected();
+		return pSelectedFilter ? pSelectedFilter->SortedGetSelected() : 0;
 	}
 
 	void UpdateServerBrowserAddress();

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -608,9 +608,8 @@ private:
 
 		ADDR_SELECTION_CHANGE = 1,
 		ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND = 2,
-		ADDR_SELECTION_RESET_ADDRESS_IF_NOT_FOUND = 4,
-		ADDR_SELECTION_REVEAL = 8,
-		ADDR_SELECTION_UPDATE_ADDRESS = 16,
+		ADDR_SELECTION_REVEAL = 4,
+		ADDR_SELECTION_UPDATE_ADDRESS = 8,
 	};
 	int m_SidebarTab;
 	bool m_SidebarActive;
@@ -637,6 +636,7 @@ private:
 
 	void UpdateServerBrowserAddress();
 	void ServerBrowserFilterOnUpdate();
+	void ServerBrowserSortingOnUpdate();
 
 
 	// video settings
@@ -706,6 +706,7 @@ private:
 	void RenderServerbrowser(CUIRect MainView);
 	static void ConchainFriendlistUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainServerbrowserUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainServerbrowserSortingUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainToggleMusic(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	void DoFriendListEntry(CUIRect *pView, CFriendItem *pFriend, const void *pID, const CContactInfo *pFriendInfo, const CServerInfo *pServerInfo, bool Checked, bool Clan = false);
 	void SetOverlay(int Type, float x, float y, const void *pData);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -198,7 +198,10 @@ private:
 	class CScrollRegion
 	{
 	private:
-		CMenus *m_pMenus;
+		CRenderTools *m_pRenderTools;
+		CUI *m_pUI;
+		IInput *m_pInput;
+
 		float m_ScrollY;
 		float m_ContentH;
 		float m_RequestScrollY; // [0, ContentHeight]

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -605,14 +605,20 @@ private:
 		COL_BROWSER_PLAYERS,
 		COL_BROWSER_PING,
 		NUM_BROWSER_COLS,
-	};
 
+		ADDR_SELECTION_CHANGE = 1,
+		ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND = 2,
+		ADDR_SELECTION_RESET_ADDRESS_IF_NOT_FOUND = 4,
+		ADDR_SELECTION_REVEAL = 8,
+		ADDR_SELECTION_UPDATE_ADDRESS = 16,
+	};
 	int m_SidebarTab;
 	bool m_SidebarActive;
 	bool m_ShowServerDetails;
-	int m_LastBrowserType;
-	int m_aSelectedFilters[IServerBrowser::NUM_TYPES];
-	char m_LastServerAddress[sizeof(g_Config.m_UiServerAddress)];
+	int m_LastBrowserType; // -1 if not initialized
+	int m_aSelectedFilters[IServerBrowser::NUM_TYPES]; // -1 if none selected, -2 if not initialized
+	char m_aLastServerAddress[sizeof(g_Config.m_UiServerAddress)]; // a[0] == 0 if not initialized
+	int m_AddressSelection;
 	static CColumn ms_aBrowserCols[NUM_BROWSER_COLS];
 
 	CBrowserFilter* GetSelectedBrowserFilter()

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -251,20 +251,25 @@ private:
 		int m_ListBoxNumItems;
 		int m_ListBoxItemsPerRow;
 		bool m_ListBoxItemActivated;
+		const char *m_pBottomText;
+		float m_FooterHeight;
 		CScrollRegion m_ScrollRegion;
 		vec2 m_ScrollOffset;
 		char m_aFilterString[64];
 		float m_OffsetFilter;
+
+	protected:
+		CListboxItem DoNextRow();
 
 	public:
 		CListBox(CMenus *pMenus);
 
 		void DoHeader(const CUIRect *pRect, const char *pTitle, float HeaderHeight = 20.0f, float Spacing = 2.0f);
 		bool DoFilter(float FilterHeight = 20.0f, float Spacing = 2.0f);
-		void DoStart(float RowHeight, const char *pBottomText, int NumItems, int ItemsPerRow, int SelectedIndex,
+		void DoFooter(const char *pBottomText, float FooterHeight = 20.0f); // call before DoStart to create a footer
+		void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int SelectedIndex,
 					const CUIRect *pRect = 0, bool Background = true, bool *pActive = 0);
 		CListboxItem DoNextItem(const void *pID, bool Selected = false, bool *pActive = 0);
-		CListboxItem DoNextRow();
 		int DoEnd(bool *pItemActivated);
 		bool FilterMatches(const char *pNeedle);
 	};

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -239,7 +239,11 @@ private:
 	class CListBox
 	{
 	private:
-		CMenus *m_pMenus;
+		CMenus *m_pMenus; // TODO: refactor to remove this
+		CRenderTools *m_pRenderTools;
+		CUI *m_pUI;
+		IInput *m_pInput;
+
 		CUIRect m_ListBoxView;
 		float m_ListBoxRowHeight;
 		int m_ListBoxItemIndex;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -183,10 +183,10 @@ private:
 		Content.HSplitTop(SomeValue, &Rect, &Content);
 		s_ScrollRegion.AddRect(Rect);
 
-		-- [Optionnal] Knowing if a rect is clipped --
+		-- [Optional] Knowing if a rect is clipped --
 		s_ScrollRegion.IsRectClipped(Rect);
 
-		-- [Optionnal] Scroll to a rect (to the last added rect)--
+		-- [Optional] Scroll to a rect (to the last added rect)--
 		...
 		s_ScrollRegion.AddRect(Rect);
 		s_ScrollRegion.ScrollHere(Option);
@@ -194,6 +194,7 @@ private:
 		-- End --
 		s_ScrollRegion.End();
 	*/
+	// Instances of CScrollRegion must be static, as member addresses are used as UI item IDs
 	class CScrollRegion
 	{
 	private:
@@ -234,6 +235,7 @@ private:
 		CUIRect m_Rect;
 	};
 
+	// Instances of CListBox must be static, as member addresses are used as UI item IDs
 	class CListBox
 	{
 	private:

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -615,7 +615,6 @@ private:
 	int m_LastBrowserType; // -1 if not initialized
 	int m_aSelectedFilters[IServerBrowser::NUM_TYPES]; // -1 if none selected, -2 if not initialized
 	int m_aSelectedServers[IServerBrowser::NUM_TYPES]; // -1 if none selected
-	char m_aLastServerAddress[sizeof(g_Config.m_UiServerAddress)]; // a[0] == 0 if not initialized
 	int m_AddressSelection;
 	static CColumn ms_aBrowserCols[NUM_BROWSER_COLS];
 
@@ -639,6 +638,8 @@ private:
 	}
 
 	void UpdateServerBrowserAddress();
+	const char *GetServerBrowserAddress();
+	void SetServerBrowserAddress(const char *pAddress);
 	void ServerBrowserFilterOnUpdate();
 	void ServerBrowserSortingOnUpdate();
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -531,7 +531,6 @@ private:
 		// buttons var
 		int m_SwitchButton;
 		int m_aButtonID[3];
-		int m_aSelectedServers[IServerBrowser::NUM_TYPES];
 
 		CBrowserFilter() {}
 		CBrowserFilter(int Custom, const char* pName, IServerBrowser *pServerBrowser);
@@ -546,7 +545,6 @@ private:
 		int NumSortedServers() const;
 		int NumPlayers() const;
 		const CServerInfo* SortedGet(int Index) const;
-		const CServerInfo* SortedGetSelected() const;
 		const void* ID(int Index) const;
 
 		void Reset();
@@ -616,6 +614,7 @@ private:
 	bool m_ShowServerDetails;
 	int m_LastBrowserType; // -1 if not initialized
 	int m_aSelectedFilters[IServerBrowser::NUM_TYPES]; // -1 if none selected, -2 if not initialized
+	int m_aSelectedServers[IServerBrowser::NUM_TYPES]; // -1 if none selected
 	char m_aLastServerAddress[sizeof(g_Config.m_UiServerAddress)]; // a[0] == 0 if not initialized
 	int m_AddressSelection;
 	static CColumn ms_aBrowserCols[NUM_BROWSER_COLS];
@@ -631,7 +630,12 @@ private:
 	const CServerInfo* GetSelectedServerInfo()
 	{
 		CBrowserFilter* pSelectedFilter = GetSelectedBrowserFilter();
-		return pSelectedFilter ? pSelectedFilter->SortedGetSelected() : 0;
+		if(!pSelectedFilter)
+			return 0;
+		const int Tab = ServerBrowser()->GetType();
+		if(m_aSelectedServers[Tab] < 0 || m_aSelectedServers[Tab] >= pSelectedFilter->NumSortedServers())
+			return 0;
+		return pSelectedFilter->SortedGet(m_aSelectedServers[Tab]);
 	}
 
 	void UpdateServerBrowserAddress();

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -979,8 +979,10 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 {
 	CUIRect Headers, Status;
 
-	float SpacingH = 2.0f;
-	float ButtonHeight = 20.0f;
+	const float SpacingH = 2.0f;
+	const float ButtonHeight = 20.0f;
+	const float HeaderHeight = GetListHeaderHeight();
+	const float HeightFactor = GetListHeaderHeightFactor();
 
 	// background
 	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, g_Config.m_ClMenuAlpha/100.0f), (Client()->State() == IClient::STATE_OFFLINE) ? CUI::CORNER_ALL : CUI::CORNER_B|CUI::CORNER_TR, 5.0f);
@@ -991,7 +993,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		View.VSplitRight(20.0f, &View, &Scroll);
 	}
 
-	View.HSplitTop(GetListHeaderHeight(), &Headers, &View);
+	View.HSplitTop(HeaderHeight, &Headers, &View);
 	View.HSplitBottom(ButtonHeight*3.0f+SpacingH*2.0f, &View, &Status);
 
 	Headers.VSplitRight(2.f, &Headers, 0); // some margin on the right
@@ -1001,7 +1003,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	{
 		if(ms_aBrowserCols[i].m_Direction == -1)
 		{
-			Headers.VSplitLeft(ms_aBrowserCols[i].m_Width*GetListHeaderHeightFactor(), &ms_aBrowserCols[i].m_Rect, &Headers);
+			Headers.VSplitLeft(ms_aBrowserCols[i].m_Width*HeightFactor, &ms_aBrowserCols[i].m_Rect, &Headers);
 
 			if(i+1 < NUM_BROWSER_COLS)
 			{
@@ -1014,7 +1016,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	{
 		if(ms_aBrowserCols[i].m_Direction == 1)
 		{
-			Headers.VSplitRight(ms_aBrowserCols[i].m_Width*GetListHeaderHeightFactor(), &Headers, &ms_aBrowserCols[i].m_Rect);
+			Headers.VSplitRight(ms_aBrowserCols[i].m_Width*HeightFactor, &Headers, &ms_aBrowserCols[i].m_Rect);
 			Headers.VSplitRight(2, &Headers, &ms_aBrowserCols[i].m_Spacer);
 		}
 	}
@@ -1253,7 +1255,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 					m_AddressSelection &= ~(ADDR_SELECTION_CHANGE|ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND);
 				}
 
-				float ItemHeight = GetListHeaderHeight();
+				float ItemHeight = HeaderHeight;
 				if(!m_SidebarActive && IsSelected && m_ShowServerDetails)
 				{
 					ItemHeight *= 6.0f;
@@ -1557,21 +1559,22 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 	// show lists
 	// only ~10 buttons will be displayed at once, a sliding window of 20 buttons ought to be enough
 	static CButtonContainer s_FriendJoinButtons[20];
+	const float HeaderHeight = GetListHeaderHeight();
 	int ButtonId = 0;
 	for(int i = 0; i < NUM_FRIEND_TYPES; ++i)
 	{
 		CUIRect Header;
 		char aBuf[64] = { 0 };
-		View.HSplitTop(GetListHeaderHeight(), &Header, &View);
+		View.HSplitTop(HeaderHeight, &Header, &View);
 		if(s_ListExtended[i])
 		{
 			// entries
 			for(int f = 0; f < m_lFriendList[i].size(); ++f, ++ButtonId)
 			{
 				if(i == FRIEND_OFF)
-					View.HSplitTop(8.0f + GetListHeaderHeight(), &Rect, &View);
+					View.HSplitTop(8.0f + HeaderHeight, &Rect, &View);
 				else
-					View.HSplitTop(20.0f + GetListHeaderHeight(), &Rect, &View);
+					View.HSplitTop(20.0f + HeaderHeight, &Rect, &View);
 				s_ScrollRegion.AddRect(Rect);
 				if(i == FRIEND_PLAYER_ON)
 					RenderTools()->DrawUIRect(&Rect, vec4(0.5f, 1.0f, 0.5f, 0.30f), CUI::CORNER_ALL, 5.0f);
@@ -1594,7 +1597,7 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 				// info
 				if(m_lFriendList[i][f].m_pServerInfo)
 				{
-					Rect.HSplitTop(GetListHeaderHeight(), &Button, &Rect);
+					Rect.HSplitTop(HeaderHeight, &Button, &Rect);
 					Button.VSplitLeft(2.0f, 0, &Button);
 					if(m_lFriendList[i][f].m_IsPlayer)
 						str_format(aBuf, sizeof(aBuf), Localize("Playing '%s' on '%s'", "Playing '(gametype)' on '(map)'"), m_lFriendList[i][f].m_pServerInfo->m_aGameType, m_lFriendList[i][f].m_pServerInfo->m_aMap);
@@ -1615,7 +1618,7 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 				Rect.VSplitRight(15.0f, &Button, 0);
 				if(m_lFriendList[i][f].m_pServerInfo)
 				{
-					Button.Margin((Button.h - GetListHeaderHeight() + 2.0f) / 2, &Button);
+					Button.Margin((Button.h - HeaderHeight + 2.0f) / 2, &Button);
 					if(DoButton_Menu(&(s_FriendJoinButtons[ButtonId%20]), Localize("Join", "Join a server"), 0, &Button) )
 					{
 						SetServerBrowserAddress(m_lFriendList[i][f].m_pServerInfo->m_aAddress);
@@ -1651,21 +1654,21 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 	s_ScrollRegion.End();
 
 	// add friend
-	BottomArea.HSplitTop(GetListHeaderHeight(), &Button, &BottomArea);
+	BottomArea.HSplitTop(HeaderHeight, &Button, &BottomArea);
 	Button.VSplitLeft(50.0f, &Label, &Button);
 	UI()->DoLabel(&Label, Localize("Name"), FontSize, CUI::ALIGN_LEFT);
 	static char s_aName[MAX_NAME_LENGTH] = { 0 };
 	static float s_OffsetName = 0.0f;
 	DoEditBox(&s_aName, &Button, s_aName, sizeof(s_aName), Button.h*ms_FontmodHeight*0.8f, &s_OffsetName);
 
-	BottomArea.HSplitTop(GetListHeaderHeight(), &Button, &BottomArea);
+	BottomArea.HSplitTop(HeaderHeight, &Button, &BottomArea);
 	Button.VSplitLeft(50.0f, &Label, &Button);
 	UI()->DoLabel(&Label, Localize("Clan"), FontSize, CUI::ALIGN_LEFT);
 	static char s_aClan[MAX_CLAN_LENGTH] = { 0 };
 	static float s_OffsetClan = 0.0f;
 	DoEditBox(&s_aClan, &Button, s_aClan, sizeof(s_aClan), Button.h*ms_FontmodHeight*0.8f, &s_OffsetClan);
 
-	BottomArea.HSplitTop(GetListHeaderHeight(), &Button, &BottomArea);
+	BottomArea.HSplitTop(HeaderHeight, &Button, &BottomArea);
 	RenderTools()->DrawUIRect(&Button, vec4(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 	if(s_aName[0] || s_aClan[0])
 		Button.VSplitLeft(Button.h, &Icon, &Label);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1027,6 +1027,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 					g_Config.m_BrSortOrder = 0;
 				g_Config.m_BrSort = ms_aBrowserCols[i].m_Sort;
 			}
+			ServerBrowserSortingOnUpdate();
 		}
 	}
 
@@ -1077,7 +1078,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			ToBeSelectedServer = m_lFilters[ToBeSelectedFilter].m_aSelectedServers[BrowserType];
 			if(ToBeSelectedServer == -1)
 			{
-				m_AddressSelection |= ADDR_SELECTION_CHANGE | ADDR_SELECTION_RESET_ADDRESS_IF_NOT_FOUND | ADDR_SELECTION_REVEAL;
+				m_AddressSelection |= ADDR_SELECTION_CHANGE | ADDR_SELECTION_REVEAL;
 			}
 		}
 		m_AddressSelection |= ADDR_SELECTION_UPDATE_ADDRESS;
@@ -1238,7 +1239,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 				// select server if address changed and match found
 				bool IsSelected = m_aSelectedFilters[BrowserType] == FilterIndex && pFilter->m_aSelectedServers[BrowserType] == ServerIndex;
-				if((m_AddressSelection&ADDR_SELECTION_CHANGE) && !str_comp(pItem->m_aAddress, g_Config.m_UiServerAddress))
+				if(!str_comp(pItem->m_aAddress, g_Config.m_UiServerAddress))
 				{
 					if(!IsSelected)
 					{
@@ -1247,7 +1248,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 						pFilter->m_aSelectedServers[BrowserType] = ServerIndex;
 						IsSelected = true;
 					}
-					m_AddressSelection &= ~(ADDR_SELECTION_CHANGE|ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND|ADDR_SELECTION_RESET_ADDRESS_IF_NOT_FOUND);
+					m_AddressSelection &= ~(ADDR_SELECTION_CHANGE|ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND);
 				}
 
 				float ItemHeight = GetListHeaderHeight();
@@ -1288,7 +1289,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 					m_ShowServerDetails = !m_ShowServerDetails || ReturnValue == 2 || pFilter->m_aSelectedServers[BrowserType] != ServerIndex; // click twice on line => fold server details
 					m_aSelectedFilters[BrowserType] = FilterIndex;
 					pFilter->m_aSelectedServers[BrowserType] = ServerIndex;
-					m_AddressSelection &= ~(ADDR_SELECTION_CHANGE|ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND|ADDR_SELECTION_RESET_ADDRESS_IF_NOT_FOUND);
+					m_AddressSelection &= ~(ADDR_SELECTION_CHANGE|ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND);
 					if(g_Config.m_UiAutoswitchInfotab)
 						m_SidebarTab = 0;
 					UpdateServerBrowserAddress(); // update now instead of using flag because of connect
@@ -1301,11 +1302,6 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			{
 				pFilter->m_aSelectedServers[BrowserType] = -1;
 				m_AddressSelection &= ~ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND;
-			}
-			if(m_AddressSelection&ADDR_SELECTION_RESET_ADDRESS_IF_NOT_FOUND)
-			{
-				g_Config.m_UiServerAddress[0] = '\0';
-				m_AddressSelection &= ~ADDR_SELECTION_RESET_ADDRESS_IF_NOT_FOUND;
 			}
 		}
 
@@ -2404,6 +2400,11 @@ void CMenus::ServerBrowserFilterOnUpdate()
 	m_AddressSelection |= ADDR_SELECTION_CHANGE | ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND;
 }
 
+void CMenus::ServerBrowserSortingOnUpdate()
+{
+	m_AddressSelection |= ADDR_SELECTION_CHANGE | ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND;
+}
+
 void CMenus::ConchainFriendlistUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
 {
 	pfnCallback(pResult, pCallbackUserData);
@@ -2419,4 +2420,11 @@ void CMenus::ConchainServerbrowserUpdate(IConsole::IResult *pResult, void *pUser
 	pfnCallback(pResult, pCallbackUserData);
 	CMenus *pMenus = (CMenus*)pUserData;
 	pMenus->ServerBrowserFilterOnUpdate();
+}
+
+void CMenus::ConchainServerbrowserSortingUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	pfnCallback(pResult, pCallbackUserData);
+	CMenus *pMenus = (CMenus*)pUserData;
+	pMenus->ServerBrowserSortingOnUpdate();
 }

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1110,17 +1110,18 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	{
 		// update stored state based on updated state of UI
 		m_aSelectedFilters[BrowserType] = SelectedFilter;
-		UpdateServerBrowserAddress();
-		m_AddressSelection |= ADDR_SELECTION_REVEAL;
-		if(SelectedFilter == -1)
+		if(SelectedFilter != -1)
 		{
-			// reset address when all filters are closed
-			m_AddressSelection |= ADDR_SELECTION_RESET_ADDRESS_IF_NOT_FOUND;
-		}
-		else if(m_lFilters[SelectedFilter].m_aSelectedServers[BrowserType] == -1)
-		{
-			// restore selection based on address only if no stored selection index for this filter
-			m_AddressSelection |= ADDR_SELECTION_CHANGE;
+			m_AddressSelection |= ADDR_SELECTION_REVEAL;
+			if(m_lFilters[SelectedFilter].m_aSelectedServers[BrowserType] == -1)
+			{
+				// restore selection based on address only if no stored selection index for this filter
+				m_AddressSelection |= ADDR_SELECTION_CHANGE;
+			}
+			else
+			{
+				m_AddressSelection |= ADDR_SELECTION_UPDATE_ADDRESS;
+			}
 		}
 	}
 
@@ -1341,7 +1342,10 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	EditBox.VSplitRight(EditBox.h, &EditBox, &Button);
 	static float s_ClearOffset = 0.0f;
 	if(DoEditBox(&g_Config.m_BrFilterString, &EditBox, g_Config.m_BrFilterString, sizeof(g_Config.m_BrFilterString), FontSize, &s_ClearOffset, false, CUI::CORNER_ALL))
+	{
 		Client()->ServerBrowserUpdate();
+		ServerBrowserFilterOnUpdate();
+	}
 
 	// clear button
 	{
@@ -2413,4 +2417,6 @@ void CMenus::ConchainFriendlistUpdate(IConsole::IResult *pResult, void *pUserDat
 void CMenus::ConchainServerbrowserUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
 {
 	pfnCallback(pResult, pCallbackUserData);
+	CMenus *pMenus = (CMenus*)pUserData;
+	pMenus->ServerBrowserFilterOnUpdate();
 }

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1367,7 +1367,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	if(BrowserType == IServerBrowser::TYPE_INTERNET)
 	{
 		static float s_InternetAddressOffset = 0.0f;
-		if(DoEditBox(&g_Config.m_UiInternetServerAddress, &EditBox, g_Config.m_UiInternetServerAddress, sizeof(g_Config.m_UiInternetServerAddress), FontSize, &s_InternetAddressOffset, false, CUI::CORNER_ALL))
+		if(DoEditBox(&g_Config.m_UiServerAddress, &EditBox, g_Config.m_UiServerAddress, sizeof(g_Config.m_UiServerAddress), FontSize, &s_InternetAddressOffset, false, CUI::CORNER_ALL))
 		{
 			m_AddressSelection |= ADDR_SELECTION_CHANGE | ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND | ADDR_SELECTION_REVEAL;
 		}
@@ -1375,7 +1375,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	else if(BrowserType == IServerBrowser::TYPE_LAN)
 	{
 		static float s_LanAddressOffset = 0.0f;
-		if(DoEditBox(&g_Config.m_UiLanServerAddress, &EditBox, g_Config.m_UiLanServerAddress, sizeof(g_Config.m_UiLanServerAddress), FontSize, &s_LanAddressOffset, false, CUI::CORNER_ALL))
+		if(DoEditBox(&g_Config.m_UiServerAddressLan, &EditBox, g_Config.m_UiServerAddressLan, sizeof(g_Config.m_UiServerAddressLan), FontSize, &s_LanAddressOffset, false, CUI::CORNER_ALL))
 		{
 			m_AddressSelection |= ADDR_SELECTION_CHANGE | ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND | ADDR_SELECTION_REVEAL;
 		}
@@ -2407,9 +2407,9 @@ const char *CMenus::GetServerBrowserAddress()
 {
 	const int Type = ServerBrowser()->GetType();
 	if(Type == IServerBrowser::TYPE_INTERNET)
-		return g_Config.m_UiInternetServerAddress;
+		return g_Config.m_UiServerAddress;
 	else if(Type == IServerBrowser::TYPE_LAN)
-		return g_Config.m_UiLanServerAddress;
+		return g_Config.m_UiServerAddressLan;
 	return 0;
 }
 
@@ -2417,9 +2417,9 @@ void CMenus::SetServerBrowserAddress(const char *pAddress)
 {
 	const int Type = ServerBrowser()->GetType();
 	if(Type == IServerBrowser::TYPE_INTERNET)
-		str_copy(g_Config.m_UiInternetServerAddress, pAddress, sizeof(g_Config.m_UiInternetServerAddress));
+		str_copy(g_Config.m_UiServerAddress, pAddress, sizeof(g_Config.m_UiServerAddress));
 	else if(Type == IServerBrowser::TYPE_LAN)
-		str_copy(g_Config.m_UiLanServerAddress, pAddress, sizeof(g_Config.m_UiLanServerAddress));
+		str_copy(g_Config.m_UiServerAddressLan, pAddress, sizeof(g_Config.m_UiServerAddressLan));
 }
 
 void CMenus::ServerBrowserFilterOnUpdate()

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -171,11 +171,18 @@ void CMenus::LoadFilters()
 		m_SidebarTab = clamp(int(rSettingsEntry["sidebar_tab"].u.integer), 0, 2);
 	if(rSettingsEntry["filters"].type == json_array)
 	{
-		for(unsigned i = 0; i < rSettingsEntry["filters"].u.array.length && i < IServerBrowser::NUM_TYPES; ++i)
+		for(unsigned i = 0; i < IServerBrowser::NUM_TYPES; ++i)
 		{
-			if(rSettingsEntry["filters"][i].type == json_integer)
+			if(i < rSettingsEntry["filters"].u.array.length && rSettingsEntry["filters"][i].type == json_integer)
 				m_aSelectedFilters[i] = rSettingsEntry["filters"][i].u.integer;
+			else
+				m_aSelectedFilters[i] = 2; // default to "all" if not set for all filters
 		}
+	}
+	else
+	{
+		for(unsigned i = 0; i < IServerBrowser::NUM_TYPES; ++i)
+			m_aSelectedFilters[i] = 2; // default to "all" if not set
 	}
 
 	// extract filter data

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -376,7 +376,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 {
 	// logic
 	int ReturnValue = 0;
-	int Inside = UI()->MouseInside(&View);
+	int Inside = UI()->MouseInside(&View) && UI()->MouseInsideClip();
 
 	if(UI()->CheckActiveItem(pID))
 	{

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -377,8 +377,8 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	MainView.HSplitTop(MainView.h - BackgroundHeight - 2 * HMargin, &ListBox, &MainView);
 
 	static CListBox s_ListBox(this);
-	s_ListBox.DoHeader(&ListBox, Localize("Recorded"), 20.0f, 2.0f);
-	s_ListBox.DoStart(20.0f, 0, m_lDemos.size(), 1, m_DemolistSelectedIndex);
+	s_ListBox.DoHeader(&ListBox, Localize("Recorded"), GetListHeaderHeight());
+	s_ListBox.DoStart(20.0f, m_lDemos.size(), 1, m_DemolistSelectedIndex);
 	for(sorted_array<CDemoItem>::range r = m_lDemos.all(); !r.empty(); r.pop_front())
 	{
 		CListboxItem Item = s_ListBox.DoNextItem((void*)(&r.front()));

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -505,8 +505,8 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 {
 	static CListBox s_ListBox(this);
 	CUIRect List = MainView;
-	s_ListBox.DoHeader(&List, Localize("Option"));
-	s_ListBox.DoStart(20.0f, 0, m_pClient->m_pVoting->m_NumVoteOptions, 1, m_CallvoteSelectedOption, 0, true);
+	s_ListBox.DoHeader(&List, Localize("Option"), GetListHeaderHeight());
+	s_ListBox.DoStart(20.0f, m_pClient->m_pVoting->m_NumVoteOptions, 1, m_CallvoteSelectedOption, 0, true);
 
 	for(CVoteOptionClient *pOption = m_pClient->m_pVoting->m_pFirst; pOption; pOption = pOption->m_pNext)
 	{
@@ -554,8 +554,8 @@ void CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 
 	static CListBox s_ListBox(this);
 	CUIRect List = MainView;
-	s_ListBox.DoHeader(&List, Localize("Player"));
-	s_ListBox.DoStart(20.0f, 0, NumOptions, 1, Selected, 0, true);
+	s_ListBox.DoHeader(&List, Localize("Player"), GetListHeaderHeight());
+	s_ListBox.DoStart(20.0f, NumOptions, 1, Selected, 0, true);
 
 	for(int i = 0; i < NumOptions; i++)
 	{

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -380,7 +380,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 
 	ServerInfo.HSplitTop(ButtonHeight, &Label, &ServerInfo);
 	Label.y += 2.0f;
-	str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Address"), g_Config.m_UiServerAddress);
+	str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Address"), CurrentServerInfo.m_aHostname);
 	UI()->DoLabel(&Label, aBuf, ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 	
 	ServerInfo.HSplitTop(ButtonHeight, &Label, &ServerInfo);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -230,13 +230,13 @@ void CMenus::RenderPlayers(CUIRect MainView)
 	MainView.Margin(5.0f, &MainView);
 
 	// prepare scroll
-	static CScrollRegion s_ScrollRegion;
+	static CScrollRegion s_ScrollRegion(this);
 	vec2 ScrollOffset(0, 0);
 	CScrollRegionParams ScrollParams;
 	ScrollParams.m_ClipBgColor = vec4(0,0,0,0);
 	ScrollParams.m_ScrollbarBgColor = vec4(0,0,0,0);
 	ScrollParams.m_ScrollSpeed = 15;
-	if(s_ScrollRegion.m_ContentH > s_ScrollRegion.m_ClipRect.h) // scrollbar is shown
+	if(s_ScrollRegion.IsScrollbarShown())
 		Row.VSplitRight(ScrollParams.m_ScrollbarWidth, &Row, 0);
 
 	// headline
@@ -264,7 +264,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 
 	// scroll, ignore margins
 	MainView.Margin(-5.0f, &MainView);
-	BeginScrollRegion(&s_ScrollRegion, &MainView, &ScrollOffset, &ScrollParams);
+	s_ScrollRegion.Begin(&MainView, &ScrollOffset, &ScrollParams);
 	MainView.Margin(5.0f, &MainView);
 	MainView.y += ScrollOffset.y;
 
@@ -279,7 +279,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 				continue;
 
 			MainView.HSplitTop(ButtonHeight, &Row, &MainView);
-			ScrollRegionAddRect(&s_ScrollRegion, Row);
+			s_ScrollRegion.AddRect(Row);
 
 			if(Count++ % 2 == 0)
 				RenderTools()->DrawUIRect(&Row, vec4(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
@@ -340,7 +340,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 			}
 		}
 	}
-	EndScrollRegion(&s_ScrollRegion);
+	s_ScrollRegion.End();
 }
 
 void CMenus::RenderServerInfo(CUIRect MainView)
@@ -483,9 +483,9 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	RenderTools()->DrawUIRect(&Motd, vec4(0.0, 0.0, 0.0, 0.25f), CUI::CORNER_ALL, 5.0f);
 	Motd.Margin(5.0f, &Motd);
 
-	static CScrollRegion s_ScrollRegion;
+	static CScrollRegion s_ScrollRegion(this);
 	vec2 ScrollOffset(0, 0);
-	BeginScrollRegion(&s_ScrollRegion, &Motd, &ScrollOffset);
+	s_ScrollRegion.Begin(&Motd, &ScrollOffset);
 	Motd.y += ScrollOffset.y;
 
 	CTextCursor Cursor;
@@ -496,9 +496,9 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	// define the MOTD text area and make it scrollable
 	CUIRect MotdTextArea;
 	Motd.HSplitTop(Cursor.m_Y-Motd.y+ButtonHeight*ms_FontmodHeight*0.8f+5.0f, &MotdTextArea, &Motd);
-	ScrollRegionAddRect(&s_ScrollRegion, MotdTextArea);
+	s_ScrollRegion.AddRect(MotdTextArea);
 
-	EndScrollRegion(&s_ScrollRegion);
+	s_ScrollRegion.End();
 }
 
 bool CMenus::RenderServerControlServer(CUIRect MainView)

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -13,7 +13,11 @@
 
 CMenus::CListBox::CListBox(CMenus *pMenus) : m_ScrollRegion(pMenus)
 {
-	m_pMenus = pMenus;
+	m_pMenus = pMenus; // TODO: Refactor in order to remove this reference to menus
+	m_pRenderTools = pMenus->RenderTools();
+	m_pUI = pMenus->UI();
+	m_pInput = pMenus->Input();
+
 	m_ScrollOffset = vec2(0,0);
 	m_ListBoxUpdateScroll = false;
 	m_aFilterString[0] = '\0';
@@ -28,12 +32,12 @@ void CMenus::CListBox::DoHeader(const CUIRect *pRect, const char *pTitle,
 
 	// background
 	View.HSplitTop(HeaderHeight+Spacing, &Header, 0);
-	m_pMenus->RenderTools()->DrawUIRect(&Header, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_T, 5.0f);
+	m_pRenderTools->DrawUIRect(&Header, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_T, 5.0f);
 
 	// draw header
 	View.HSplitTop(HeaderHeight, &Header, &View);
 	Header.y += 2.0f;
-	m_pMenus->UI()->DoLabel(&Header, pTitle, Header.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
+	m_pUI->DoLabel(&Header, pTitle, Header.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 
 	View.HSplitTop(Spacing, &Header, &View);
 
@@ -48,7 +52,7 @@ bool CMenus::CListBox::DoFilter(float FilterHeight, float Spacing)
 
 	// background
 	View.HSplitTop(FilterHeight+Spacing, &Filter, 0);
-	m_pMenus->RenderTools()->DrawUIRect(&Filter, vec4(0.0f, 0.0f, 0.0f, 0.25f), 0, 5.0f);
+	m_pRenderTools->DrawUIRect(&Filter, vec4(0.0f, 0.0f, 0.0f, 0.25f), 0, 5.0f);
 
 	// draw filter
 	View.HSplitTop(FilterHeight, &Filter, &View);
@@ -59,7 +63,7 @@ bool CMenus::CListBox::DoFilter(float FilterHeight, float Spacing)
 	CUIRect Label, EditBox;
 	Filter.VSplitLeft(Filter.w/5.0f, &Label, &EditBox);
 	Label.y += Spacing;
-	m_pMenus->UI()->DoLabel(&Label, Localize("Search:"), FontSize, CUI::ALIGN_CENTER);
+	m_pUI->DoLabel(&Label, Localize("Search:"), FontSize, CUI::ALIGN_CENTER);
 	bool Changed = m_pMenus->DoEditBox(m_aFilterString, &EditBox, m_aFilterString, sizeof(m_aFilterString), FontSize, &m_OffsetFilter);
 
 	View.HSplitTop(Spacing, &Filter, &View);
@@ -86,7 +90,7 @@ void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, i
 
 	// background
 	if(Background)
-		m_pMenus->RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
+		m_pRenderTools->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
 
 	// draw footers
 	if(m_pBottomText)
@@ -95,7 +99,7 @@ void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, i
 		View.HSplitBottom(m_FooterHeight, &View, &Footer);
 		Footer.VSplitLeft(10.0f, 0, &Footer);
 		Footer.y += 2.0f;
-		m_pMenus->UI()->DoLabel(&Footer, m_pBottomText, Footer.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
+		m_pUI->DoLabel(&Footer, m_pBottomText, Footer.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 	}
 
 	// setup the variables
@@ -163,7 +167,7 @@ CMenus::CListboxItem CMenus::CListBox::DoNextItem(const void *pId, bool Selected
 	CListboxItem Item = DoNextRow();
 	static bool s_ItemClicked = false;
 
-	if(Item.m_Visible && m_pMenus->UI()->DoButtonLogic(pId, "", m_ListBoxSelectedIndex == m_ListBoxItemIndex, &Item.m_Rect))
+	if(Item.m_Visible && m_pUI->DoButtonLogic(pId, "", m_ListBoxSelectedIndex == m_ListBoxItemIndex, &Item.m_Rect))
 	{
 		s_ItemClicked = true;
 		m_ListBoxNewSelected = ThisItemIndex;
@@ -182,20 +186,20 @@ CMenus::CListboxItem CMenus::CListBox::DoNextItem(const void *pId, bool Selected
 		{
 			m_ListBoxDoneEvents = 1;
 
-			if(m_pMenus->m_EnterPressed || (s_ItemClicked && m_pMenus->Input()->MouseDoubleClick()))
+			if(m_pMenus->m_EnterPressed || (s_ItemClicked && m_pInput->MouseDoubleClick()))
 			{
 				m_ListBoxItemActivated = true;
-				m_pMenus->UI()->SetActiveItem(0);
+				m_pUI->SetActiveItem(0);
 			}
 		}
 
 		CUIRect r = Item.m_Rect;
-		m_pMenus->RenderTools()->DrawUIRect(&r, vec4(1, 1, 1, ProcessInput ? 0.5f : 0.33f), CUI::CORNER_ALL, 5.0f);
+		m_pRenderTools->DrawUIRect(&r, vec4(1, 1, 1, ProcessInput ? 0.5f : 0.33f), CUI::CORNER_ALL, 5.0f);
 	}
-	/*else*/ if(m_pMenus->UI()->HotItem() == pId)
+	/*else*/ if(m_pUI->HotItem() == pId)
 	{
 		CUIRect r = Item.m_Rect;
-		m_pMenus->RenderTools()->DrawUIRect(&r, vec4(1, 1, 1, 0.33f), CUI::CORNER_ALL, 5.0f);
+		m_pRenderTools->DrawUIRect(&r, vec4(1, 1, 1, 0.33f), CUI::CORNER_ALL, 5.0f);
 	}
 
 	return Item;

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -1,0 +1,217 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <math.h>
+
+#include <base/system.h>
+#include <base/math.h>
+#include <base/vmath.h>
+
+#include <engine/config.h>
+#include <engine/shared/config.h>
+
+#include "menus.h"
+
+CMenus::CListBox::CListBox(CMenus *pMenus) : m_ScrollRegion(pMenus)
+{
+	m_pMenus = pMenus;
+	m_ScrollOffset = vec2(0,0);
+	m_ListBoxUpdateScroll = false;
+	m_aFilterString[0] = '\0';
+	m_OffsetFilter = 0.0f;
+}
+
+void CMenus::CListBox::DoHeader(const CUIRect *pRect, const char *pTitle,
+							   float HeaderHeight, float Spacing)
+{
+	CUIRect Header;
+	CUIRect View = *pRect;
+
+	// background
+	const float Height = m_pMenus->GetListHeaderHeight();
+	View.HSplitTop(Height+Spacing, &Header, 0);
+	m_pMenus->RenderTools()->DrawUIRect(&Header, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_T, 5.0f);
+
+	// draw header
+	View.HSplitTop(Height, &Header, &View);
+	Header.y += 2.0f;
+	m_pMenus->UI()->DoLabel(&Header, pTitle, Header.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
+
+	View.HSplitTop(Spacing, &Header, &View);
+
+	// setup the variables
+	m_ListBoxView = View;
+}
+
+bool CMenus::CListBox::DoFilter(float FilterHeight, float Spacing)
+{
+	CUIRect Filter;
+	CUIRect View = m_ListBoxView;
+
+	// background
+	View.HSplitTop(FilterHeight+Spacing, &Filter, 0);
+	m_pMenus->RenderTools()->DrawUIRect(&Filter, vec4(0.0f, 0.0f, 0.0f, 0.25f), 0, 5.0f);
+
+	// draw filter
+	View.HSplitTop(FilterHeight, &Filter, &View);
+	Filter.Margin(Spacing, &Filter);
+
+	float FontSize = Filter.h*ms_FontmodHeight*0.8f;
+
+	CUIRect Label, EditBox;
+	Filter.VSplitLeft(Filter.w/5.0f, &Label, &EditBox);
+	Label.y += Spacing;
+	m_pMenus->UI()->DoLabel(&Label, Localize("Search:"), FontSize, CUI::ALIGN_CENTER);
+	bool Changed = m_pMenus->DoEditBox(m_aFilterString, &EditBox, m_aFilterString, sizeof(m_aFilterString), FontSize, &m_OffsetFilter);
+
+	View.HSplitTop(Spacing, &Filter, &View);
+
+	m_ListBoxView = View;
+
+	return Changed;
+}
+
+void CMenus::CListBox::DoStart(float RowHeight,
+							  const char *pBottomText, int NumItems, int ItemsPerRow, int SelectedIndex,
+							  const CUIRect *pRect, bool Background, bool *pActive)
+{
+	CUIRect View;
+	if(pRect)
+		View = *pRect;
+	else
+		View = m_ListBoxView;
+	CUIRect Footer;
+
+	// background
+	if(Background)
+		m_pMenus->RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
+
+	// draw footers
+	if(pBottomText)
+	{
+		const float Height = m_pMenus->GetListHeaderHeight();
+		View.HSplitBottom(Height, &View, &Footer);
+		Footer.VSplitLeft(10.0f, 0, &Footer);
+		Footer.y += 2.0f;
+		m_pMenus->UI()->DoLabel(&Footer, pBottomText, Footer.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
+	}
+
+	// setup the variables
+	m_ListBoxView = View;
+	m_ListBoxSelectedIndex = SelectedIndex;
+	m_ListBoxNewSelected = SelectedIndex;
+	m_ListBoxNewSelOffset = 0;
+	m_ListBoxItemIndex = 0;
+	m_ListBoxRowHeight = RowHeight;
+	m_ListBoxNumItems = NumItems;
+	m_ListBoxItemsPerRow = ItemsPerRow;
+	m_ListBoxDoneEvents = 0;
+	m_ListBoxItemActivated = false;
+
+	// handle input
+	if(!pActive || *pActive)
+	{
+		if(m_pMenus->m_DownArrowPressed)
+			m_ListBoxNewSelOffset += 1;
+		if(m_pMenus->m_UpArrowPressed)
+			m_ListBoxNewSelOffset -= 1;
+	}
+
+	// setup the scrollbar
+	m_ScrollOffset = vec2(0, 0);
+	m_ScrollRegion.Begin(&m_ListBoxView, &m_ScrollOffset);
+	m_ListBoxView.y += m_ScrollOffset.y;
+}
+
+CMenus::CListboxItem CMenus::CListBox::DoNextRow()
+{
+	static CUIRect s_RowView;
+	CListboxItem Item = {0};
+
+	if(m_ListBoxItemIndex%m_ListBoxItemsPerRow == 0)
+		m_ListBoxView.HSplitTop(m_ListBoxRowHeight /*-2.0f*/, &s_RowView, &m_ListBoxView);
+	m_ScrollRegion.AddRect(s_RowView);
+	if(m_ListBoxUpdateScroll && m_ListBoxSelectedIndex == m_ListBoxItemIndex)
+	{
+		m_ScrollRegion.ScrollHere(CScrollRegion::SCROLLHERE_KEEP_IN_VIEW);
+		m_ListBoxUpdateScroll = false;
+	}
+
+	s_RowView.VSplitLeft(s_RowView.w/(m_ListBoxItemsPerRow-m_ListBoxItemIndex%m_ListBoxItemsPerRow), &Item.m_Rect, &s_RowView);
+
+	if(m_ListBoxSelectedIndex == m_ListBoxItemIndex)
+		Item.m_Selected = 1;
+
+	Item.m_Visible = !m_ScrollRegion.IsRectClipped(Item.m_Rect);
+
+	m_ListBoxItemIndex++;
+	return Item;
+}
+
+CMenus::CListboxItem CMenus::CListBox::DoNextItem(const void *pId, bool Selected, bool *pActive)
+{
+	int ThisItemIndex = m_ListBoxItemIndex;
+	if(Selected)
+	{
+		if(m_ListBoxSelectedIndex == m_ListBoxNewSelected)
+			m_ListBoxNewSelected = ThisItemIndex;
+		m_ListBoxSelectedIndex = ThisItemIndex;
+	}
+
+	CListboxItem Item = DoNextRow();
+	static bool s_ItemClicked = false;
+
+	if(Item.m_Visible && m_pMenus->UI()->DoButtonLogic(pId, "", m_ListBoxSelectedIndex == m_ListBoxItemIndex, &Item.m_Rect))
+	{
+		s_ItemClicked = true;
+		m_ListBoxNewSelected = ThisItemIndex;
+		if(pActive)
+			*pActive = true;
+	}
+	else
+		s_ItemClicked = false;
+
+	const bool ProcessInput = !pActive || *pActive;
+
+	// process input, regard selected index
+	if(m_ListBoxSelectedIndex == ThisItemIndex)
+	{
+		if(ProcessInput && !m_ListBoxDoneEvents)
+		{
+			m_ListBoxDoneEvents = 1;
+
+			if(m_pMenus->m_EnterPressed || (s_ItemClicked && m_pMenus->Input()->MouseDoubleClick()))
+			{
+				m_ListBoxItemActivated = true;
+				m_pMenus->UI()->SetActiveItem(0);
+			}
+		}
+
+		CUIRect r = Item.m_Rect;
+		m_pMenus->RenderTools()->DrawUIRect(&r, vec4(1, 1, 1, ProcessInput ? 0.5f : 0.33f), CUI::CORNER_ALL, 5.0f);
+	}
+	/*else*/ if(m_pMenus->UI()->HotItem() == pId)
+	{
+		CUIRect r = Item.m_Rect;
+		m_pMenus->RenderTools()->DrawUIRect(&r, vec4(1, 1, 1, 0.33f), CUI::CORNER_ALL, 5.0f);
+	}
+
+	return Item;
+}
+
+int CMenus::CListBox::DoEnd(bool *pItemActivated)
+{
+	m_ScrollRegion.End();
+	if(m_ListBoxNewSelOffset != 0 && m_ListBoxSelectedIndex != -1 && m_ListBoxSelectedIndex == m_ListBoxNewSelected)
+	{
+		m_ListBoxNewSelected = clamp(m_ListBoxNewSelected + m_ListBoxNewSelOffset, 0, m_ListBoxNumItems - 1);
+		m_ListBoxUpdateScroll = true;
+	}
+	if(pItemActivated)
+		*pItemActivated = m_ListBoxItemActivated;
+	return m_ListBoxNewSelected;
+}
+
+bool CMenus::CListBox::FilterMatches(const char *pNeedle)
+{
+	return !m_aFilterString[0] || str_find_nocase(pNeedle, m_aFilterString);
+}

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -27,12 +27,11 @@ void CMenus::CListBox::DoHeader(const CUIRect *pRect, const char *pTitle,
 	CUIRect View = *pRect;
 
 	// background
-	const float Height = m_pMenus->GetListHeaderHeight();
-	View.HSplitTop(Height+Spacing, &Header, 0);
+	View.HSplitTop(HeaderHeight+Spacing, &Header, 0);
 	m_pMenus->RenderTools()->DrawUIRect(&Header, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_T, 5.0f);
 
 	// draw header
-	View.HSplitTop(Height, &Header, &View);
+	View.HSplitTop(HeaderHeight, &Header, &View);
 	Header.y += 2.0f;
 	m_pMenus->UI()->DoLabel(&Header, pTitle, Header.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 
@@ -70,8 +69,13 @@ bool CMenus::CListBox::DoFilter(float FilterHeight, float Spacing)
 	return Changed;
 }
 
-void CMenus::CListBox::DoStart(float RowHeight,
-							  const char *pBottomText, int NumItems, int ItemsPerRow, int SelectedIndex,
+void CMenus::CListBox::DoFooter(const char *pBottomText, float FooterHeight)
+{
+	m_pBottomText = pBottomText;
+	m_FooterHeight = FooterHeight;
+}
+
+void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int SelectedIndex,
 							  const CUIRect *pRect, bool Background, bool *pActive)
 {
 	CUIRect View;
@@ -79,20 +83,19 @@ void CMenus::CListBox::DoStart(float RowHeight,
 		View = *pRect;
 	else
 		View = m_ListBoxView;
-	CUIRect Footer;
 
 	// background
 	if(Background)
 		m_pMenus->RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
 
 	// draw footers
-	if(pBottomText)
+	if(m_pBottomText)
 	{
-		const float Height = m_pMenus->GetListHeaderHeight();
-		View.HSplitBottom(Height, &View, &Footer);
+		CUIRect Footer;
+		View.HSplitBottom(m_FooterHeight, &View, &Footer);
 		Footer.VSplitLeft(10.0f, 0, &Footer);
 		Footer.y += 2.0f;
-		m_pMenus->UI()->DoLabel(&Footer, pBottomText, Footer.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
+		m_pMenus->UI()->DoLabel(&Footer, m_pBottomText, Footer.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 	}
 
 	// setup the variables

--- a/src/game/client/components/menus_scrollregion.cpp
+++ b/src/game/client/components/menus_scrollregion.cpp
@@ -114,9 +114,10 @@ void CMenus::CScrollRegion::End()
 	bool Hovered = false;
 	bool Grabbed = false;
 	const void* pID = &m_ScrollY;
-	int Inside = m_pUI->MouseInside(&Slider);
+	const bool InsideSlider = m_pUI->MouseInside(&Slider);
+	const bool InsideRail = m_pUI->MouseInside(&m_RailRect);
 
-	if(Inside)
+	if(InsideSlider)
 	{
 		m_pUI->SetHotItem(pID);
 
@@ -126,6 +127,12 @@ void CMenus::CScrollRegion::End()
 			m_MouseGrabStart.y = m_pUI->MouseY();
 		}
 
+		Hovered = true;
+	}
+	else if(InsideRail && m_pUI->MouseButton(0))
+	{
+		const float SliderDistance = m_pUI->MouseY() - (Slider.y+Slider.h/2);
+		m_ScrollY += sign(SliderDistance) * log(abs(SliderDistance)); // slow down to reasonable scroll speed; keep sign with logarithm
 		Hovered = true;
 	}
 

--- a/src/game/client/components/menus_scrollregion.cpp
+++ b/src/game/client/components/menus_scrollregion.cpp
@@ -1,0 +1,201 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <math.h>
+
+#include <base/system.h>
+#include <base/math.h>
+#include <base/vmath.h>
+
+#include <engine/config.h>
+#include <engine/keys.h>
+#include <engine/shared/config.h>
+
+#include "menus.h"
+
+CMenus::CScrollRegion::CScrollRegion(CMenus *pMenus)
+{
+	m_pMenus = pMenus;
+	m_ScrollY = 0;
+	m_ContentH = 0;
+	m_RequestScrollY = -1;
+	m_ContentScrollOff = vec2(0,0);
+	m_WasClipped = false;
+	m_Params = CScrollRegionParams();
+}
+
+void CMenus::CScrollRegion::Begin(CUIRect* pClipRect, vec2* pOutOffset, const CScrollRegionParams* pParams)
+{
+	if(pParams)
+		m_Params = *pParams;
+
+	m_WasClipped = m_pMenus->UI()->IsClipped();
+	m_OldClipRect = *m_pMenus->UI()->ClipArea();
+
+	const bool ContentOverflows = m_ContentH > pClipRect->h;
+	const bool ForceShowScrollbar = m_Params.m_Flags&CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH;
+
+	CUIRect ScrollBarBg;
+	CUIRect* pModifyRect = (ContentOverflows || ForceShowScrollbar) ? pClipRect : 0;
+	pClipRect->VSplitRight(m_Params.m_ScrollbarWidth, pModifyRect, &ScrollBarBg);
+	ScrollBarBg.Margin(m_Params.m_ScrollbarMargin, &m_RailRect);
+
+	// only show scrollbar if required
+	if(ContentOverflows || ForceShowScrollbar)
+	{
+		if(m_Params.m_ScrollbarBgColor.a > 0)
+			m_pMenus->RenderTools()->DrawRoundRect(&ScrollBarBg, m_Params.m_ScrollbarBgColor, 4.0f);
+		if(m_Params.m_RailBgColor.a > 0)
+			m_pMenus->RenderTools()->DrawRoundRect(&m_RailRect, m_Params.m_RailBgColor, m_RailRect.w/2.0f);
+	}
+	if(!ContentOverflows)
+		m_ContentScrollOff.y = 0;
+
+	if(m_Params.m_ClipBgColor.a > 0)
+		m_pMenus->RenderTools()->DrawRoundRect(pClipRect, m_Params.m_ClipBgColor, 4.0f);
+
+	CUIRect ClipRect = *pClipRect;
+	if(m_WasClipped)
+	{
+		CUIRect Intersection;
+		Intersection.x = max(ClipRect.x, m_OldClipRect.x);
+		Intersection.y = max(ClipRect.y, m_OldClipRect.y);
+		Intersection.w = min(ClipRect.x+ClipRect.w, m_OldClipRect.x+m_OldClipRect.w) - ClipRect.x;
+		Intersection.h = min(ClipRect.y+ClipRect.h, m_OldClipRect.y+m_OldClipRect.h) - ClipRect.y;
+		ClipRect = Intersection;
+	}
+
+	m_pMenus->UI()->ClipEnable(&ClipRect);
+
+	m_ClipRect = *pClipRect;
+	m_ContentH = 0;
+	*pOutOffset = m_ContentScrollOff;
+}
+
+void CMenus::CScrollRegion::End()
+{
+	m_pMenus->UI()->ClipDisable();
+	if(m_WasClipped)
+		m_pMenus->UI()->ClipEnable(&m_OldClipRect);
+
+	// only show scrollbar if content overflows
+	if(m_ContentH <= m_ClipRect.h)
+		return;
+
+	// scroll wheel
+	CUIRect RegionRect = m_ClipRect;
+	RegionRect.w += m_Params.m_ScrollbarWidth;
+	if(m_pMenus->UI()->MouseInside(&RegionRect))
+	{
+		if(m_pMenus->Input()->KeyPress(KEY_MOUSE_WHEEL_UP))
+			m_ScrollY -= m_Params.m_ScrollSpeed;
+		else if(m_pMenus->Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
+			m_ScrollY += m_Params.m_ScrollSpeed;
+	}
+
+	const float SliderHeight = max(m_Params.m_SliderMinHeight,
+		m_ClipRect.h/m_ContentH * m_RailRect.h);
+
+	CUIRect Slider = m_RailRect;
+	Slider.h = SliderHeight;
+	const float MaxScroll = m_RailRect.h - SliderHeight;
+
+	if(m_RequestScrollY >= 0)
+	{
+		m_ScrollY = m_RequestScrollY/(m_ContentH - m_ClipRect.h) * MaxScroll;
+		m_RequestScrollY = -1;
+	}
+
+	m_ScrollY = clamp(m_ScrollY, 0.0f, MaxScroll);
+	Slider.y += m_ScrollY;
+
+	bool Hovered = false;
+	bool Grabbed = false;
+	const void* pID = &m_ScrollY;
+	int Inside = m_pMenus->UI()->MouseInside(&Slider);
+
+	if(Inside)
+	{
+		m_pMenus->UI()->SetHotItem(pID);
+
+		if(!m_pMenus->UI()->CheckActiveItem(pID) && m_pMenus->UI()->MouseButtonClicked(0))
+		{
+			m_pMenus->UI()->SetActiveItem(pID);
+			m_MouseGrabStart.y = m_pMenus->UI()->MouseY();
+		}
+
+		Hovered = true;
+	}
+
+	if(m_pMenus->UI()->CheckActiveItem(pID) && !m_pMenus->UI()->MouseButton(0))
+		m_pMenus->UI()->SetActiveItem(0);
+
+	// move slider
+	if(m_pMenus->UI()->CheckActiveItem(pID) && m_pMenus->UI()->MouseButton(0))
+	{
+		float my = m_pMenus->UI()->MouseY();
+		m_ScrollY += my - m_MouseGrabStart.y;
+		m_MouseGrabStart.y = my;
+
+		Grabbed = true;
+	}
+
+	m_ScrollY = clamp(m_ScrollY, 0.0f, MaxScroll);
+	m_ContentScrollOff.y = -m_ScrollY/MaxScroll * (m_ContentH - m_ClipRect.h);
+
+	vec4 SliderColor = m_Params.m_SliderColor;
+	if(Grabbed)
+		SliderColor = m_Params.m_SliderColorGrabbed;
+	else if(Hovered)
+		SliderColor = m_Params.m_SliderColorHover;
+
+	m_pMenus->RenderTools()->DrawRoundRect(&Slider, SliderColor, Slider.w/2.0f);
+}
+
+void CMenus::CScrollRegion::AddRect(CUIRect Rect)
+{
+	vec2 ContentPos = vec2(m_ClipRect.x, m_ClipRect.y);
+	ContentPos.x += m_ContentScrollOff.x;
+	ContentPos.y += m_ContentScrollOff.y;
+	m_LastAddedRect = Rect;
+	m_ContentH = max(Rect.y + Rect.h - ContentPos.y, m_ContentH);
+}
+
+void CMenus::CScrollRegion::ScrollHere(int Option)
+{
+	const float MinHeight = min(m_ClipRect.h, m_LastAddedRect.h);
+	const float TopScroll = m_LastAddedRect.y - (m_ClipRect.y + m_ContentScrollOff.y);
+
+	switch(Option)
+	{
+		case CScrollRegion::SCROLLHERE_TOP:
+			m_RequestScrollY = TopScroll;
+			break;
+
+		case CScrollRegion::SCROLLHERE_BOTTOM:
+			m_RequestScrollY = TopScroll - (m_ClipRect.h - MinHeight);
+			break;
+
+		case CScrollRegion::SCROLLHERE_KEEP_IN_VIEW:
+		default: {
+			const float dy = m_LastAddedRect.y - m_ClipRect.y;
+
+			if(dy < 0)
+				m_RequestScrollY = TopScroll;
+			else if(dy > (m_ClipRect.h-MinHeight))
+				m_RequestScrollY = TopScroll - (m_ClipRect.h - MinHeight);
+		} break;
+	}
+}
+
+bool CMenus::CScrollRegion::IsRectClipped(const CUIRect& Rect) const
+{
+	return (m_ClipRect.x > (Rect.x + Rect.w)
+		|| (m_ClipRect.x + m_ClipRect.w) < Rect.x
+		|| m_ClipRect.y > (Rect.y + Rect.h)
+		|| (m_ClipRect.y + m_ClipRect.h) < Rect.y);
+}
+
+bool CMenus::CScrollRegion::IsScrollbarShown() const
+{
+	return m_ContentH > m_ClipRect.h;
+}

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1539,11 +1539,11 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 
 	const float HeaderHeight = 20.0f;
 
-	static CScrollRegion s_ScrollRegion;
+	static CScrollRegion s_ScrollRegion(this);
 	vec2 ScrollOffset(0, 0);
 	CScrollRegionParams ScrollParams;
 	ScrollParams.m_ClipBgColor = vec4(0,0,0,0);
-	BeginScrollRegion(&s_ScrollRegion, &MainView, &ScrollOffset, &ScrollParams);
+	s_ScrollRegion.Begin(&MainView, &ScrollOffset, &ScrollParams);
 	MainView.y += ScrollOffset.y;
 
 	CUIRect LastExpandRect;
@@ -1552,51 +1552,51 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 	float Split = DoIndependentDropdownMenu(&s_MouseDropdown, &MainView, Localize("Mouse"), HeaderHeight, RenderSettingsControlsMouse, &s_MouseActive);
 
 	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
-	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
+	s_ScrollRegion.AddRect(LastExpandRect);
 	static int s_JoystickDropdown = 0;
 	static bool s_JoystickActive = m_pClient->Input()->NumJoysticks() > 0; // hide by default if no joystick found
 	Split = DoIndependentDropdownMenu(&s_JoystickDropdown, &MainView, Localize("Joystick"), HeaderHeight, RenderSettingsControlsJoystick, &s_JoystickActive);
 
 	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
-	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
+	s_ScrollRegion.AddRect(LastExpandRect);
 	static int s_MovementDropdown = 0;
 	static bool s_MovementActive = true;
 	Split = DoIndependentDropdownMenu(&s_MovementDropdown, &MainView, Localize("Movement"), HeaderHeight, RenderSettingsControlsMovement, &s_MovementActive);
 
 	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
-	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
+	s_ScrollRegion.AddRect(LastExpandRect);
 	static int s_WeaponDropdown = 0;
 	static bool s_WeaponActive = true;
 	Split = DoIndependentDropdownMenu(&s_WeaponDropdown, &MainView, Localize("Weapon"), HeaderHeight, RenderSettingsControlsWeapon, &s_WeaponActive);
 
 	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
-	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
+	s_ScrollRegion.AddRect(LastExpandRect);
 	static int s_VotingDropdown = 0;
 	static bool s_VotingActive = true;
 	Split = DoIndependentDropdownMenu(&s_VotingDropdown, &MainView, Localize("Voting"), HeaderHeight, RenderSettingsControlsVoting, &s_VotingActive);
 
 	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
-	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
+	s_ScrollRegion.AddRect(LastExpandRect);
 	static int s_ChatDropdown = 0;
 	static bool s_ChatActive = true;
 	Split = DoIndependentDropdownMenu(&s_ChatDropdown, &MainView, Localize("Chat"), HeaderHeight, RenderSettingsControlsChat, &s_ChatActive);
 
 	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
-	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
+	s_ScrollRegion.AddRect(LastExpandRect);
 	static int s_ScoreboardDropdown = 0;
 	static bool s_ScoreboardActive = true;
 	Split = DoIndependentDropdownMenu(&s_ScoreboardDropdown, &MainView, Localize("Scoreboard"), HeaderHeight, RenderSettingsControlsScoreboard, &s_ScoreboardActive);
 
 	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
-	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
+	s_ScrollRegion.AddRect(LastExpandRect);
 	static int s_MiscDropdown = 0;
 	static bool s_MiscActive = true;
 	Split = DoIndependentDropdownMenu(&s_MiscDropdown, &MainView, Localize("Misc"), HeaderHeight, RenderSettingsControlsMisc, &s_MiscActive);
 
 	MainView.HSplitTop(Split+10.0f, &LastExpandRect, &MainView);
-	ScrollRegionAddRect(&s_ScrollRegion, LastExpandRect);
+	s_ScrollRegion.AddRect(LastExpandRect);
 
-	EndScrollRegion(&s_ScrollRegion);
+	s_ScrollRegion.End();
 
 	// reset button
 	float Spacing = 3.0f;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -427,9 +427,9 @@ void CMenus::RenderSkinSelection(CUIRect MainView)
 
 	m_pSelectedSkin = 0;
 	int OldSelected = -1;
-	s_ListBox.DoHeader(&MainView, Localize("Skins"));
+	s_ListBox.DoHeader(&MainView, Localize("Skins"), GetListHeaderHeight());
 	m_RefreshSkinSelector = s_ListBox.DoFilter();
-	s_ListBox.DoStart(50.0f, 0, s_paSkinList.size(), 10, OldSelected);
+	s_ListBox.DoStart(50.0f, s_paSkinList.size(), 10, OldSelected);
 
 	for(int i = 0; i < s_paSkinList.size(); ++i)
 	{
@@ -506,9 +506,9 @@ void CMenus::RenderSkinPartSelection(CUIRect MainView)
 	}
 
 	static int OldSelected = -1;
-	s_ListBox.DoHeader(&MainView, Localize(CSkins::ms_apSkinPartNames[m_TeePartSelected]));
+	s_ListBox.DoHeader(&MainView, Localize(CSkins::ms_apSkinPartNames[m_TeePartSelected]), GetListHeaderHeight());
 	s_InitSkinPartList = s_ListBox.DoFilter();
-	s_ListBox.DoStart(50.0f, 0, s_paList[m_TeePartSelected].size(), 5, OldSelected);
+	s_ListBox.DoStart(50.0f, s_paList[m_TeePartSelected].size(), 5, OldSelected);
 
 	for(int i = 0; i < s_paList[m_TeePartSelected].size(); ++i)
 	{
@@ -784,9 +784,9 @@ void CMenus::RenderLanguageSelection(CUIRect MainView, bool Header)
 	int OldSelected = s_SelectedLanguage;
 
 	if(Header)
-		s_ListBox.DoHeader(&MainView, Localize("Language"));
+		s_ListBox.DoHeader(&MainView, Localize("Language"), GetListHeaderHeight());
 	bool IsActive = m_ActiveListBox == ACTLB_LANG;
-	s_ListBox.DoStart(20.0f, 0, s_Languages.size(), 1, s_SelectedLanguage, Header?0:&MainView, Header, &IsActive);
+	s_ListBox.DoStart(20.0f, s_Languages.size(), 1, s_SelectedLanguage, Header?0:&MainView, Header, &IsActive);
 
 	for(sorted_array<CLanguage>::range r = s_Languages.all(); !r.empty(); r.pop_front())
 	{
@@ -849,9 +849,9 @@ void CMenus::RenderThemeSelection(CUIRect MainView, bool Header)
 	int OldSelected = s_SelectedTheme;
 
 	if(Header)
-		s_ListBox.DoHeader(&MainView, Localize("Theme"));
+		s_ListBox.DoHeader(&MainView, Localize("Theme"), GetListHeaderHeight());
 	bool IsActive = m_ActiveListBox == ACTLB_THEME;
-	s_ListBox.DoStart(20.0f, 0, m_lThemes.size(), 1, s_SelectedTheme, Header?0:&MainView, Header, &IsActive);
+	s_ListBox.DoStart(20.0f, m_lThemes.size(), 1, s_SelectedTheme, Header?0:&MainView, Header, &IsActive);
 
 	for(sorted_array<CTheme>::range r = m_lThemes.all(); !r.empty(); r.pop_front())
 	{
@@ -1212,8 +1212,8 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	MainView.HSplitTop(10.0f, 0, &MainView);
 	static CListBox s_ListBox(this);
 	int OldSelected = -1;
-	s_ListBox.DoHeader(&MainView, Localize("Country"));
-	s_ListBox.DoStart(40.0f, 0, m_pClient->m_pCountryFlags->Num(), 18, OldSelected);
+	s_ListBox.DoHeader(&MainView, Localize("Country"), GetListHeaderHeight());
+	s_ListBox.DoStart(40.0f, m_pClient->m_pCountryFlags->Num(), 18, OldSelected);
 
 	for(int i = 0; i < m_pClient->m_pCountryFlags->Num(); ++i)
 	{
@@ -1671,7 +1671,7 @@ bool CMenus::DoResolutionList(CUIRect* pRect, CListBox* pListBox,
 	int OldSelected = -1;
 	char aBuf[32];
 
-	pListBox->DoStart(20.0f, 0, lModes.size(), 1, OldSelected, pRect);
+	pListBox->DoStart(20.0f, lModes.size(), 1, OldSelected, pRect);
 
 	for(int i = 0; i < lModes.size(); ++i)
 	{

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -79,8 +79,8 @@ MACRO_CONFIG_STR(PlayerSkinEyes, player_skin_eyes, 24, "standard", CFGFLAG_CLIEN
 
 MACRO_CONFIG_INT(UiBrowserPage, ui_browser_page, 5, 5, 8, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface serverbrowser page")
 MACRO_CONFIG_INT(UiSettingsPage, ui_settings_page, 0, 0, 5, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface settings page")
-MACRO_CONFIG_STR(UiInternetServerAddress, ui_internet_server_address, 64, "localhost:8303", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface server address (Internet page)")
-MACRO_CONFIG_STR(UiLanServerAddress, ui_lan_server_address, 64, "localhost:8303", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface server address (LAN page)")
+MACRO_CONFIG_STR(UiServerAddress, ui_server_address, 64, "localhost:8303", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface server address (Internet page)")
+MACRO_CONFIG_STR(UiServerAddressLan, ui_server_address_lan, 64, "localhost:8303", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface server address (LAN page)")
 MACRO_CONFIG_INT(UiMousesens, ui_mousesens, 100, 1, 100000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Mouse sensitivity for menus/editor")
 MACRO_CONFIG_INT(UiAutoswitchInfotab, ui_autoswitch_infotab, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Switch to the info tab when clicking on a server")
 MACRO_CONFIG_INT(UiWideview, ui_wideview, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Extended menus GUI")

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -79,7 +79,8 @@ MACRO_CONFIG_STR(PlayerSkinEyes, player_skin_eyes, 24, "standard", CFGFLAG_CLIEN
 
 MACRO_CONFIG_INT(UiBrowserPage, ui_browser_page, 5, 5, 8, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface serverbrowser page")
 MACRO_CONFIG_INT(UiSettingsPage, ui_settings_page, 0, 0, 5, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface settings page")
-MACRO_CONFIG_STR(UiServerAddress, ui_server_address, 64, "localhost:8303", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface server address")
+MACRO_CONFIG_STR(UiInternetServerAddress, ui_internet_server_address, 64, "localhost:8303", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface server address (Internet page)")
+MACRO_CONFIG_STR(UiLanServerAddress, ui_lan_server_address, 64, "localhost:8303", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface server address (LAN page)")
 MACRO_CONFIG_INT(UiMousesens, ui_mousesens, 100, 1, 100000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Mouse sensitivity for menus/editor")
 MACRO_CONFIG_INT(UiAutoswitchInfotab, ui_autoswitch_infotab, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Switch to the info tab when clicking on a server")
 MACRO_CONFIG_INT(UiWideview, ui_wideview, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Extended menus GUI")


### PR DESCRIPTION
- Make sure that the selected server is always in sync with the server address (handle Page change, Filter selection, Server selection, Filter change). Changing the address changes the selection, will now also deselect if no address matches. Closes #2003.
- Store selected filter for each browser page (internet, LAN) separately.
- Store selected server for each filter and browser page separately.
- Reenables the important message "No servers match your filter criteria" in case the filter excludes everything
- Adds additional important message "No filter category is selected" if no filter category is expanded, because this was really confusing the first time it happended.
- Adds additional important message "Fetching server info" when no servers are available because they are refreshing.
- Move CListBox class to menus_listbox.cpp
- Refactor CScrollRegion by moving the associated methods inside the class, move the class to menus_scrollregion.cpp
- Remove obsolete comments and some unused constants.
- Fixes browser headers selection not working because of clipped server entry behind (closes #2422). Also adds a background to the header to indicate hot state.
- Implement clicking on scrollbar of CScrollRegion to scroll there (closes #2429).