### PR TITLE
Implement global support for nested clipping regions

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -214,12 +214,10 @@ private:
 		float m_ContentH;
 		float m_RequestScrollY; // [0, ContentHeight]
 		CUIRect m_ClipRect;
-		CUIRect m_OldClipRect;
 		CUIRect m_RailRect;
 		CUIRect m_LastAddedRect; // saved for ScrollHere()
 		vec2 m_MouseGrabStart;
 		vec2 m_ContentScrollOff;
-		bool m_WasClipped;
 		CScrollRegionParams m_Params;
 
 	public:

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -653,13 +653,9 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 		View.VSplitLeft(160.0f, &Info, &View);
 		RenderDetailInfo(Info, pEntry);
 
-		CUIRect NewClipArea = *UI()->ClipArea();
-		CUIRect OldClipArea = NewClipArea;
-		NewClipArea.x = View.x;
-		NewClipArea.w = View.w;
-		UI()->ClipEnable(&NewClipArea);
+		UI()->ClipEnable(&View);
 		RenderDetailScoreboard(View, pEntry, 4, vec4(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha));
-		UI()->ClipEnable(&OldClipArea);
+		UI()->ClipDisable();
 	}
 
 	TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.3f);

--- a/src/game/client/components/menus_scrollregion.cpp
+++ b/src/game/client/components/menus_scrollregion.cpp
@@ -18,7 +18,6 @@ CMenus::CScrollRegion::CScrollRegion()
 	m_ContentH = 0;
 	m_RequestScrollY = -1;
 	m_ContentScrollOff = vec2(0,0);
-	m_WasClipped = false;
 	m_Params = CScrollRegionParams();
 }
 
@@ -26,9 +25,6 @@ void CMenus::CScrollRegion::Begin(CUIRect* pClipRect, vec2* pOutOffset, const CS
 {
 	if(pParams)
 		m_Params = *pParams;
-
-	m_WasClipped = m_pUI->IsClipped();
-	m_OldClipRect = *m_pUI->ClipArea();
 
 	const bool ContentOverflows = m_ContentH > pClipRect->h;
 	const bool ForceShowScrollbar = m_Params.m_Flags&CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH;
@@ -52,18 +48,7 @@ void CMenus::CScrollRegion::Begin(CUIRect* pClipRect, vec2* pOutOffset, const CS
 	if(m_Params.m_ClipBgColor.a > 0)
 		m_pRenderTools->DrawRoundRect(pClipRect, m_Params.m_ClipBgColor, 4.0f);
 
-	CUIRect ClipRect = *pClipRect;
-	if(m_WasClipped)
-	{
-		CUIRect Intersection;
-		Intersection.x = max(ClipRect.x, m_OldClipRect.x);
-		Intersection.y = max(ClipRect.y, m_OldClipRect.y);
-		Intersection.w = min(ClipRect.x+ClipRect.w, m_OldClipRect.x+m_OldClipRect.w) - ClipRect.x;
-		Intersection.h = min(ClipRect.y+ClipRect.h, m_OldClipRect.y+m_OldClipRect.h) - ClipRect.y;
-		ClipRect = Intersection;
-	}
-
-	m_pUI->ClipEnable(&ClipRect);
+	m_pUI->ClipEnable(pClipRect);
 
 	m_ClipRect = *pClipRect;
 	m_ContentH = 0;
@@ -73,8 +58,6 @@ void CMenus::CScrollRegion::Begin(CUIRect* pClipRect, vec2* pOutOffset, const CS
 void CMenus::CScrollRegion::End()
 {
 	m_pUI->ClipDisable();
-	if(m_WasClipped)
-		m_pUI->ClipEnable(&m_OldClipRect);
 
 	// only show scrollbar if content overflows
 	if(m_ContentH <= m_ClipRect.h)

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -306,7 +306,7 @@ int CUI::DoButtonLogic(const void *pID, const char *pText, int Checked, const CU
 	int ReturnValue = 0;
 	int Inside = MouseInside(pRect);
 	if(IsClipped())
-		Inside &= MouseInsideClip();
+		Inside &= (MouseInsideClip() ? 1 : 0);
 	static int ButtonUsed = 0;
 
 	if(CheckActiveItem(pID))

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -35,7 +35,21 @@ class CUI
 	unsigned m_LastMouseButtons;
 
 	CUIRect m_Screen;
-	CUIRect m_ClipRect;
+
+	class CClip
+	{
+	public:
+		CUIRect m_Rect;
+		const CClip *m_pParent;
+		CClip(const CUIRect *pRect, const CClip *pParent)
+		{
+			m_Rect = *pRect;
+			m_pParent = pParent;
+		}
+	};
+	const CClip *m_pClip;
+	void UpdateClipping();
+
 	class IGraphics *m_pGraphics;
 	class ITextRender *m_pTextRender;
 
@@ -46,6 +60,7 @@ public:
 	class ITextRender *TextRender() const { return m_pTextRender; }
 
 	CUI();
+	~CUI();
 
 	enum
 	{
@@ -106,10 +121,11 @@ public:
 
 	CUIRect *Screen();
 	float PixelSize();
+
 	void ClipEnable(const CUIRect *pRect);
 	void ClipDisable();
-	const CUIRect *ClipArea() const { return &m_ClipRect; };
-	inline bool IsClipped() const { return m_Clipped; };
+	const CUIRect *ClipArea() const;
+	inline bool IsClipped() const { return m_pClip != 0; };
 
 	int DoButtonLogic(const void *pID, const char *pText /* TODO: Refactor: Remove */, int Checked, const CUIRect *pRect);
 	int DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *pY);

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -28,7 +28,6 @@ class CUI
 	const void *m_pLastActiveItem;
 	const void *m_pBecommingHotItem;
 	bool m_ActiveItemValid;
-	bool m_Clipped;
 	float m_MouseX, m_MouseY; // in gui space
 	float m_MouseWorldX, m_MouseWorldY; // in world space
 	unsigned m_MouseButtons;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -23,6 +23,11 @@ public:
 
 class CUI
 {
+	enum
+	{
+		MAX_CLIP_NESTING_DEPTH = 16
+	};
+
 	const void *m_pHotItem;
 	const void *m_pActiveItem;
 	const void *m_pLastActiveItem;
@@ -35,18 +40,8 @@ class CUI
 
 	CUIRect m_Screen;
 
-	class CClip
-	{
-	public:
-		CUIRect m_Rect;
-		const CClip *m_pParent;
-		CClip(const CUIRect *pRect, const CClip *pParent)
-		{
-			m_Rect = *pRect;
-			m_pParent = pParent;
-		}
-	};
-	const CClip *m_pClip;
+	CUIRect m_aClips[MAX_CLIP_NESTING_DEPTH];
+	unsigned m_NumClips;
 	void UpdateClipping();
 
 	class IGraphics *m_pGraphics;
@@ -59,7 +54,6 @@ public:
 	class ITextRender *TextRender() const { return m_pTextRender; }
 
 	CUI();
-	~CUI();
 
 	enum
 	{
@@ -124,7 +118,7 @@ public:
 	void ClipEnable(const CUIRect *pRect);
 	void ClipDisable();
 	const CUIRect *ClipArea() const;
-	inline bool IsClipped() const { return m_pClip != 0; };
+	inline bool IsClipped() const { return m_NumClips > 0; };
 
 	int DoButtonLogic(const void *pID, const char *pText /* TODO: Refactor: Remove */, int Checked, const CUIRect *pRect);
 	int DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *pY);


### PR DESCRIPTION
`ClipEnable` pushes a clip region on the stack, intersected with the previous clip.

`ClipDisable` pops a clip region of the stack and restores the previous clip.