### PR TITLE
Stop server on logfile error

### DIFF
--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -95,10 +95,12 @@ public:
 			char aLogFilename[128];			
 			str_format(aLogFilename, sizeof(aLogFilename), "dumps/%s%s.txt", g_Config.m_Logfile, aBuf);
 			IOHANDLE Handle = m_pStorage->OpenFile(aLogFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
-			if(Handle)
-				dbg_logger_filehandle(Handle);
-			else
+			if(!Handle)
+			{
 				dbg_msg("engine/logfile", "failed to open '%s' for logging", aLogFilename);
+				exit(1);
+			}
+			dbg_logger_filehandle(Handle);
 		}
 	}
 


### PR DESCRIPTION
It is save to assume that a server hoster who manually set the ``logfile`` config wants his logging to work.

The new log system does not allow absolute paths or anything outside of the teeworlds/dumps directory. So when updating to the new system with old path configs there is a small silent error somewhere in the beginning of the server log. This change fails loudly and shows directly what went wrong:

```
$ ./teeworlds_srv "logfile /tmp/bar"
[2020-01-28 17:51:41][engine]: running on unix-linux-amd64
[2020-01-28 17:51:41][engine]: arch is little endian
[2020-01-28 17:51:41][storage]: couldn't open storage.cfg
[2020-01-28 17:51:41][storage]: using standard paths
[2020-01-28 17:51:41][storage]: added path '$USERDIR' ('/home/chiller/.teeworlds')
[2020-01-28 17:51:41][storage]: added path '$DATADIR' ('data')
[2020-01-28 17:51:41][storage]: added path '$CURRENTDIR' ('/home/chiller/Desktop/git/teeworlds/build')
[2020-01-28 17:51:41][storage]: added path '$APPDIR' ('.')
[2020-01-28 17:51:41][console]: failed to open 'autoexec.cfg'
[2020-01-28 17:51:41][console]: Info: only relative paths starting from the ones you specify in 'storage.cfg' are allowed
[2020-01-28 17:51:41][engine/logfile]: failed to open 'dumps//tmp/bar.txt' for logging

```