### PR TITLE
Bam: fix cl detection

### DIFF
--- a/configure.lua
+++ b/configure.lua
@@ -359,7 +359,7 @@ function OptCCompiler(name, default_driver, default_c, default_cxx, desc)
 			-- no need todo anything if we have a driver
 			-- TODO: test if we can find the compiler
 		else
-			if (ExecuteSilent("g++ -v") and ((arch ~= "amd64" and arch ~= "ia64") or CTestCompile(settings, "int main(){return 0;}", "-m64"))) then
+			if ExecuteSilent("g++ -v") == 0 and ((arch ~= "amd64" and arch ~= "ia64") or CTestCompile(settings, "int main(){return 0;}", "-m64")) then
 				option.driver = "gcc"
 			elseif ExecuteSilent("cl") == 0 then
 				option.driver = "cl"


### PR DESCRIPTION
With d70ac6ceff7a0eac12f7efe7ab79f8f60a6f2dbf, cl detection is broken when mingw is not installed as well. This should fix it.