### PR TITLE
Add CHud::FormatTimer for all timers, add cl_timerprecision (closes #2398), minor refactoring

### DIFF
--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -33,6 +33,10 @@ class CHud : public CComponent
 	void RenderWarmupTimer();
 	void RenderRaceTime(const CNetObj_PlayerInfoRace *pRaceInfo);
 	void RenderCheckpoint();
+
+	// Time is in seconds, can include minutes and ms.
+	// FullFormat always shows all the timer components. Otherwise just shows what's relevant.
+	void FormatTimer(char *pStr, unsigned StrSize, float Time, bool FullFormat = false);
 public:
 	CHud();
 

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -17,6 +17,7 @@ MACRO_CONFIG_INT(ClShowhud, cl_showhud, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "S
 MACRO_CONFIG_INT(ClFilterchat, cl_filterchat, 0, 0, 2, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show chat messages from: 0=all, 1=friends only, 2=no one")
 MACRO_CONFIG_INT(ClShowsocial, cl_showsocial, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show social data like names, clans, chat etc.")
 MACRO_CONFIG_INT(ClShowfps, cl_showfps, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show ingame FPS counter")
+MACRO_CONFIG_INT(ClTimerPrecision, cl_timerprecision, 1, 0, 3, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Precision of ingame timer HUD (number of decimal places)")
 
 MACRO_CONFIG_INT(ClAirjumpindicator, cl_airjumpindicator, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show double jump indicator")
 


### PR DESCRIPTION
- Add CHud::FormatTimer which is used for all HUD timers.
- Add cl_timerprecision 0-3 config variable (default 1), which is used by CHud::FormatTimer (closes #2398).
- Short timers (warmup, countdown etc.) only show precision in last 5 seconds.
- Extract some FontSizes as constants. Extract offset constant in score HUD.
- Fix some naming and FPS string buffer size.