### PR TITLE
Add say_self command, reorder parameters and add default values

### DIFF
--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -16,6 +16,7 @@ class CChat : public CComponent
 	{
 		MAX_LINES = 250,
 		MAX_CHAT_PAGES = 10,
+		MAX_LINE_LENGTH = 512,
 	};
 
 	struct CLine
@@ -27,15 +28,8 @@ class CChat : public CComponent
 		int m_Mode;
 		int m_NameColor;
 		char m_aName[MAX_NAME_LENGTH];
-		char m_aText[512];
+		char m_aText[MAX_LINE_LENGTH];
 		bool m_Highlighted;
-	};
-
-	// client IDs for special messages
-	enum
-	{
-		CLIENT_MSG = -2,
-		SERVER_MSG = -1,
 	};
 
 	CLine m_aLines[MAX_LINES];
@@ -68,7 +62,7 @@ class CChat : public CComponent
 	float m_CurrentLineWidth;
 
 	int m_ChatBufferMode;
-	char m_ChatBuffer[512];
+	char m_ChatBuffer[MAX_LINE_LENGTH];
 	char m_ChatCmdBuffer[1024];
 
 	struct CHistoryEntry
@@ -143,22 +137,26 @@ class CChat : public CComponent
 
 	static void ConSay(IConsole::IResult *pResult, void *pUserData);
 	static void ConSayTeam(IConsole::IResult *pResult, void *pUserData);
+	static void ConSaySelf(IConsole::IResult *pResult, void *pUserData);
 	static void ConWhisper(IConsole::IResult *pResult, void *pUserData);
 	static void ConChat(IConsole::IResult *pResult, void *pUserData);
 	static void ConShowChat(IConsole::IResult *pResult, void *pUserData);
 
 public:
+	// client IDs for special messages
+	enum
+	{
+		CLIENT_MSG = -2,
+		SERVER_MSG = -1,
+	};
+	// Mode defined by the CHAT_* constants in protocol.h
+
 	bool IsActive() const { return m_Mode != CHAT_NONE; }
-
-	void AddLine(int ClientID, int Team, const char *pLine, int TargetID = -1);
-
-	void EnableMode(int Team, const char* pText = NULL);
-
-	void Say(int Team, const char *pLine);
-
+	void AddLine(const char *pLine, int ClientID = SERVER_MSG, int Mode = CHAT_NONE, int TargetID = -1);
+	void EnableMode(int Mode, const char* pText = NULL);
+	void Say(int Mode, const char *pLine);
 	void ClearChatBuffer();
-
-	const char* GetCommandName(int Mode);
+	const char* GetCommandName(int Mode) const;
 
 	virtual void OnInit();
 	virtual void OnReset();

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -108,7 +108,7 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 				str_append(aBuf, aImprovement, sizeof(aBuf));
 			}
 
-			m_pClient->m_pChat->AddLine(-1, 0, aBuf);
+			m_pClient->m_pChat->AddLine(aBuf);
 		}
 
 		if(m_pClient->m_Snap.m_pGameDataRace && m_pClient->m_Snap.m_pGameDataRace->m_RaceFlags&RACEFLAG_FINISHMSG_AS_CHAT)
@@ -116,7 +116,7 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 			if(!pMsg->m_NewRecord) // don't print the time twice
 			{
 				str_format(aBuf, sizeof(aBuf), Localize("'%s' finished in: %s"), aLabel, aTime);
-				m_pClient->m_pChat->AddLine(-1, 0, aBuf);
+				m_pClient->m_pChat->AddLine(aBuf);
 			}
 		}
 		else

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -186,7 +186,7 @@ void CVoting::OnMessage(int MsgType, void *pRawMsg)
 				case VOTE_START_OP:
 					str_format(aBuf, sizeof(aBuf), Localize("'%s' called vote to change server option '%s' (%s)"), aLabel, pMsg->m_pDescription, pMsg->m_pReason);
 					str_copy(m_aDescription, pMsg->m_pDescription, sizeof(m_aDescription));
-					m_pClient->m_pChat->AddLine(-1, 0, aBuf);
+					m_pClient->m_pChat->AddLine(aBuf);
 					break;
 				case VOTE_START_KICK:
 					{
@@ -195,7 +195,7 @@ void CVoting::OnMessage(int MsgType, void *pRawMsg)
 							str_copy(aName, pMsg->m_pDescription, sizeof(aName));
 						str_format(aBuf, sizeof(aBuf), Localize("'%s' called for vote to kick '%s' (%s)"), aLabel, g_Config.m_ClShowsocial ? pMsg->m_pDescription : aName, pMsg->m_pReason);
 						str_format(m_aDescription, sizeof(m_aDescription), "Kick '%s'", g_Config.m_ClShowsocial ? pMsg->m_pDescription : aName);
-						m_pClient->m_pChat->AddLine(-1, 0, aBuf);
+						m_pClient->m_pChat->AddLine(aBuf);
 						break;
 					}
 				case VOTE_START_SPEC:
@@ -205,7 +205,7 @@ void CVoting::OnMessage(int MsgType, void *pRawMsg)
 							str_copy(aName, pMsg->m_pDescription, sizeof(aName));
 						str_format(aBuf, sizeof(aBuf), Localize("'%s' called for vote to move '%s' to spectators (%s)"), aLabel, g_Config.m_ClShowsocial ? pMsg->m_pDescription : aName, pMsg->m_pReason);
 						str_format(m_aDescription, sizeof(m_aDescription), "Move '%s' to spectators", g_Config.m_ClShowsocial ? pMsg->m_pDescription : aName);
-						m_pClient->m_pChat->AddLine(-1, 0, aBuf);
+						m_pClient->m_pChat->AddLine(aBuf);
 					}
 				}
 				if(pMsg->m_ClientID == m_pClient->m_LocalClientID)
@@ -218,29 +218,23 @@ void CVoting::OnMessage(int MsgType, void *pRawMsg)
 			{
 			case VOTE_START_OP:
 				str_format(aBuf, sizeof(aBuf), Localize("Admin forced server option '%s' (%s)"), pMsg->m_pDescription, pMsg->m_pReason);
-				m_pClient->m_pChat->AddLine(-1, 0, aBuf);
+				m_pClient->m_pChat->AddLine(aBuf);
 				break;
 			case VOTE_START_SPEC:
 				str_format(aBuf, sizeof(aBuf), Localize("Admin moved '%s' to spectator (%s)"), pMsg->m_pDescription, pMsg->m_pReason);
-				m_pClient->m_pChat->AddLine(-1, 0, aBuf);
+				m_pClient->m_pChat->AddLine(aBuf);
 				break;
 			case VOTE_END_ABORT:
 				OnReset();
-				m_pClient->m_pChat->AddLine(-1, 0, Localize("Vote aborted"));
+				m_pClient->m_pChat->AddLine(Localize("Vote aborted"));
 				break;
 			case VOTE_END_PASS:
 				OnReset();
-				if(pMsg->m_ClientID == -1)
-					m_pClient->m_pChat->AddLine(-1, 0, Localize("Admin forced vote yes"));
-				else
-					m_pClient->m_pChat->AddLine(-1, 0, Localize("Vote passed"));
+				m_pClient->m_pChat->AddLine(pMsg->m_ClientID == -1 ? Localize("Admin forced vote yes") : Localize("Vote passed"));
 				break;
 			case  VOTE_END_FAIL:
 				OnReset();
-				if(pMsg->m_ClientID == -1)
-					m_pClient->m_pChat->AddLine(-1, 0, Localize("Admin forced vote no"));
-				else
-					m_pClient->m_pChat->AddLine(-1, 0, Localize("Vote failed"));
+				m_pClient->m_pChat->AddLine(pMsg->m_ClientID == -1 ? Localize("Admin forced vote no") : Localize("Vote failed"));
 				m_CallvoteBlockTick = BlockTick;
 			}
 		}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -681,7 +681,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 					char aLabel[64];
 					GetPlayerLabel(aLabel, sizeof(aLabel), ClientID, m_aClients[ClientID].m_aName);
 					str_format(aBuf, sizeof(aBuf), Localize("'%s' initiated a pause"), aLabel);
-					m_pChat->AddLine(-1, 0, aBuf);
+					m_pChat->AddLine(aBuf);
 				}
 				break;
 			case GAMEMSG_CTF_CAPTURE:
@@ -714,7 +714,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 						str_format(aBuf, sizeof(aBuf), Localize("The red flag was captured by '%s'"), aLabel);
 					}
 				}
-				m_pChat->AddLine(-1, 0, aBuf);
+				m_pChat->AddLine(aBuf);
 			}
 			return;
 		}
@@ -730,7 +730,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 		switch(gs_GameMsgList[GameMsgID].m_Action)
 		{
 		case DO_CHAT:
-			m_pChat->AddLine(-1, 0, pText);
+			m_pChat->AddLine(pText);
 			break;
 		case DO_BROADCAST:
 			m_pBroadcast->DoBroadcast(pText);
@@ -813,7 +813,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 			char aLabel[64];
 			GetPlayerLabel(aLabel, sizeof(aLabel), pMsg->m_ClientID, m_aClients[pMsg->m_ClientID].m_aName);
 			str_format(aBuf, sizeof(aBuf), Localize("%s is muted by you"), aLabel);
-			m_pChat->AddLine(-2, 0, aBuf);
+			m_pChat->AddLine(aBuf, CChat::CLIENT_MSG);
 		}
 
 		m_aClients[pMsg->m_ClientID].UpdateRenderInfo(this, pMsg->m_ClientID, true);
@@ -893,9 +893,10 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 		CNetMsg_Sv_ServerSettings *pMsg = (CNetMsg_Sv_ServerSettings *)pRawMsg;
 
 		if(!m_ServerSettings.m_TeamLock && pMsg->m_TeamLock)
-			m_pChat->AddLine(-1, 0, Localize("Teams were locked"));
+			m_pChat->AddLine(Localize("Teams were locked"));
 		else if(m_ServerSettings.m_TeamLock && !pMsg->m_TeamLock)
-			m_pChat->AddLine(-1, 0, Localize("Teams were unlocked"));
+			m_pChat->AddLine(Localize("Teams were unlocked"));
+
 		m_ServerSettings.m_KickVote = pMsg->m_KickVote;
 		m_ServerSettings.m_KickMin = pMsg->m_KickMin;
 		m_ServerSettings.m_SpecVote = pMsg->m_SpecVote;
@@ -1701,7 +1702,7 @@ void CGameClient::DoEnterMessage(const char *pName, int ClientID, int Team)
 	case STR_TEAM_BLUE: str_format(aBuf, sizeof(aBuf), Localize("'%s' entered and joined the blue team"), aLabel); break;
 	case STR_TEAM_SPECTATORS: str_format(aBuf, sizeof(aBuf), Localize("'%s' entered and joined the spectators"), aLabel); break;
 	}
-	m_pChat->AddLine(-1, 0, aBuf);
+	m_pChat->AddLine(aBuf);
 }
 
 void CGameClient::DoLeaveMessage(const char *pName, int ClientID, const char *pReason)
@@ -1712,7 +1713,7 @@ void CGameClient::DoLeaveMessage(const char *pName, int ClientID, const char *pR
 		str_format(aBuf, sizeof(aBuf), Localize("'%s' has left the game (%s)"), aLabel, pReason);
 	else
 		str_format(aBuf, sizeof(aBuf), Localize("'%s' has left the game"), aLabel);
-	m_pChat->AddLine(-1, 0, aBuf);
+	m_pChat->AddLine(aBuf);
 }
 
 void CGameClient::DoTeamChangeMessage(const char *pName, int ClientID, int Team)
@@ -1727,7 +1728,7 @@ void CGameClient::DoTeamChangeMessage(const char *pName, int ClientID, int Team)
 	case STR_TEAM_BLUE: str_format(aBuf, sizeof(aBuf), Localize("'%s' joined the blue team"), aLabel); break;
 	case STR_TEAM_SPECTATORS: str_format(aBuf, sizeof(aBuf), Localize("'%s' joined the spectators"), aLabel); break;
 	}
-	m_pChat->AddLine(-1, 0, aBuf);
+	m_pChat->AddLine(aBuf);
 }
 
 void CGameClient::SendSwitchTeam(int Team)


### PR DESCRIPTION
- Add `say_self s` command (closes #2142).
- Change order of `CChat::AddLine` parameters to allow using defaults for most calls.
- Use appropriate constants instead of magic numbers.