### PR TITLE
Store server password for favorites (closes #1196), replace IsFavorite

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -115,7 +115,7 @@ public:
 	virtual void Rcon(const char *pLine) = 0;
 
 	// server info
-	virtual void GetServerInfo(class CServerInfo *pServerInfo) const = 0;
+	virtual void GetServerInfo(class CServerInfo *pServerInfo) = 0;
 
 	// snapshot interface
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -571,9 +571,10 @@ void CClient::Disconnect()
 }
 
 
-void CClient::GetServerInfo(CServerInfo *pServerInfo) const
+void CClient::GetServerInfo(CServerInfo *pServerInfo)
 {
 	mem_copy(pServerInfo, &m_CurrentServerInfo, sizeof(m_CurrentServerInfo));
+	m_ServerBrowser.UpdateFavoriteState(pServerInfo);
 }
 
 int CClient::LoadData()

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -240,7 +240,7 @@ public:
 	virtual void Disconnect();
 
 
-	virtual void GetServerInfo(CServerInfo *pServerInfo) const;
+	virtual void GetServerInfo(CServerInfo *pServerInfo);
 
 	int LoadData();
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -82,6 +82,7 @@ class CClient : public IClient, public CDemoPlayer::IListner
 	class CMapChecker m_MapChecker;
 
 	char m_aServerAddressStr[256];
+	char m_aServerPassword[128];
 
 	unsigned m_SnapshotParts;
 	int64 m_LocalStartTime;
@@ -234,6 +235,7 @@ public:
 	// called when the map is loaded and we should init for a new round
 	void OnEnterGame();
 	virtual void EnterGame();
+	void OnClientOnline();
 
 	virtual void Connect(const char *pAddress);
 	void DisconnectWithReason(const char *pReason);

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -375,7 +375,8 @@ void CServerBrowser::RemoveFavorite(const CServerInfo *pInfo)
 
 void CServerBrowser::UpdateFavoriteState(CServerInfo *pInfo)
 {
-	pInfo->m_Favorite = m_ServerBrowserFavorites.FindFavoriteByAddr(pInfo->m_NetAddr, 0) != 0;
+	pInfo->m_Favorite = m_ServerBrowserFavorites.FindFavoriteByAddr(pInfo->m_NetAddr, 0) != 0
+		|| m_ServerBrowserFavorites.FindFavoriteByHostname(pInfo->m_aHostname, 0) != 0;
 }
 
 void CServerBrowser::SetFavoritePassword(const char *pAddress, const char *pPassword)

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -41,9 +41,11 @@ public:
 	const CServerInfo *SortedGet(int FilterIndex, int Index) const { return &m_aServerlist[m_ActServerlistType].m_ppServerlist[m_ServerBrowserFilter.GetIndex(FilterIndex, Index)]->m_Info; };
 	const void *GetID(int FilterIndex, int Index) const { return m_ServerBrowserFilter.GetID(FilterIndex, Index); };
 
-	bool IsFavorite(const NETADDR &Addr) { return m_ServerBrowserFavorites.FindFavoriteByAddr(Addr, 0) != 0; }
-	void AddFavorite(const CServerInfo *pEntry);
-	void RemoveFavorite(const CServerInfo *pEntry);
+	void AddFavorite(const CServerInfo *pInfo);
+	void RemoveFavorite(const CServerInfo *pInfo);
+	void UpdateFavoriteState(CServerInfo *pInfo);
+	void SetFavoritePassword(const char *pAddress, const char *pPassword);
+	const char *GetFavoritePassword(const char *pAddress);
 
 	int AddFilter(const CServerFilterInfo *pFilterInfo) { return m_ServerBrowserFilter.AddFilter(pFilterInfo); };
 	void SetFilter(int Index, const CServerFilterInfo *pFilterInfo) { m_ServerBrowserFilter.SetFilter(Index, pFilterInfo); };

--- a/src/engine/client/serverbrowser_fav.cpp
+++ b/src/engine/client/serverbrowser_fav.cpp
@@ -34,14 +34,24 @@ void CServerBrowserFavorites::Init(CNetClient *pNetClient, IConsole *pConsole, I
 	if(pConfig)
 		pConfig->RegisterCallback(ConfigSaveCallback, this);
 
-	m_pConsole->Register("add_favorite", "s", CFGFLAG_CLIENT, ConAddFavorite, this, "Add a server as a favorite");
+	m_pConsole->Register("add_favorite", "s?s", CFGFLAG_CLIENT, ConAddFavorite, this, "Add a server (optionally with password) as a favorite. Also updates password of existing favorite.");
 	m_pConsole->Register("remove_favorite", "s", CFGFLAG_CLIENT, ConRemoveFavorite, this, "Remove a server from favorites");
 }
 
-bool CServerBrowserFavorites::AddFavoriteEx(const char *pHostname, const NETADDR *pAddr, bool DoCheck)
+bool CServerBrowserFavorites::AddFavoriteEx(const char *pHostname, const NETADDR *pAddr, bool DoCheck, const char *pPassword)
 {
-	if(m_NumFavoriteServers == MAX_FAVORITES || FindFavoriteByHostname(pHostname, 0))
+	if(m_NumFavoriteServers == MAX_FAVORITES)
 		return false;
+
+	CFavoriteServer *pExistingFavorite = FindFavoriteByHostname(pHostname, 0);
+	if(pExistingFavorite)
+	{
+		if(pPassword)
+			str_copy(pExistingFavorite->m_aPassword, pPassword, sizeof(pExistingFavorite->m_aPassword));
+		else
+			pExistingFavorite->m_aPassword[0] = '\0';
+		return false;
+	}
 
 	bool Result = false;
 	// check if hostname is a net address string
@@ -73,6 +83,12 @@ bool CServerBrowserFavorites::AddFavoriteEx(const char *pHostname, const NETADDR
 	}
 
 	str_copy(m_aFavoriteServers[m_NumFavoriteServers].m_aHostname, pHostname, sizeof(m_aFavoriteServers[m_NumFavoriteServers].m_aHostname));
+
+	if(pPassword)
+		str_copy(m_aFavoriteServers[m_NumFavoriteServers].m_aPassword, pPassword, sizeof(m_aFavoriteServers[m_NumFavoriteServers].m_aPassword));
+	else
+		m_aFavoriteServers[m_NumFavoriteServers].m_aPassword[0] = '\0';
+
 	++m_NumFavoriteServers;
 
 	if(g_Config.m_Debug)
@@ -229,7 +245,7 @@ const NETADDR *CServerBrowserFavorites::UpdateFavorites()
 void CServerBrowserFavorites::ConAddFavorite(IConsole::IResult *pResult, void *pUserData)
 {
 	CServerBrowserFavorites *pSelf = static_cast<CServerBrowserFavorites *>(pUserData);
-	pSelf->AddFavoriteEx(pResult->GetString(0), 0, false);
+	pSelf->AddFavoriteEx(pResult->GetString(0), 0, false, pResult->NumArguments() > 1 ? pResult->GetString(1) : 0);
 }
 
 void CServerBrowserFavorites::ConRemoveFavorite(IConsole::IResult *pResult, void *pUserData)
@@ -242,10 +258,13 @@ void CServerBrowserFavorites::ConfigSaveCallback(IConfig *pConfig, void *pUserDa
 {
 	CServerBrowserFavorites *pSelf = (CServerBrowserFavorites *)pUserData;
 
-	char aBuffer[256];
+	char aBuffer[320];
 	for(int i = 0; i < pSelf->m_NumFavoriteServers; i++)
 	{
-		str_format(aBuffer, sizeof(aBuffer), "add_favorite %s", pSelf->m_aFavoriteServers[i].m_aHostname);
+		if(pSelf->m_aFavoriteServers[i].m_aPassword[0])
+			str_format(aBuffer, sizeof(aBuffer), "add_favorite \"%s\" \"%s\"", pSelf->m_aFavoriteServers[i].m_aHostname, pSelf->m_aFavoriteServers[i].m_aPassword);
+		else
+			str_format(aBuffer, sizeof(aBuffer), "add_favorite \"%s\"", pSelf->m_aFavoriteServers[i].m_aHostname);
 		pConfig->WriteLine(aBuffer);
 	}
 }

--- a/src/engine/client/serverbrowser_fav.h
+++ b/src/engine/client/serverbrowser_fav.h
@@ -24,6 +24,7 @@ public:
 	struct CFavoriteServer
 	{
 		char m_aHostname[128];
+		char m_aPassword[sizeof(g_Config.m_Password)];
 		NETADDR m_Addr;
 		int m_State;
 	} m_aFavoriteServers[MAX_FAVORITES];
@@ -45,7 +46,7 @@ public:
 	CServerBrowserFavorites();
 	void Init(class CNetClient *pNetClient, class IConsole *pConsole, class IEngine *pEngine, class IConfig *pConfig);
 	
-	bool AddFavoriteEx(const char *pHostname, const NETADDR *pAddr, bool DoCheck);
+	bool AddFavoriteEx(const char *pHostname, const NETADDR *pAddr, bool DoCheck, const char *pPassword = 0);
 	CFavoriteServer *FindFavoriteByAddr(const NETADDR &Addr, int *Index);
 	CFavoriteServer *FindFavoriteByHostname(const char *pHostname, int *Index);
 	void RemoveFavoriteEntry(int Index);

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -59,7 +59,7 @@ public:
 	int m_NumBotSpectators;
 	int m_Flags;
 	int m_ServerLevel;
-	int m_Favorite;
+	bool m_Favorite;
 	int m_Latency; // in ms
 	char m_aGameType[16];
 	char m_aName[64];
@@ -166,9 +166,11 @@ public:
 	virtual const CServerInfo *SortedGet(int FilterIndex, int Index) const = 0;
 	virtual const void *GetID(int FilterIndex, int Index) const = 0;
 
-	virtual bool IsFavorite(const NETADDR &Addr) = 0;	// todo: remove this
-	virtual void AddFavorite(const CServerInfo *pEntry) = 0;
-	virtual void RemoveFavorite(const CServerInfo *pEntry) = 0;
+	virtual void AddFavorite(const CServerInfo *pInfo) = 0;
+	virtual void RemoveFavorite(const CServerInfo *pInfo) = 0;
+	virtual void UpdateFavoriteState(CServerInfo *pInfo) = 0;
+	virtual void SetFavoritePassword(const char *pAddress, const char *pPassword) = 0;
+	virtual const char *GetFavoritePassword(const char *pAddress) = 0;
 
 	virtual int AddFilter(const CServerFilterInfo *pFilterInfo) = 0;
 	virtual void SetFilter(int Index, const CServerFilterInfo *pFilterInfo) = 0;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -30,7 +30,7 @@ MACRO_CONFIG_INT(ClAutoScreenshotMax, cl_auto_screenshot_max, 10, 0, 1000, CFGFL
 MACRO_CONFIG_INT(ClShowServerBroadcast, cl_show_server_broadcast, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Show server broadcast")
 MACRO_CONFIG_INT(ClColoredBroadcast, cl_colored_broadcast, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Enable colored server broadcasts")
 
-MACRO_CONFIG_INT(ClSaveServerPasswords, cl_save_server_passwords, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Save passwords of servers you successfully connect to as favorites")
+MACRO_CONFIG_INT(ClSaveServerPasswords, cl_save_server_passwords, 1, 0, 2, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Save server passwords (0 = never, 1 = only favorites, 2 = all servers)")
 
 MACRO_CONFIG_STR(BrFilterString, br_filter_string, 25, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Server browser filtering string")
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -30,6 +30,8 @@ MACRO_CONFIG_INT(ClAutoScreenshotMax, cl_auto_screenshot_max, 10, 0, 1000, CFGFL
 MACRO_CONFIG_INT(ClShowServerBroadcast, cl_show_server_broadcast, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Show server broadcast")
 MACRO_CONFIG_INT(ClColoredBroadcast, cl_colored_broadcast, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Enable colored server broadcasts")
 
+MACRO_CONFIG_INT(ClSaveServerPasswords, cl_save_server_passwords, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Save passwords of servers you successfully connect to as favorites")
+
 MACRO_CONFIG_STR(BrFilterString, br_filter_string, 25, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Server browser filtering string")
 
 MACRO_CONFIG_INT(BrSort, br_sort, 4, 0, 256, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Sort criterion for the server browser")

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2726,10 +2726,7 @@ void CMenus::OnRender()
 	UI()->StartCheck();
 
 	// reset cursor
-	if(m_CursorActive)
-		m_PrevCursorActive = true;
-	else
-		m_PrevCursorActive = false;
+	m_PrevCursorActive = m_CursorActive;
 	m_CursorActive = false;
 
 	if(m_KeyReaderIsActive)

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2093,13 +2093,16 @@ int CMenus::Render()
 			UI()->DoLabel(&Label, pExtraText, ButtonHeight*ms_FontmodHeight*0.8f, ExtraAlign);
 
 			Box.HSplitTop(20.0f, &EditBox, &Box);
-
 			static float s_OffsetPassword = 0.0f;
 			DoEditBoxOption(g_Config.m_Password, g_Config.m_Password, sizeof(g_Config.m_Password), &EditBox, Localize("Password"), ButtonWidth, &s_OffsetPassword, true);
 
 			Box.HSplitTop(2.0f, 0, &Box);
 			Box.HSplitTop(20.0f, &Save, &Box);
-			if(DoButton_CheckBox(&g_Config.m_ClSaveServerPasswords, Localize("Save password and server as favorite"), g_Config.m_ClSaveServerPasswords, &Save))
+			CServerInfo ServerInfo = {0};
+			str_copy(ServerInfo.m_aHostname, g_Config.m_UiServerAddress, sizeof(ServerInfo.m_aHostname));
+			ServerBrowser()->UpdateFavoriteState(&ServerInfo);
+			const char *pSaveText = ServerInfo.m_Favorite ? Localize("Save password") : Localize("Save password and server as favorite");
+			if(DoButton_CheckBox(&g_Config.m_ClSaveServerPasswords, pSaveText, g_Config.m_ClSaveServerPasswords, &Save))
 				g_Config.m_ClSaveServerPasswords ^= 1;
 
 			// buttons

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -398,7 +398,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Password"), CurrentServerInfo.m_Flags&IServerBrowser::FLAG_PASSWORD ? Localize("Yes", "With") : Localize("No", "Without/None"));
 	UI()->DoLabel(&Label, aBuf, ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 	
-	const bool IsFavorite = ServerBrowser()->IsFavorite(CurrentServerInfo.m_NetAddr);
+	const bool IsFavorite = CurrentServerInfo.m_Favorite;
 	ServerInfo.HSplitBottom(ButtonHeight, &ServerInfo, &Label);
 	static int s_AddFavButton = 0;
 	if(DoButton_CheckBox(&s_AddFavButton, Localize("Favorite"), IsFavorite, &Label))


### PR DESCRIPTION
Changes the `add_favorite` command to accept an optional password as a second parameter. Also updates existing favorites. Example: `add_favorite "1.2.3.4" "Hunter2"`

Adds config variable `cl_save_server_passwords 0/1` for this new UI:
![screenshot_2020-01-22_17-52-13](https://user-images.githubusercontent.com/23437060/72915693-fc668580-3d40-11ea-95ca-191cbb7b5ee4.png)

Password is stored once you successfully connect to a password protected server and password saving is enabled. Password of favorite is loaded into `password` config var before sending the info. Should a stored password result in a password error on connection, the stored password is reset.

Removes the `IsFavorite` function from the serverbrowser, which was only used by the ingame favorite button, and replaces it with `UpdateFavoriteState`, which is called in `CClient::GetServerInfo` to make sure that the server info provided has the correct `m_Favorite` state, is then used in the ingame menu instead of `IsFavorite`.