### PR TITLE
Fix overlap (missing margin) when gametype scrollbar is shown in browser filter

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1883,8 +1883,7 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 		UpdateFilter = true;
 	}
 
-	if(!NeedScrollbar)
-		ServerFilter.HSplitTop(LineSize - 4.f, &Button, &ServerFilter);
+	ServerFilter.HSplitTop(LineSize - 4.f, &Button, &ServerFilter);
 
 	{
 		int Value = FilterInfo.m_Ping, Min = 20, Max = 999;


### PR DESCRIPTION
As seen here:

![screenshot_2020-01-27_17-14-31](https://user-images.githubusercontent.com/23437060/73195027-70cc6a80-412d-11ea-8b5c-f2a2e6d2f4e4.png)
