### PR TITLE
Namespace conflicts with SDLApplication

### DIFF
--- a/src/osxlaunch/client.m
+++ b/src/osxlaunch/client.m
@@ -64,10 +64,10 @@ static NSString *getApplicationName(void)
 @end
 #endif
 
-@interface SDLApplication : NSApplication
+@interface TWSDLApplication : NSApplication
 @end
 
-@implementation SDLApplication
+@implementation TWSDLApplication
 /* Invoked from the Quit menu item */
 - (void)terminate:(id)sender
 {
@@ -193,7 +193,7 @@ static void CustomApplicationMain (int argc, char **argv)
 	SDLMain				*sdlMain;
 
 	/* Ensure the application object is initialised */
-	[SDLApplication sharedApplication];
+	[TWSDLApplication sharedApplication];
 
 #ifdef SDL_USE_CPS
 	{
@@ -202,7 +202,7 @@ static void CustomApplicationMain (int argc, char **argv)
 		if (!CPSGetCurrentProcess(&PSN))
 			if (!CPSEnableForegroundOperation(&PSN,0x03,0x3C,0x2C,0x1103))
 				if (!CPSSetFrontProcess(&PSN))
-					[SDLApplication sharedApplication];
+					[TWSDLApplication sharedApplication];
 	}
 #endif /* SDL_USE_CPS */
 
@@ -362,7 +362,7 @@ int main (int argc, char **argv)
 	}
 
 #if SDL_USE_NIB_FILE
-	[SDLApplication poseAsClass:[NSApplication class]];
+	[TWSDLApplication poseAsClass:[NSApplication class]];
 	NSApplicationMain (argc, argv);
 #else
 	CustomApplicationMain (argc, argv);


### PR DESCRIPTION
Thanks to @markph0204
https://github.com/markph0204/pygame/commit/ab30380546e672f917fe54bf253ed14bbdd547bc

Fixed the warning on launch:
```
% ./teeworlds
objc[5031]: Class SDLApplication is implemented in both /usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib (0x10935e190) and /Users/chillerdragon/Desktop/git/teeworlds/build/x86_64/release/./teeworlds (0x10908f5f0). One of the two will be used. Which one is undefined.
[2020-01-31 18:30:54][engine]: running on unix-macosx-amd64
[2020-01-31 18:30:54][engine]: arch is little endian
[2020-01-31 18:30:54][storage]: couldn't open storage.cfg
[2020-01-31 18:30:54][storage]: using standard paths
```