### PR TITLE
Dropping glu as dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,7 @@ endif()
 
 if(TARGET_OS STREQUAL "windows")
   set(PLATFORM_CLIENT)
-  set(PLATFORM_CLIENT_LIBS opengl32 glu32 winmm)
+  set(PLATFORM_CLIENT_LIBS opengl32 winmm)
   set(PLATFORM_LIBS ws2_32) # Windows sockets
 elseif(TARGET_OS STREQUAL "mac")
   find_library(CARBON Carbon)
@@ -410,7 +410,7 @@ else()
   set(PLATFORM_CLIENT)
   find_package(OpenGL)
   find_package(X11)
-  set(PLATFORM_CLIENT_LIBS ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY} ${X11_X11_LIB})
+  set(PLATFORM_CLIENT_LIBS ${OPENGL_gl_LIBRARY} ${X11_X11_LIB})
   set(PLATFORM_CLIENT_INCLUDE_DIRS ${OPENGL_INCLUDE_DIR} ${X11_X11_INCLUDE_PATH})
   if(TARGET_OS STREQUAL "linux")
     set(PLATFORM_LIBS rt) # clock_gettime for glibc < 2.17

--- a/bam.lua
+++ b/bam.lua
@@ -208,7 +208,6 @@ function GenerateLinuxSettings(settings, conf, arch, compiler)
 	-- Client
 	settings.link.libs:Add("X11")
 	settings.link.libs:Add("GL")
-	settings.link.libs:Add("GLU")
 	BuildClient(settings)
 
 	-- Content

--- a/bam.lua
+++ b/bam.lua
@@ -271,7 +271,6 @@ function GenerateWindowsSettings(settings, conf, target_arch, compiler)
 	settings.link.extrafiles:Add(icons.client)
 	settings.link.extrafiles:Add(manifests.client)
 	settings.link.libs:Add("opengl32")
-	settings.link.libs:Add("glu32")
 	settings.link.libs:Add("winmm")
 	BuildClient(settings)
 

--- a/readme.md
+++ b/readme.md
@@ -34,10 +34,10 @@ Installing dependencies
     sudo apt install build-essential cmake git libfreetype6-dev libsdl2-dev libpnglite-dev libwavpack-dev python3
 
     # Fedora
-    sudo dnf install @development-tools cmake gcc-c++ git freetype-devel mesa-libGLU-devel pnglite-devel python3 SDL2-devel wavpack-devel
+    sudo dnf install @development-tools cmake gcc-c++ git freetype-devel pnglite-devel python3 SDL2-devel wavpack-devel
 
     # Arch Linux (doesn't have pnglite in its repositories)
-    sudo pacman -S --needed base-devel cmake freetype2 git glu python sdl2 wavpack
+    sudo pacman -S --needed base-devel cmake freetype2 git python sdl2 wavpack
 
     # macOS
     brew install cmake freetype sdl2

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1,11 +1,6 @@
 #include <base/detect.h>
 #include "SDL.h"
 #include "SDL_opengl.h"
-#if defined(CONF_PLATFORM_MACOSX)
-#include "OpenGL/glu.h"
-#else
-#include "GL/glu.h"
-#endif
 
 #include <base/tl/threading.h>
 
@@ -375,7 +370,8 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Create(const CCommandBuffer::
 				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 			else
 				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_NEAREST);
-			gluBuild2DMipmaps(GL_TEXTURE_2D, StoreOglformat, Width, Height, Oglformat, GL_UNSIGNED_BYTE, pTexData);
+			glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
+			glTexImage2D(GL_TEXTURE_2D, 0, StoreOglformat, Width, Height, 0, Oglformat, GL_UNSIGNED_BYTE, pTexData);
 		}
 
 		// calculate memory usage


### PR DESCRIPTION
It's nothing big but I thought it's worth a shot:
You can replace the call to GLU with 2 openGL calls and have the same functionality.

Since this is the only call that uses GLU, I thought it might be a good idea to patch it and thereby drop GLU, since this is the only time it's used in the whole codebase.