### PR TITLE
Add some stylistic changes to `CJsonWriter`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1721,6 +1721,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     fs.cpp
     git_revision.cpp
     hash.cpp
+    jsonwriter.cpp
     storage.cpp
     str.cpp
     test.cpp

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -178,6 +178,20 @@ void mem_zero(void *block, unsigned size);
 */
 int mem_comp(const void *a, const void *b, int size);
 
+/*
+	Function: mem_has_null
+		Checks whether a block of memory contains null bytes.
+
+	Parameters:
+		block - Pointer to the block to check for nulls.
+		size - Size of the block.
+
+	Returns:
+		1 - The block has a null byte.
+		0 - The block does not have a null byte.
+*/
+int mem_has_null(const void *block, unsigned size);
+
 /* Group: File IO */
 enum {
 	IOFLAG_READ = 1,
@@ -219,6 +233,40 @@ IOHANDLE io_open(const char *filename, int flags);
 
 */
 unsigned io_read(IOHANDLE io, void *buffer, unsigned size);
+
+/*
+	Function: io_read_all
+		Reads the rest of the file into a buffer.
+
+	Parameters:
+		io - Handle to the file to read data from.
+		result - Receives the file's remaining contents.
+		result_len - Receives the file's remaining length.
+
+	Remarks:
+		- Does NOT guarantee that there are no internal null bytes.
+		- Guarantees that result will contain zero-termination.
+		- The result must be freed after it has been used.
+*/
+void io_read_all(IOHANDLE io, void **result, unsigned *result_len);
+
+/*
+	Function: io_read_all_str
+		Reads the rest of the file into a zero-terminated buffer with
+		no internal null bytes.
+
+	Parameters:
+		io - Handle to the file to read data from.
+
+	Returns:
+		The file's remaining contents or null on failure.
+
+	Remarks:
+		- Guarantees that there are no internal null bytes.
+		- Guarantees that result will contain zero-termination.
+		- The result must be freed after it has been used.
+*/
+char *io_read_all_str(IOHANDLE io);
 
 /*
 	Function: io_unread_byte
@@ -1337,6 +1385,44 @@ int fs_remove(const char *filename);
 		- The strings are treated as zero-terminated strings.
 */
 int fs_rename(const char *oldname, const char *newname);
+
+/*
+	Function: fs_read
+		Reads a whole file into memory and returns its contents.
+
+	Parameters:
+		name - The filename to read.
+		result - Receives the file's contents.
+		result_len - Receives the file's length.
+
+	Returns:
+		Returns 0 on success, 1 on failure.
+
+	Remarks:
+		- Does NOT guarantee that there are no internal null bytes.
+		- Guarantees that result will contain zero-termination.
+		- The result must be freed after it has been used.
+*/
+int fs_read(const char *name, void **result, unsigned *result_len);
+
+/*
+	Function: fs_read
+		Reads a whole file into memory and returns its contents,
+		guaranteeing a null-terminated string with no internal null
+		bytes.
+
+	Parameters:
+		name - The filename to read.
+
+	Returns:
+		Returns the file's contents on success, null on failure.
+
+	Remarks:
+		- Guarantees that there are no internal null bytes.
+		- Guarantees that result will contain zero-termination.
+		- The result must be freed after it has been used.
+*/
+char *fs_read_str(const char *name);
 
 /*
 	Group: Undocumented

--- a/src/engine/shared/jsonwriter.h
+++ b/src/engine/shared/jsonwriter.h
@@ -7,45 +7,48 @@
 
 class CJsonWriter
 {
-	enum EState
+	enum
 	{
-		OBJECT,
-		ARRAY,
-		ATTRIBUTE
+		STATE_INVALID,
+		STATE_OBJECT,
+		STATE_ARRAY,
+		STATE_ATTRIBUTE,
+
+		MAX_DEPTH=16,
 	};
 
 	class CState
 	{
 	public:
-		EState m_State;
-		CState *m_pParent;
+		unsigned char m_Kind;
 		bool m_Empty;
 
-		CState(EState State, CState *pParent)
+		CState(unsigned char Kind = STATE_INVALID)
 		{
-			m_State = State;
-			m_pParent = pParent;
+			m_Kind = Kind;
 			m_Empty = true;
 		};
 	};
 
 	IOHANDLE m_IO;
 
-	CState *m_pState;
+	CState m_aStates[MAX_DEPTH];
+	int m_NumStates;
 	int m_Indentation;
 
 	bool CanWriteDatatype();
 	inline void WriteInternal(const char *pStr);
 	void WriteInternalEscaped(const char *pStr);
 	void WriteIndent(bool EndElement);
-	void PushState(EState NewState);
-	EState PopState();
+	void PushState(unsigned char NewState);
+	CState *TopState();
+	unsigned char PopState();
 	void CompleteDataType();
 
 public:
 	// Create a new writer object without writing anything to the file yet.
 	// The file will automatically be closed by the destructor.
-	CJsonWriter(IOHANDLE io);
+	CJsonWriter(IOHANDLE IO);
 	~CJsonWriter();
 
 	// The root is created by beginning the first datatype (object, array, value).

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -378,6 +378,32 @@ public:
 		return 0;
 	}
 
+	bool ReadFile(const char *pFilename, int Type, void **ppResult, unsigned *pResultLen)
+	{
+		IOHANDLE File = OpenFile(pFilename, IOFLAG_READ, Type);
+		*ppResult = 0;
+		*pResultLen = 0;
+		if(!File)
+		{
+			return true;
+		}
+		io_read_all(File, ppResult, pResultLen);
+		io_close(File);
+		return false;
+	}
+
+	char *ReadFileStr(const char *pFilename, int Type)
+	{
+		IOHANDLE File = OpenFile(pFilename, IOFLAG_READ, Type);
+		if(!File)
+		{
+			return 0;
+		}
+		char *pResult = io_read_all_str(File);
+		io_close(File);
+		return pResult;
+	}
+
 	struct CFindCBData
 	{
 		CStorage *m_pStorage;

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -24,6 +24,8 @@ public:
 
 	virtual void ListDirectory(int Type, const char *pPath, FS_LISTDIR_CALLBACK pfnCallback, void *pUser) = 0;
 	virtual IOHANDLE OpenFile(const char *pFilename, int Flags, int Type, char *pBuffer = 0, int BufferSize = 0, FCheckCallback pfnCheckCB = 0, const void *pCheckCBData = 0) = 0;
+	virtual bool ReadFile(const char *pFilename, int Type, void **ppResult, unsigned *pResultLen) = 0;
+	virtual char *ReadFileStr(const char *pFilename, int Type) = 0;
 	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize) = 0;
 	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize, const SHA256_DIGEST *pWantedSha256, unsigned WantedCrc, unsigned WantedSize) = 0;
 	virtual bool RemoveFile(const char *pFilename, int Type) = 0;

--- a/src/test/jsonwriter.cpp
+++ b/src/test/jsonwriter.cpp
@@ -1,0 +1,98 @@
+#include "test.h"
+#include <gtest/gtest.h>
+
+#include <engine/shared/jsonwriter.h>
+#include <limits.h>
+
+class JsonWriter : public ::testing::Test
+{
+protected:
+	CTestInfo m_Info;
+	CJsonWriter *m_pJson;
+	char m_aOutputFilename[64];
+
+	JsonWriter()
+		: m_pJson(0)
+	{
+		m_Info.Filename(m_aOutputFilename, sizeof(m_aOutputFilename),
+			"-got.json");
+		IOHANDLE File = io_open(m_aOutputFilename, IOFLAG_WRITE);
+		EXPECT_TRUE(File);
+		m_pJson = new CJsonWriter(File);
+	}
+
+	void Expect(const char *pExpected)
+	{
+		ASSERT_TRUE(m_pJson);
+		delete m_pJson;
+		m_pJson = 0;
+
+		char *pOutput = fs_read_str(m_aOutputFilename);
+		ASSERT_TRUE(pOutput);
+		EXPECT_STREQ(pOutput, pExpected);
+		bool Correct = str_comp(pOutput, pExpected) == 0;
+		mem_free(pOutput);
+
+		if(!Correct)
+		{
+			char aFilename[64];
+			m_Info.Filename(aFilename, sizeof(aFilename),
+				"-expected.json");
+			IOHANDLE File = io_open(aFilename, IOFLAG_WRITE);
+			ASSERT_TRUE(File);
+			io_write(File, pExpected, str_length(pExpected));
+			io_close(File);
+		}
+		else
+		{
+			fs_remove(m_aOutputFilename);
+		}
+	}
+};
+
+TEST_F(JsonWriter, EmptyObject)
+{
+	m_pJson->BeginObject();
+	m_pJson->EndObject();
+	Expect("{\n}\n");
+}
+
+TEST_F(JsonWriter, EmptyArray)
+{
+	m_pJson->BeginArray();
+	m_pJson->EndArray();
+	Expect("[\n]\n");
+}
+
+TEST_F(JsonWriter, SpecialCharacters)
+{
+	m_pJson->BeginObject();
+	m_pJson->WriteAttribute("\x01\"'\r\n\t");
+	m_pJson->BeginArray();
+	m_pJson->WriteStrValue(" \"'abc\x01\n");
+	m_pJson->EndArray();
+	m_pJson->EndObject();
+	Expect(
+		"{\n"
+		"\t\"\\u0001\\\"'\\r\\n\\t\": [\n"
+		"\t\t\" \\\"'abc\\u0001\\n\"\n"
+		"\t]\n"
+		"}\n"
+	);
+}
+
+TEST_F(JsonWriter, HelloWorld)
+{
+	m_pJson->WriteStrValue("hello world");
+	Expect("\"hello world\"\n");
+}
+
+TEST_F(JsonWriter, True) { m_pJson->WriteBoolValue(true); Expect("true\n"); }
+TEST_F(JsonWriter, False) { m_pJson->WriteBoolValue(false); Expect("false\n"); }
+TEST_F(JsonWriter, Null) { m_pJson->WriteNullValue(); Expect("null\n"); }
+TEST_F(JsonWriter, EmptyString) { m_pJson->WriteStrValue(""); Expect("\"\"\n"); }
+TEST_F(JsonWriter, Zero) { m_pJson->WriteIntValue(0); Expect("0\n"); }
+TEST_F(JsonWriter, One) { m_pJson->WriteIntValue(1); Expect("1\n"); }
+TEST_F(JsonWriter, MinusOne) { m_pJson->WriteIntValue(-1); Expect("-1\n"); }
+TEST_F(JsonWriter, Large) { m_pJson->WriteIntValue(INT_MAX); Expect("2147483647\n"); }
+TEST_F(JsonWriter, Small) { m_pJson->WriteIntValue(INT_MIN); Expect("-2147483648\n"); }

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -7,8 +7,14 @@ CTestInfo::CTestInfo()
 {
 	const ::testing::TestInfo *pTestInfo =
 		::testing::UnitTest::GetInstance()->current_test_info();
-	str_format(m_aFilename, sizeof(m_aFilename), "%s.%s-%d.tmp",
+	str_format(m_aFilenamePrefix, sizeof(m_aFilenamePrefix), "%s.%s-%d",
 		pTestInfo->test_case_name(), pTestInfo->name(), pid());
+	Filename(m_aFilename, sizeof(m_aFilename), ".tmp");
+}
+
+void CTestInfo::Filename(char *pBuffer, int BufferLength, const char *pSuffix)
+{
+	str_format(pBuffer, BufferLength, "%s%s", m_aFilenamePrefix, pSuffix);
 }
 
 int main(int argc, char **argv)

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -4,6 +4,8 @@ class CTestInfo
 {
 public:
 	CTestInfo();
+	void Filename(char *pBuffer, int BufferLength, const char *pSuffix);
+	char m_aFilenamePrefix[64];
 	char m_aFilename[64];
 };
 #endif // TEST_TEST_H


### PR DESCRIPTION
Depends on #2440.

- Remove all allocations, replacing it with a maximum depth of 16.
- Explicitly prefix enum variants with their type.
- Rename `io` to `IO`.

What do you think about this, @Robyt3? (especially the last commit, the others *should* be uncontroversial).