### PR TITLE
Race: differentiate between personal and map record

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -5,6 +5,7 @@ Emotes = Enum("EMOTE", ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
 Emoticons = Enum("EMOTICON", ["OOP", "EXCLAMATION", "HEARTS", "DROP", "DOTDOT", "MUSIC", "SORRY", "GHOST", "SUSHI", "SPLATTEE", "DEVILTEE", "ZOMG", "ZZZ", "WTF", "EYES", "QUESTION"])
 Votes = Enum("VOTE", ["UNKNOWN", "START_OP", "START_KICK", "START_SPEC", "END_ABORT", "END_PASS", "END_FAIL"]) # todo 0.8: add RUN_OP, RUN_KICK, RUN_SPEC; rem UNKNOWN
 ChatModes = Enum("CHAT", ["NONE", "ALL", "TEAM", "WHISPER"])
+RaceRecordTypes = Enum("RECORDTYPE", ["NONE", "PLAYER", "MAP"])
 
 PlayerFlags = Flags("PLAYERFLAG", ["ADMIN", "CHATTING", "SCOREBOARD", "READY", "DEAD", "WATCHING", "BOT"])
 GameFlags = Flags("GAMEFLAG", ["TEAMS", "FLAGS", "SURVIVAL", "RACE"])
@@ -68,6 +69,7 @@ Enums = [
 	Emoticons,
 	Votes,
 	ChatModes,
+	RaceRecordTypes,
 	GameMsgIDs,
 ]
 
@@ -452,7 +454,7 @@ Messages = [
 		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
 		NetIntRange("m_Time", -1, 'max_int'),
 		NetIntAny("m_Diff"),
-		NetBool("m_NewRecord"),
+		NetEnum("m_RecordType", RaceRecordTypes)
 	]),
 
 	NetMessage("Sv_Checkpoint", [

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -289,8 +289,10 @@ void CInfoMessages::RenderFinishMsg(const CInfoMsg *pInfoMsg, float x, float y) 
 	float TimeW = TextRender()->TextWidth(0, FontSize, aTime, -1, -1.0f);
 
 	x -= TimeW;
-	if(pInfoMsg->m_RecordType != RECORDTYPE_NONE)
+	if(pInfoMsg->m_RecordType == RECORDTYPE_PLAYER)
 		TextRender()->TextColor(0.2f, 0.6f, 1.0f, 1.0f);
+	else if(pInfoMsg->m_RecordType == RECORDTYPE_MAP)
+		TextRender()->TextColor(1.0f, 0.5f, 0.0f, 1.0f);
 	TextRender()->Text(0, x, y, FontSize, aTime, -1);
 
 	x -= 52.0f + 10.0f;

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -97,9 +97,13 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 		str_format(aBuf, sizeof(aBuf), "%2d: %s: finished in %s", pMsg->m_ClientID, m_pClient->m_aClients[pMsg->m_ClientID].m_aName, aTime);
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "race", aBuf);
 
-		if(pMsg->m_NewRecord)
+		if(pMsg->m_RecordType != RECORDTYPE_NONE)
 		{
-			str_format(aBuf, sizeof(aBuf), Localize("'%s' has set a new record: %s"), aLabel, aTime);
+			if(pMsg->m_RecordType == RECORDTYPE_MAP)
+				str_format(aBuf, sizeof(aBuf), Localize("'%s' has set a new map record: %s"), aLabel, aTime);
+			else // RECORDTYPE_PLAYER
+				str_format(aBuf, sizeof(aBuf), Localize("'%s' has set a new personal record: %s"), aLabel, aTime);
+			
 			if(pMsg->m_Diff < 0)
 			{
 				char aImprovement[64];
@@ -113,7 +117,7 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 
 		if(m_pClient->m_Snap.m_pGameDataRace && m_pClient->m_Snap.m_pGameDataRace->m_RaceFlags&RACEFLAG_FINISHMSG_AS_CHAT)
 		{
-			if(!pMsg->m_NewRecord) // don't print the time twice
+			if(pMsg->m_RecordType == RECORDTYPE_NONE) // don't print the time twice
 			{
 				str_format(aBuf, sizeof(aBuf), Localize("'%s' finished in: %s"), aLabel, aTime);
 				m_pClient->m_pChat->AddLine(aBuf);
@@ -128,7 +132,7 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 
 			Finish.m_Time = pMsg->m_Time;
 			Finish.m_Diff = pMsg->m_Diff;
-			Finish.m_NewRecord = pMsg->m_NewRecord;
+			Finish.m_RecordType = pMsg->m_RecordType;
 
 			AddInfoMsg(INFOMSG_FINISH, Finish);
 		}
@@ -285,7 +289,7 @@ void CInfoMessages::RenderFinishMsg(const CInfoMsg *pInfoMsg, float x, float y) 
 	float TimeW = TextRender()->TextWidth(0, FontSize, aTime, -1, -1.0f);
 
 	x -= TimeW;
-	if(pInfoMsg->m_NewRecord)
+	if(pInfoMsg->m_RecordType != RECORDTYPE_NONE)
 		TextRender()->TextColor(0.2f, 0.6f, 1.0f, 1.0f);
 	TextRender()->Text(0, x, y, FontSize, aTime, -1);
 
@@ -312,6 +316,6 @@ void CInfoMessages::RenderFinishMsg(const CInfoMsg *pInfoMsg, float x, float y) 
 	x -= 28.0f;
 
 	// render player tee
-	int Emote = pInfoMsg->m_NewRecord ? EMOTE_HAPPY : EMOTE_NORMAL;
+	int Emote = pInfoMsg->m_RecordType != RECORDTYPE_NONE ? EMOTE_HAPPY : EMOTE_NORMAL;
 	RenderTools()->RenderTee(CAnimState::GetIdle(), &pInfoMsg->m_Player1RenderInfo, Emote, vec2(-1,0), vec2(x, y+28));
 }

--- a/src/game/client/components/infomessages.h
+++ b/src/game/client/components/infomessages.h
@@ -30,7 +30,7 @@ class CInfoMessages : public CComponent
 		// finish msg
 		int m_Time;
 		int m_Diff;
-		bool m_NewRecord;
+		int m_RecordType;
 	};
 
 	enum


### PR DESCRIPTION
This addresses #2389 

Replacing the `NetBool` with `NetEnum` works because `RECORDTYPE_NONE` maps to `0` and `RECORDTYPE_PLAYER` to `1`. The modder has to ensure that `RECORDTYPE_MAP` is only sent to 0.7.5 clients.

Finish messages for map records are orange:
![image](https://user-images.githubusercontent.com/550744/73122643-75efb500-3f87-11ea-939b-894ae742383d.png)
