### PR TITLE
Only print the bad path message for paths starting with a slash

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1932,7 +1932,7 @@ void str_sanitize_cc(char *str_in)
 }
 
 /* check if the string contains '..' (parent directory) paths */
-int str_check_pathname(const char* str)
+int str_path_unsafe(const char *str)
 {
 	// State machine. 0 means that we're at the beginning
 	// of a new directory/filename, and a positive number represents the number of

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -942,22 +942,22 @@ void str_sanitize(char *str);
 	Remarks:
 		- The strings are treated as zero-terminated strings.
 */
-char* str_sanitize_filename(char* aName);
+char *str_sanitize_filename(char *name);
 
 /*
-	Function: str_check_pathname
+	Function: str_path_unsafe
 		Check if the string contains '..' (parent directory) paths.
 
 	Parameters:
 		str - String to check.
 
 	Returns:
-		Returns 0 if the path is valid, -1 otherwise.
+		Returns 0 if the path is safe, -1 otherwise.
 
 	Remarks:
 		- The strings are treated as zero-terminated strings.
 */
-int str_check_pathname(const char* str);
+int str_path_unsafe(const char *str);
 
 /*
 	Function: str_clean_whitespaces

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -439,7 +439,13 @@ bool CConsole::ExecuteFile(const char *pFilename)
 	{
 		str_format(aBuf, sizeof(aBuf), "failed to open '%s'", pFilename);
 		Print(IConsole::OUTPUT_LEVEL_STANDARD, "console", aBuf);
-		Print(IConsole::OUTPUT_LEVEL_STANDARD, "console", "Info: only relative paths starting from the ones you specify in 'storage.cfg' are allowed");
+		bool AbsHeur = false;
+		AbsHeur = AbsHeur || (pFilename[0] == '/' || pFilename[0] == '\\');
+		AbsHeur = AbsHeur || (pFilename[0] && pFilename[1] == ':' && (pFilename[2] == '/' || pFilename[2] == '\\'));
+		if(AbsHeur)
+		{
+			Print(IConsole::OUTPUT_LEVEL_STANDARD, "console", "Info: only relative paths starting from the ones you specify in 'storage.cfg' are allowed");
+		}
 	}
 
 	m_pFirstExec = pPrev;

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -333,9 +333,9 @@ public:
 		//
 		// E. g. "/etc/passwd" => "/path/to/storage//etc/passwd", which
 		// is safe.
-		if(str_check_pathname(pFilename) != 0)
+		if(str_path_unsafe(pFilename) != 0)
 		{
-			pBuffer[0] = 0;
+			dbg_msg("storage", "refusing to open path which looks like it could escape those specified in 'storage.cfg': %s", pFilename);
 			return 0;
 		}
 

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -100,3 +100,27 @@ TEST(StrFormat, Positional)
 	str_format(aBuf, sizeof(aBuf), "%1$s %1$s %2$d %1$s %2$d", "str", 1);
 	EXPECT_STREQ(aBuf, "str str 1 str 1");
 }
+
+TEST(Str, PathUnsafe)
+{
+	EXPECT_TRUE(str_path_unsafe(".."));
+	EXPECT_TRUE(str_path_unsafe("/.."));
+	EXPECT_TRUE(str_path_unsafe("/../"));
+	EXPECT_TRUE(str_path_unsafe("../"));
+
+	EXPECT_TRUE(str_path_unsafe("/../foobar"));
+	EXPECT_TRUE(str_path_unsafe("../foobar"));
+	EXPECT_TRUE(str_path_unsafe("foobar/../foobar"));
+	EXPECT_TRUE(str_path_unsafe("foobar/.."));
+	EXPECT_TRUE(str_path_unsafe("foobar/../"));
+
+	EXPECT_FALSE(str_path_unsafe("abc"));
+	EXPECT_FALSE(str_path_unsafe("abc/"));
+	EXPECT_FALSE(str_path_unsafe("abc/def"));
+	EXPECT_FALSE(str_path_unsafe("abc/def.txt"));
+	EXPECT_FALSE(str_path_unsafe("abc\\"));
+	EXPECT_FALSE(str_path_unsafe("abc\\def"));
+	EXPECT_FALSE(str_path_unsafe("abc\\def.txt"));
+	EXPECT_FALSE(str_path_unsafe("abc/def\\ghi.txt"));
+	EXPECT_FALSE(str_path_unsafe("любовь"));
+}


### PR DESCRIPTION
Also generate an extra warning for paths containing '..'.