### PR TITLE
Make the path for accessing config variables shorter

### DIFF
--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -62,7 +62,8 @@ class CClient : public IClient, public CDemoPlayer::IListner
 	IEngineSound *m_pSound;
 	IGameClient *m_pGameClient;
 	IEngineMap *m_pMap;
-	IConfig *m_pConfig;
+	IConfigManager *m_pConfigManager;
+	CConfig *m_pConfig;
 	IConsole *m_pConsole;
 	IStorage *m_pStorage;
 	IEngineMasterServer *m_pMasterServer;
@@ -200,7 +201,8 @@ public:
 	IEngineSound *Sound() { return m_pSound; }
 	IGameClient *GameClient() { return m_pGameClient; }
 	IEngineMasterServer *MasterServer() { return m_pMasterServer; }
-	IConfig *Config() { return m_pConfig; }
+	IConfigManager *ConfigManager() { return m_pConfigManager; }
+	CConfig *Config() { return m_pConfig; }
 	IStorage *Storage() { return m_pStorage; }
 
 	CClient();

--- a/src/engine/client/contacts.cpp
+++ b/src/engine/client/contacts.cpp
@@ -98,7 +98,7 @@ void IContactList::RemoveContact(int Index)
 	return;
 }
 
-void IContactList::ConfigSave(IConfig *pConfig, const char* pCmdStr)
+void IContactList::ConfigSave(IConfigManager *pConfigManager, const char* pCmdStr)
 {
 	char aBuf[128];
 	const char *pEnd = aBuf+sizeof(aBuf)-4;
@@ -129,7 +129,7 @@ void IContactList::ConfigSave(IConfig *pConfig, const char* pCmdStr)
 		*pDst++ = '"';
 		*pDst++ = 0;
 
-		pConfig->WriteLine(aBuf);
+		pConfigManager->WriteLine(aBuf);
 	}	
 }
 
@@ -159,9 +159,9 @@ void CBlacklist::ConRemoveIgnore(IConsole::IResult *pResult, void *pUserData)
 
 void CFriends::Init()
 {
-	IConfig *pConfig = Kernel()->RequestInterface<IConfig>();
-	if(pConfig)
-		pConfig->RegisterCallback(ConfigSaveCallback, this);
+	IConfigManager *pConfigManager = Kernel()->RequestInterface<IConfigManager>();
+	if(pConfigManager)
+		pConfigManager->RegisterCallback(ConfigSaveCallback, this);
 
 	IConsole *pConsole = Kernel()->RequestInterface<IConsole>();
 	if(pConsole)
@@ -173,9 +173,9 @@ void CFriends::Init()
 
 void CBlacklist::Init()
 {
-	IConfig *pConfig = Kernel()->RequestInterface<IConfig>();
-	if(pConfig)
-		pConfig->RegisterCallback(ConfigSaveCallback, this);
+	IConfigManager *pConfigManager = Kernel()->RequestInterface<IConfigManager>();
+	if(pConfigManager)
+		pConfigManager->RegisterCallback(ConfigSaveCallback, this);
 
 	IConsole *pConsole = Kernel()->RequestInterface<IConsole>();
 	if(pConsole)
@@ -185,14 +185,14 @@ void CBlacklist::Init()
 	}
 }
 
-void CFriends::ConfigSaveCallback(IConfig *pConfig, void *pUserData)
+void CFriends::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
 {
 	CFriends *pSelf = (CFriends *)pUserData;
-	pSelf->ConfigSave(pConfig, "add_friend ");
+	pSelf->ConfigSave(pConfigManager, "add_friend ");
 }
 
-void CBlacklist::ConfigSaveCallback(IConfig *pConfig, void *pUserData)
+void CBlacklist::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
 {
 	CBlacklist *pSelf = (CBlacklist *)pUserData;
-	pSelf->ConfigSave(pConfig, "add_ignore ");
+	pSelf->ConfigSave(pConfigManager, "add_ignore ");
 }

--- a/src/engine/client/contacts.h
+++ b/src/engine/client/contacts.h
@@ -16,7 +16,7 @@ private:
 public:
 	IContactList();
 
-	void ConfigSave(IConfig *pConfig, const char* pCmdStr);
+	void ConfigSave(IConfigManager *pConfigManager, const char* pCmdStr);
 
 	virtual void Init() = 0;
 
@@ -33,7 +33,7 @@ public:
 class CFriends: public IFriends, public IContactList
 {
 public:
-	static void ConfigSaveCallback(IConfig *pConfig, void *pUserData);
+	static void ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData);
 
 	void Init();
 
@@ -52,7 +52,7 @@ public:
 class CBlacklist: public IBlacklist, public IContactList
 {
 public:
-	static void ConfigSaveCallback(IConfig *pConfig, void *pUserData);
+	static void ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData);
 
 	void Init();
 

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -332,7 +332,7 @@ int CGraphics_Threaded::LoadTextureRawSub(CTextureHandle TextureID, int x, int y
 IGraphics::CTextureHandle CGraphics_Threaded::LoadTextureRaw(int Width, int Height, int Format, const void *pData, int StoreFormat, int Flags)
 {
 	// don't waste memory on texture if we are stress testing
-	if(m_pConfig->Values()->m_DbgStress)
+	if(m_pConfig->m_DbgStress)
 		return m_InvalidTexture;
 
 	// grab texture
@@ -353,9 +353,9 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadTextureRaw(int Width, int Heig
 	Cmd.m_Flags = CCommandBuffer::TEXFLAG_TEXTURE2D;
 	if(Flags&IGraphics::TEXLOAD_NOMIPMAPS)
 		Cmd.m_Flags |= CCommandBuffer::TEXFLAG_NOMIPMAPS;
-	if(m_pConfig->Values()->m_GfxTextureCompression)
+	if(m_pConfig->m_GfxTextureCompression)
 		Cmd.m_Flags |= CCommandBuffer::TEXFLAG_COMPRESSED;
-	if(m_pConfig->Values()->m_GfxTextureQuality || Flags&TEXLOAD_NORESAMPLE)
+	if(m_pConfig->m_GfxTextureQuality || Flags&TEXLOAD_NORESAMPLE)
 		Cmd.m_Flags |= CCommandBuffer::TEXFLAG_QUALITY;
 	if(Flags&IGraphics::TEXLOAD_ARRAY_256)
 	{
@@ -397,7 +397,7 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadTexture(const char *pFilename,
 
 		ID = LoadTextureRaw(Img.m_Width, Img.m_Height, Img.m_Format, Img.m_pData, StoreFormat, Flags);
 		mem_free(Img.m_pData);
-		if(ID.Id() != m_InvalidTexture.Id() && m_pConfig->Values()->m_Debug)
+		if(ID.Id() != m_InvalidTexture.Id() && m_pConfig->m_Debug)
 			dbg_msg("graphics/texture", "loaded %s", pFilename);
 		return ID;
 	}
@@ -742,15 +742,15 @@ void CGraphics_Threaded::QuadsText(float x, float y, float Size, const char *pTe
 int CGraphics_Threaded::IssueInit()
 {
 	int Flags = 0;
-	if(m_pConfig->Values()->m_GfxBorderless) Flags |= IGraphicsBackend::INITFLAG_BORDERLESS;
-	if(m_pConfig->Values()->m_GfxFullscreen) Flags |= IGraphicsBackend::INITFLAG_FULLSCREEN;
-	if(m_pConfig->Values()->m_GfxVsync) Flags |= IGraphicsBackend::INITFLAG_VSYNC;
-	if(m_pConfig->Values()->m_GfxHighdpi) Flags |= IGraphicsBackend::INITFLAG_HIGHDPI;
-	if(m_pConfig->Values()->m_DbgResizable) Flags |= IGraphicsBackend::INITFLAG_RESIZABLE;
-	if(m_pConfig->Values()->m_GfxUseX11XRandRWM) Flags |= IGraphicsBackend::INITFLAG_X11XRANDR;
+	if(m_pConfig->m_GfxBorderless) Flags |= IGraphicsBackend::INITFLAG_BORDERLESS;
+	if(m_pConfig->m_GfxFullscreen) Flags |= IGraphicsBackend::INITFLAG_FULLSCREEN;
+	if(m_pConfig->m_GfxVsync) Flags |= IGraphicsBackend::INITFLAG_VSYNC;
+	if(m_pConfig->m_GfxHighdpi) Flags |= IGraphicsBackend::INITFLAG_HIGHDPI;
+	if(m_pConfig->m_DbgResizable) Flags |= IGraphicsBackend::INITFLAG_RESIZABLE;
+	if(m_pConfig->m_GfxUseX11XRandRWM) Flags |= IGraphicsBackend::INITFLAG_X11XRANDR;
 
-	return m_pBackend->Init("Teeworlds", &m_pConfig->Values()->m_GfxScreen, &m_pConfig->Values()->m_GfxScreenWidth,
-			&m_pConfig->Values()->m_GfxScreenHeight, &m_ScreenWidth, &m_ScreenHeight, m_pConfig->Values()->m_GfxFsaaSamples,
+	return m_pBackend->Init("Teeworlds", &m_pConfig->m_GfxScreen, &m_pConfig->m_GfxScreenWidth,
+			&m_pConfig->m_GfxScreenHeight, &m_ScreenWidth, &m_ScreenHeight, m_pConfig->m_GfxFsaaSamples,
 			Flags, &m_DesktopScreenWidth, &m_DesktopScreenHeight);
 }
 
@@ -760,12 +760,12 @@ int CGraphics_Threaded::InitWindow()
 		return 0;
 
 	// try disabling fsaa
-	while(m_pConfig->Values()->m_GfxFsaaSamples)
+	while(m_pConfig->m_GfxFsaaSamples)
 	{
-		m_pConfig->Values()->m_GfxFsaaSamples--;
+		m_pConfig->m_GfxFsaaSamples--;
 
-		if(m_pConfig->Values()->m_GfxFsaaSamples)
-			dbg_msg("gfx", "lowering FSAA to %d and trying again", m_pConfig->Values()->m_GfxFsaaSamples);
+		if(m_pConfig->m_GfxFsaaSamples)
+			dbg_msg("gfx", "lowering FSAA to %d and trying again", m_pConfig->m_GfxFsaaSamples);
 		else
 			dbg_msg("gfx", "disabling FSAA and trying again");
 
@@ -774,11 +774,11 @@ int CGraphics_Threaded::InitWindow()
 	}
 
 	// try lowering the resolution
-	if(m_pConfig->Values()->m_GfxScreenWidth != 640 || m_pConfig->Values()->m_GfxScreenHeight != 480)
+	if(m_pConfig->m_GfxScreenWidth != 640 || m_pConfig->m_GfxScreenHeight != 480)
 	{
 		dbg_msg("gfx", "setting resolution to 640x480 and trying again");
-		m_pConfig->Values()->m_GfxScreenWidth = 640;
-		m_pConfig->Values()->m_GfxScreenHeight = 480;
+		m_pConfig->m_GfxScreenWidth = 640;
+		m_pConfig->m_GfxScreenHeight = 480;
 
 		if(IssueInit() == 0)
 			return 0;
@@ -793,7 +793,7 @@ int CGraphics_Threaded::Init()
 {
 	// fetch pointers
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
-	m_pConfig = Kernel()->RequestInterface<IConfig>();
+	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 
 	// init textures
@@ -960,7 +960,7 @@ void CGraphics_Threaded::Swap()
 
 	// add swap command
 	CCommandBuffer::SCommand_Swap Cmd;
-	Cmd.m_Finish = m_pConfig->Values()->m_GfxFinish;
+	Cmd.m_Finish = m_pConfig->m_GfxFinish;
 	m_pCommandBuffer->AddCommand(Cmd);
 
 	// kick the command buffer
@@ -1002,7 +1002,7 @@ void CGraphics_Threaded::WaitForIdle()
 
 int CGraphics_Threaded::GetVideoModes(CVideoMode *pModes, int MaxModes, int Screen)
 {
-	if(m_pConfig->Values()->m_GfxDisplayAllModes)
+	if(m_pConfig->m_GfxDisplayAllModes)
 	{
 		int Count = sizeof(g_aFakeModes)/sizeof(CVideoMode);
 		mem_copy(pModes, g_aFakeModes, sizeof(g_aFakeModes));

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -360,7 +360,7 @@ class CGraphics_Threaded : public IEngineGraphics
 
 	//
 	class IStorage *m_pStorage;
-	class IConfig *m_pConfig;
+	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
 
 	CCommandBuffer::SVertex m_aVertices[MAX_VERTICES];

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -72,7 +72,7 @@ CInput::~CInput()
 void CInput::Init()
 {
 	m_pGraphics = Kernel()->RequestInterface<IEngineGraphics>();
-	m_pConfig = Kernel()->RequestInterface<IConfig>();
+	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	// FIXME: unicode handling: use SDL_StartTextInput/SDL_StopTextInput on inputs
 
@@ -126,7 +126,7 @@ SDL_Joystick* CInput::GetActiveJoystick()
 	{
 		return NULL;
 	}
-	if(m_aSelectedJoystickGUID[0] && str_comp(m_aSelectedJoystickGUID, m_pConfig->Values()->m_JoystickGUID) != 0)
+	if(m_aSelectedJoystickGUID[0] && str_comp(m_aSelectedJoystickGUID, m_pConfig->m_JoystickGUID) != 0)
 	{
 		// Refresh if cached GUID differs from configured GUID
 		m_SelectedJoystickIndex = -1;
@@ -137,10 +137,10 @@ SDL_Joystick* CInput::GetActiveJoystick()
 		{
 			char aGUID[sizeof(m_aSelectedJoystickGUID)];
 			SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(m_apJoysticks[i]), aGUID, sizeof(aGUID));
-			if(str_comp(m_pConfig->Values()->m_JoystickGUID, aGUID) == 0)
+			if(str_comp(m_pConfig->m_JoystickGUID, aGUID) == 0)
 			{
 				m_SelectedJoystickIndex = i;
-				str_copy(m_aSelectedJoystickGUID, m_pConfig->Values()->m_JoystickGUID, sizeof(m_aSelectedJoystickGUID));
+				str_copy(m_aSelectedJoystickGUID, m_pConfig->m_JoystickGUID, sizeof(m_aSelectedJoystickGUID));
 				break;
 			}
 		}
@@ -148,8 +148,8 @@ SDL_Joystick* CInput::GetActiveJoystick()
 		if(m_SelectedJoystickIndex == -1)
 		{
 			m_SelectedJoystickIndex = 0;
-			SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(m_apJoysticks[0]), m_pConfig->Values()->m_JoystickGUID, sizeof(m_pConfig->Values()->m_JoystickGUID));
-			str_copy(m_aSelectedJoystickGUID, m_pConfig->Values()->m_JoystickGUID, sizeof(m_aSelectedJoystickGUID));
+			SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(m_apJoysticks[0]), m_pConfig->m_JoystickGUID, sizeof(m_pConfig->m_JoystickGUID));
+			str_copy(m_aSelectedJoystickGUID, m_pConfig->m_JoystickGUID, sizeof(m_aSelectedJoystickGUID));
 		}
 	}
 	return m_apJoysticks[m_SelectedJoystickIndex];
@@ -173,7 +173,7 @@ void CInput::SelectNextJoystick()
 	if(Num > 1)
 	{
 		const int NextIndex = (m_SelectedJoystickIndex + 1) % Num;
-		SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(m_apJoysticks[NextIndex]), m_pConfig->Values()->m_JoystickGUID, sizeof(m_pConfig->Values()->m_JoystickGUID));
+		SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(m_apJoysticks[NextIndex]), m_pConfig->m_JoystickGUID, sizeof(m_pConfig->m_JoystickGUID));
 	}
 }
 
@@ -204,27 +204,27 @@ void CInput::MouseRelative(float *x, float *y)
 		return;
 
 	int nx = 0, ny = 0;
-	float MouseSens = m_pConfig->Values()->m_InpMousesens/100.0f;
-	float JoystickSens = m_pConfig->Values()->m_JoystickSens/100.0f;
+	float MouseSens = m_pConfig->m_InpMousesens/100.0f;
+	float JoystickSens = m_pConfig->m_JoystickSens/100.0f;
 
 	SDL_GetRelativeMouseState(&nx,&ny);
 
 	vec2 j = vec2(0.0f, 0.0f);
 
-	if(m_pConfig->Values()->m_JoystickEnable && GetActiveJoystick())
+	if(m_pConfig->m_JoystickEnable && GetActiveJoystick())
 	{
 		const float Max = 50.0f;
-		j = vec2(GetJoystickAxisValue(m_pConfig->Values()->m_JoystickX), GetJoystickAxisValue(m_pConfig->Values()->m_JoystickY)) * Max;
+		j = vec2(GetJoystickAxisValue(m_pConfig->m_JoystickX), GetJoystickAxisValue(m_pConfig->m_JoystickY)) * Max;
 		const float Len = length(j);
 
-		if(Len/sqrtf(2.0f) <= m_pConfig->Values()->m_JoystickTolerance)
+		if(Len/sqrtf(2.0f) <= m_pConfig->m_JoystickTolerance)
 		{
 			j = vec2(0.0f, 0.0f);
 		}
 		else
 		{
 			const vec2 nj = Len > 0.0f ? j / Len : vec2(0.0f, 0.0f);
-			j = nj * min(Len, Max) - nj * m_pConfig->Values()->m_JoystickTolerance;
+			j = nj * min(Len, Max) - nj * m_pConfig->m_JoystickTolerance;
 		}
 	}
 
@@ -248,7 +248,7 @@ void CInput::MouseModeRelative()
 	{
 		m_InputGrabbed = 1;
 		SDL_ShowCursor(SDL_DISABLE);
-		if(SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, m_pConfig->Values()->m_InpGrab ? "0" : "1", SDL_HINT_OVERRIDE) == SDL_FALSE)
+		if(SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, m_pConfig->m_InpGrab ? "0" : "1", SDL_HINT_OVERRIDE) == SDL_FALSE)
 		{
 			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "input", "unable to switch relative mouse mode");
 		}

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -8,7 +8,7 @@
 class CInput : public IEngineInput
 {
 	IEngineGraphics *m_pGraphics;
-	IConfig *m_pConfig;
+	CConfig *m_pConfig;
 	IConsole *m_pConsole;
 
 	sorted_array<SDL_Joystick*> m_apJoysticks;

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -79,13 +79,14 @@ CServerBrowser::CServerBrowser()
 
 void CServerBrowser::Init(class CNetClient *pNetClient, const char *pNetVersion)
 {
-	m_pConfig = Kernel()->RequestInterface<IConfig>();
+	IConfigManager *pConfigManager = Kernel()->RequestInterface<IConfigManager>();
+	m_pConfig = pConfigManager->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 	m_pMasterServer = Kernel()->RequestInterface<IMasterServer>();
 	m_pNetClient = pNetClient;
 
-	m_ServerBrowserFavorites.Init(pNetClient, m_pConsole, Kernel()->RequestInterface<IEngine>(), Config());
+	m_ServerBrowserFavorites.Init(pNetClient, m_pConsole, Kernel()->RequestInterface<IEngine>(), pConfigManager);
 	m_ServerBrowserFilter.Init(Config(), Kernel()->RequestInterface<IFriends>(), pNetVersion);
 }
 
@@ -188,7 +189,7 @@ void CServerBrowser::Update(bool ForceResort)
 
 		m_MasterRefreshTime = Now;
 
-		if(Config()->Values()->m_Debug)
+		if(Config()->m_Debug)
 			m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "client_srvbrowse", "requesting server list");
 	}
 
@@ -198,7 +199,7 @@ void CServerBrowser::Update(bool ForceResort)
 		LoadServerlist();
 		m_MasterRefreshTime = 0;
 
-		if(Config()->Values()->m_Debug)
+		if(Config()->m_Debug)
 			m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "client_srvbrowse", "using backup server list");
 	}
 
@@ -229,7 +230,7 @@ void CServerBrowser::Update(bool ForceResort)
 			break;
 
 		// no more then 10 concurrent requests
-		if(Count == Config()->Values()->m_BrMaxRequests)
+		if(Count == Config()->m_BrMaxRequests)
 			break;
 
 		if(pEntry->m_RequestTime == 0)
@@ -302,7 +303,7 @@ void CServerBrowser::Refresh(int RefreshFlags)
 			m_pNetClient->Send(&Packet);
 		}
 
-		if(Config()->Values()->m_Debug)
+		if(Config()->m_Debug)
 			m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "client_srvbrowse", "broadcasting for servers");
 	}
 
@@ -535,7 +536,7 @@ void CServerBrowser::CBFTrackPacket(int TrackID, void *pCallbackUser)
 
 void CServerBrowser::RequestImpl(const NETADDR &Addr, CServerEntry *pEntry)
 {
-	if(Config()->Values()->m_Debug)
+	if(Config()->m_Debug)
 	{
 		char aAddrStr[NETADDR_MAXSTRSIZE];
 		net_addr_str(&Addr, aAddrStr, sizeof(aAddrStr), true);

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -59,7 +59,7 @@ public:
 
 private:
 	class CNetClient *m_pNetClient;
-	class IConfig *m_pConfig;
+	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
 	class IStorage *m_pStorage;
 	class IMasterServer *m_pMasterServer;
@@ -67,7 +67,7 @@ private:
 	class CServerBrowserFavorites m_ServerBrowserFavorites;
 	class CServerBrowserFilter m_ServerBrowserFilter;
 
-	class IConfig *Config() const { return m_pConfig; }
+	class CConfig *Config() const { return m_pConfig; }
 	class IConsole *Console() const { return m_pConsole; }
 	class IStorage *Storage() const { return m_pStorage; }
 

--- a/src/engine/client/serverbrowser_fav.cpp
+++ b/src/engine/client/serverbrowser_fav.cpp
@@ -26,14 +26,14 @@ CServerBrowserFavorites::CServerBrowserFavorites()
 	m_FavLookup.m_Active = false;
 }
 
-void CServerBrowserFavorites::Init(CNetClient *pNetClient, IConsole *pConsole, IEngine *pEngine, IConfig *pConfig)
+void CServerBrowserFavorites::Init(CNetClient *pNetClient, IConsole *pConsole, IEngine *pEngine, IConfigManager *pConfigManager)
 {
 	m_pNetClient = pNetClient;
-	m_pConfig = pConfig;
+	m_pConfig = pConfigManager->Values();
 	m_pConsole = pConsole;
 	m_pEngine = pEngine;
-	if(pConfig)
-		pConfig->RegisterCallback(ConfigSaveCallback, this);
+	if(pConfigManager)
+		pConfigManager->RegisterCallback(ConfigSaveCallback, this);
 
 	m_pConsole->Register("add_favorite", "s?s", CFGFLAG_CLIENT, ConAddFavorite, this, "Add a server (optionally with password) as a favorite. Also updates password of existing favorite.");
 	m_pConsole->Register("remove_favorite", "s", CFGFLAG_CLIENT, ConRemoveFavorite, this, "Remove a server from favorites");
@@ -92,7 +92,7 @@ bool CServerBrowserFavorites::AddFavoriteEx(const char *pHostname, const NETADDR
 
 	++m_NumFavoriteServers;
 
-	if(m_pConfig->Values()->m_Debug)
+	if(m_pConfig->m_Debug)
 	{
 		char aBuf[256];
 		str_format(aBuf, sizeof(aBuf), "added fav '%s'", pHostname);
@@ -255,7 +255,7 @@ void CServerBrowserFavorites::ConRemoveFavorite(IConsole::IResult *pResult, void
 	pSelf->RemoveFavoriteEx(pResult->GetString(0), 0);
 }
 
-void CServerBrowserFavorites::ConfigSaveCallback(IConfig *pConfig, void *pUserData)
+void CServerBrowserFavorites::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
 {
 	CServerBrowserFavorites *pSelf = (CServerBrowserFavorites *)pUserData;
 
@@ -266,6 +266,6 @@ void CServerBrowserFavorites::ConfigSaveCallback(IConfig *pConfig, void *pUserDa
 			str_format(aBuffer, sizeof(aBuffer), "add_favorite \"%s\" \"%s\"", pSelf->m_aFavoriteServers[i].m_aHostname, pSelf->m_aFavoriteServers[i].m_aPassword);
 		else
 			str_format(aBuffer, sizeof(aBuffer), "add_favorite \"%s\"", pSelf->m_aFavoriteServers[i].m_aHostname);
-		pConfig->WriteLine(aBuffer);
+		pConfigManager->WriteLine(aBuffer);
 	}
 }

--- a/src/engine/client/serverbrowser_fav.h
+++ b/src/engine/client/serverbrowser_fav.h
@@ -40,12 +40,12 @@ public:
 	} m_FavLookup;
 
 	class CNetClient *m_pNetClient;
-	class IConfig *m_pConfig;
+	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
 	class IEngine *m_pEngine;
 
 	CServerBrowserFavorites();
-	void Init(class CNetClient *pNetClient, class IConsole *pConsole, class IEngine *pEngine, class IConfig *pConfig);
+	void Init(class CNetClient *pNetClient, class IConsole *pConsole, class IEngine *pEngine, class IConfigManager *pConfigManager);
 	
 	bool AddFavoriteEx(const char *pHostname, const NETADDR *pAddr, bool DoCheck, const char *pPassword = 0);
 	CFavoriteServer *FindFavoriteByAddr(const NETADDR &Addr, int *Index);
@@ -56,7 +56,7 @@ public:
 
 	static void ConAddFavorite(IConsole::IResult *pResult, void *pUserData);
 	static void ConRemoveFavorite(IConsole::IResult *pResult, void *pUserData);
-	static void ConfigSaveCallback(IConfig *pConfig, void *pUserData);
+	static void ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData);
 };
 
 #endif

--- a/src/engine/client/serverbrowser_filter.cpp
+++ b/src/engine/client/serverbrowser_filter.cpp
@@ -19,7 +19,7 @@ class SortWrap
 	CServerBrowserFilter::CServerFilter *m_pThis;
 public:
 	SortWrap(CServerBrowserFilter::CServerFilter *t, SortFunc f) : m_pfnSort(f), m_pThis(t) {}
-	bool operator()(int a, int b) { return (m_pThis->Config()->Values()->m_BrSortOrder ? (m_pThis->*m_pfnSort)(b, a) : (m_pThis->*m_pfnSort)(a, b)); }
+	bool operator()(int a, int b) { return (m_pThis->Config()->m_BrSortOrder ? (m_pThis->*m_pfnSort)(b, a) : (m_pThis->*m_pfnSort)(a, b)); }
 };
 
 //	CServerFilter
@@ -157,14 +157,14 @@ void CServerBrowserFilter::CServerFilter::Filter()
 				}
 			}
 
-			if(!Filtered && Config()->Values()->m_BrFilterString[0] != 0)
+			if(!Filtered && Config()->m_BrFilterString[0] != 0)
 			{
 				int MatchFound = 0;
 
 				m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit = 0;
 
 				// match against server name
-				if(str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aName, Config()->Values()->m_BrFilterString))
+				if(str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aName, Config()->m_BrFilterString))
 				{
 					MatchFound = 1;
 					m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit |= IServerBrowser::QUICK_SERVERNAME;
@@ -173,8 +173,8 @@ void CServerBrowserFilter::CServerFilter::Filter()
 				// match against players
 				for(int p = 0; p < m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_NumClients; p++)
 				{
-					if(str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aClients[p].m_aName, Config()->Values()->m_BrFilterString) ||
-						str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aClients[p].m_aClan, Config()->Values()->m_BrFilterString))
+					if(str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aClients[p].m_aName, Config()->m_BrFilterString) ||
+						str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aClients[p].m_aClan, Config()->m_BrFilterString))
 					{
 						MatchFound = 1;
 						m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit |= IServerBrowser::QUICK_PLAYER;
@@ -183,14 +183,14 @@ void CServerBrowserFilter::CServerFilter::Filter()
 				}
 
 				// match against map
-				if(str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aMap, Config()->Values()->m_BrFilterString))
+				if(str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aMap, Config()->m_BrFilterString))
 				{
 					MatchFound = 1;
 					m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit |= IServerBrowser::QUICK_MAPNAME;
 				}
 
 				// match against game type
-				if(str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aGameType, Config()->Values()->m_BrFilterString))
+				if(str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aGameType, Config()->m_BrFilterString))
 				{
 					MatchFound = 1;
 					m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit |= IServerBrowser::QUICK_GAMETYPE;
@@ -223,8 +223,8 @@ void CServerBrowserFilter::CServerFilter::Filter()
 
 int CServerBrowserFilter::CServerFilter::GetSortHash() const
 {
-	int i = Config()->Values()->m_BrSort&0x7;
-	i |= Config()->Values()->m_BrSortOrder<<3;
+	int i = Config()->m_BrSort&0x7;
+	i |= Config()->m_BrSortOrder<<3;
 	if(m_FilterInfo.m_SortHash&IServerBrowser::FILTER_BOTS) i |= 1<<4;
 	if(m_FilterInfo.m_SortHash&IServerBrowser::FILTER_EMPTY) i |= 1<<5;
 	if(m_FilterInfo.m_SortHash&IServerBrowser::FILTER_FULL) i |= 1<<6;
@@ -245,7 +245,7 @@ void CServerBrowserFilter::CServerFilter::Sort()
 	Filter();
 
 	// sort
-	switch(Config()->Values()->m_BrSort)
+	switch(Config()->m_BrSort)
 	{
 	case IServerBrowser::SORT_NAME:
 		std::stable_sort(m_pSortedServerlist, m_pSortedServerlist+m_NumSortedServers, SortWrap(this, &CServerBrowserFilter::CServerFilter::SortCompareName));
@@ -336,7 +336,7 @@ bool CServerBrowserFilter::CServerFilter::SortCompareNumRealClients(int Index1, 
 }
 
 //	CServerBrowserFilter
-void CServerBrowserFilter::Init(IConfig *pConfig, IFriends *pFriends, const char *pNetVersion)
+void CServerBrowserFilter::Init(CConfig *pConfig, IFriends *pFriends, const char *pNetVersion)
 {
 	m_pConfig = pConfig;
 	m_pFriends = pFriends;

--- a/src/engine/client/serverbrowser_filter.h
+++ b/src/engine/client/serverbrowser_filter.h
@@ -18,7 +18,7 @@ public:
 	{
 	public:
 		CServerBrowserFilter *m_pServerBrowserFilter;
-		IConfig *Config() const { return m_pServerBrowserFilter->m_pConfig; }
+		CConfig *Config() const { return m_pServerBrowserFilter->m_pConfig; }
 
 		// filter settings
 		CServerFilterInfo m_FilterInfo;
@@ -47,10 +47,10 @@ public:
 		bool SortCompareNumClients(int Index1, int Index2) const;
 		bool SortCompareNumRealClients(int Index1, int Index2) const;
 	};
-	IConfig *Config() { return m_pConfig; }
+	CConfig *Config() { return m_pConfig; }
 
 	//
-	void Init(class IConfig *pConfig, class IFriends *pFriends, const char *pNetVersion);
+	void Init(class CConfig *pConfig, class IFriends *pFriends, const char *pNetVersion);
 	void Clear();
 	void Sort(class CServerEntry **ppServerlist, int NumServers, int ResortFlags);
 
@@ -67,7 +67,7 @@ public:
 	int GetNumSortedPlayers(int FilterIndex) const { return m_lFilters[FilterIndex].m_NumSortedPlayers; }
 
 private:
-	class IConfig *m_pConfig;
+	class CConfig *m_pConfig;
 	class IFriends *m_pFriends;
 	char m_aNetVersion[128];
 	array<CServerFilter> m_lFilters;

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -207,7 +207,7 @@ int CSound::Init()
 		m_aChannels[i].m_Vol = 255;
 
 	m_SoundEnabled = 0;
-	m_pConfig = Kernel()->RequestInterface<IConfig>();
+	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pGraphics = Kernel()->RequestInterface<IEngineGraphics>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 
@@ -215,7 +215,7 @@ int CSound::Init()
 
 	m_SoundLock = lock_create();
 
-	if(!m_pConfig->Values()->m_SndInit)
+	if(!m_pConfig->m_SndInit)
 		return 0;
 
 	if(SDL_InitSubSystem(SDL_INIT_AUDIO) < 0)
@@ -224,13 +224,13 @@ int CSound::Init()
 		return -1;
 	}
 
-	m_MixingRate = m_pConfig->Values()->m_SndRate;
+	m_MixingRate = m_pConfig->m_SndRate;
 
 	// Set 16-bit stereo audio at 22Khz
-	Format.freq = m_pConfig->Values()->m_SndRate; // ignore_convention
+	Format.freq = m_pConfig->m_SndRate; // ignore_convention
 	Format.format = AUDIO_S16; // ignore_convention
 	Format.channels = 2; // ignore_convention
-	Format.samples = m_pConfig->Values()->m_SndBufferSize; // ignore_convention
+	Format.samples = m_pConfig->m_SndBufferSize; // ignore_convention
 	Format.callback = SdlCallback; // ignore_convention
 	Format.userdata = NULL; // ignore_convention
 
@@ -243,7 +243,7 @@ int CSound::Init()
 	else
 		dbg_msg("client/sound", "sound init successful");
 
-	m_MaxFrames = m_pConfig->Values()->m_SndBufferSize*2;
+	m_MaxFrames = m_pConfig->m_SndBufferSize*2;
 	m_pMixBuffer = (int *)mem_alloc(m_MaxFrames*2*sizeof(int), 1);
 
 	SDL_PauseAudio(0);
@@ -256,9 +256,9 @@ int CSound::Init()
 int CSound::Update()
 {
 	// update volume
-	int WantedVolume = m_pConfig->Values()->m_SndVolume;
+	int WantedVolume = m_pConfig->m_SndVolume;
 
-	if(!m_pGraphics->WindowActive() && m_pConfig->Values()->m_SndNonactiveMute)
+	if(!m_pGraphics->WindowActive() && m_pConfig->m_SndNonactiveMute)
 		WantedVolume = 0;
 
 	if(WantedVolume != m_SoundVolume)
@@ -379,7 +379,7 @@ ISound::CSampleHandle CSound::LoadWV(const char *pFilename)
 	WavpackContext *pContext;
 
 	// don't waste memory on sound when we are stress testing
-	if(m_pConfig->Values()->m_DbgStress)
+	if(m_pConfig->m_DbgStress)
 		return CSampleHandle();
 
 	// no need to load sound when we are running with no sound
@@ -483,7 +483,7 @@ ISound::CSampleHandle CSound::LoadWV(const char *pFilename)
 	io_close(s_File);
 	s_File = NULL;
 
-	if(m_pConfig->Values()->m_Debug)
+	if(m_pConfig->m_Debug)
 		dbg_msg("sound/wv", "loaded %s", pFilename);
 
 	RateConvert(SampleID);

--- a/src/engine/client/sound.h
+++ b/src/engine/client/sound.h
@@ -10,7 +10,7 @@ class CSound : public IEngineSound
 	int m_SoundEnabled;
 
 public:
-	IConfig *m_pConfig;
+	CConfig *m_pConfig;
 	IEngineGraphics *m_pGraphics;
 	IStorage *m_pStorage;
 

--- a/src/engine/config.h
+++ b/src/engine/config.h
@@ -5,23 +5,23 @@
 
 #include "kernel.h"
 
-class IConfig : public IInterface
+class IConfigManager : public IInterface
 {
 	MACRO_INTERFACE("config", 0)
 public:
-	typedef void (*SAVECALLBACKFUNC)(IConfig *pConfig, void *pUserData);
+	typedef void (*SAVECALLBACKFUNC)(IConfigManager *pConfigManager, void *pUserData);
 
 	virtual void Init(int FlagMask) = 0;
 	virtual void Reset() = 0;
 	virtual void RestoreStrings() = 0;
 	virtual void Save(const char *pFilename=0) = 0;
-	virtual class CConfiguration *Values() = 0;
+	virtual class CConfig *Values() = 0;
 
 	virtual void RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData) = 0;
 
 	virtual void WriteLine(const char *pLine) = 0;
 };
 
-extern IConfig *CreateConfig();
+extern IConfigManager *CreateConfigManager();
 
 #endif

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -46,7 +46,7 @@ void CRegister::RegisterSendFwcheckresponse(NETADDR *pAddr, TOKEN Token)
 void CRegister::RegisterSendHeartbeat(NETADDR Addr)
 {
 	static unsigned char aData[sizeof(SERVERBROWSE_HEARTBEAT) + 2];
-	unsigned short Port = m_pConfig->Values()->m_SvPort;
+	unsigned short Port = m_pConfig->m_SvPort;
 	CNetChunk Packet;
 
 	mem_copy(aData, SERVERBROWSE_HEARTBEAT, sizeof(SERVERBROWSE_HEARTBEAT));
@@ -58,8 +58,8 @@ void CRegister::RegisterSendHeartbeat(NETADDR Addr)
 	Packet.m_pData = &aData;
 
 	// supply the set port that the master can use if it has problems
-	if(m_pConfig->Values()->m_SvExternalPort)
-		Port = m_pConfig->Values()->m_SvExternalPort;
+	if(m_pConfig->m_SvExternalPort)
+		Port = m_pConfig->m_SvExternalPort;
 	aData[sizeof(SERVERBROWSE_HEARTBEAT)] = Port >> 8;
 	aData[sizeof(SERVERBROWSE_HEARTBEAT)+1] = Port&0xff;
 	m_pNetServer->Send(&Packet);
@@ -91,7 +91,7 @@ void CRegister::RegisterGotCount(CNetChunk *pChunk)
 	}
 }
 
-void CRegister::Init(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, IConfig *pConfig, IConsole *pConsole)
+void CRegister::Init(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, CConfig *pConfig, IConsole *pConsole)
 {
 	m_pNetServer = pNetServer;
 	m_pMasterServer = pMasterServer;
@@ -104,7 +104,7 @@ void CRegister::RegisterUpdate(int Nettype)
 	int64 Now = time_get();
 	int64 Freq = time_freq();
 
-	if(!m_pConfig->Values()->m_SvRegister)
+	if(!m_pConfig->m_SvRegister)
 		return;
 
 	m_pMasterServer->Update();
@@ -276,7 +276,7 @@ int CRegister::RegisterProcessPacket(CNetChunk *pPacket, TOKEN Token)
 	{
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "register", "ERROR: the master server reports that clients can not connect to this server.");
 		char aBuf[256];
-		str_format(aBuf, sizeof(aBuf), "ERROR: configure your firewall/nat to let through udp on port %d.", m_pConfig->Values()->m_SvPort);
+		str_format(aBuf, sizeof(aBuf), "ERROR: configure your firewall/nat to let through udp on port %d.", m_pConfig->m_SvPort);
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "register", aBuf);
 		RegisterNewState(REGISTERSTATE_ERROR);
 		return 1;

--- a/src/engine/server/register.h
+++ b/src/engine/server/register.h
@@ -27,7 +27,7 @@ class CRegister
 
 	class CNetServer *m_pNetServer;
 	class IEngineMasterServer *m_pMasterServer;
-	class IConfig *m_pConfig;
+	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
 
 	int m_RegisterState;
@@ -46,7 +46,7 @@ class CRegister
 
 public:
 	CRegister();
-	void Init(class CNetServer *pNetServer, class IEngineMasterServer *pMasterServer, class IConfig *pConfig, class IConsole *pConsole);
+	void Init(class CNetServer *pNetServer, class IEngineMasterServer *pMasterServer, class CConfig *pConfig, class IConsole *pConsole);
 	void RegisterUpdate(int Nettype);
 	int RegisterProcessPacket(struct CNetChunk *pPacket, TOKEN Token);
 };

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -62,12 +62,12 @@ public:
 class CServer : public IServer
 {
 	class IGameServer *m_pGameServer;
-	class IConfig *m_pConfig;
+	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
 	class IStorage *m_pStorage;
 public:
 	class IGameServer *GameServer() { return m_pGameServer; }
-	class IConfig *Config() { return m_pConfig; }
+	class CConfig *Config() { return m_pConfig; }
 	class IConsole *Console() { return m_pConsole; }
 	class IStorage *Storage() { return m_pStorage; }
 
@@ -256,7 +256,7 @@ public:
 	const char *GetMapName();
 	int LoadMap(const char *pMapName);
 
-	void InitRegister(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, IConfig *pConfig, IConsole *pConsole);
+	void InitRegister(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, CConfig *pConfig, IConsole *pConsole);
 	int Run();
 
 	static int MapListEntryCallback(const char *pFilename, int IsDir, int DirType, void *pUser);

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -29,10 +29,10 @@ static void Con_SaveConfig(IConsole::IResult *pResult, void *pUserData)
 		str_timestamp(aDate, sizeof(aDate));
 		str_format(aFilename, sizeof(aFilename), "configs/config_%s.cfg", aDate);
 	}
-	((CConfig*)pUserData)->Save(aFilename);
+	((CConfigManager *)pUserData)->Save(aFilename);
 }
 
-CConfig::CConfig()
+CConfigManager::CConfigManager()
 {
 	m_pStorage = 0;
 	m_pConsole = 0;
@@ -41,7 +41,7 @@ CConfig::CConfig()
 	m_NumCallbacks = 0;
 }
 
-void CConfig::Init(int FlagMask)
+void CConfigManager::Init(int FlagMask)
 {
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
@@ -52,7 +52,7 @@ void CConfig::Init(int FlagMask)
 		m_pConsole->Register("save_config", "?s", CFGFLAG_SERVER|CFGFLAG_CLIENT|CFGFLAG_STORE, Con_SaveConfig, this, "Save config to file");
 }
 
-void CConfig::Reset()
+void CConfigManager::Reset()
 {
 	#define MACRO_CONFIG_INT(Name,ScriptName,def,min,max,flags,desc) m_Values.m_##Name = def;
 	#define MACRO_CONFIG_STR(Name,ScriptName,len,def,flags,desc) str_copy(m_Values.m_##Name, def, len);
@@ -63,7 +63,7 @@ void CConfig::Reset()
 	#undef MACRO_CONFIG_STR
 }
 
-void CConfig::RestoreStrings()
+void CConfigManager::RestoreStrings()
 {
 	#define MACRO_CONFIG_INT(Name,ScriptName,def,min,max,flags,desc)	// nop
 	#define MACRO_CONFIG_STR(Name,ScriptName,len,def,flags,desc) if(!m_Values.m_##Name[0] && def[0]) str_copy(m_Values.m_##Name, def, len);
@@ -74,7 +74,7 @@ void CConfig::RestoreStrings()
 	#undef MACRO_CONFIG_STR
 }
 
-void CConfig::Save(const char *pFilename)
+void CConfigManager::Save(const char *pFilename)
 {
 	if(!m_pStorage)
 		return;
@@ -112,7 +112,7 @@ void CConfig::Save(const char *pFilename)
 	}
 }
 
-void CConfig::RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData)
+void CConfigManager::RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData)
 {
 	dbg_assert(m_NumCallbacks < MAX_CALLBACKS, "too many config callbacks");
 	m_aCallbacks[m_NumCallbacks].m_pfnFunc = pfnFunc;
@@ -120,7 +120,7 @@ void CConfig::RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData)
 	m_NumCallbacks++;
 }
 
-void CConfig::WriteLine(const char *pLine)
+void CConfigManager::WriteLine(const char *pLine)
 {
 	if(!m_ConfigFile)
 		return;
@@ -129,4 +129,4 @@ void CConfig::WriteLine(const char *pLine)
 	io_write_newline(m_ConfigFile);
 }
 
-IConfig *CreateConfig() { return new CConfig; }
+IConfigManager *CreateConfigManager() { return new CConfigManager; }

--- a/src/engine/shared/config.h
+++ b/src/engine/shared/config.h
@@ -5,7 +5,7 @@
 
 #include <engine/config.h>
 
-class CConfiguration
+class CConfig
 {
 public:
 	#define MACRO_CONFIG_INT(Name,ScriptName,Def,Min,Max,Save,Desc) int m_##Name;
@@ -26,7 +26,7 @@ enum
 	CFGFLAG_BASICACCESS=64,
 };
 
-class CConfig : public IConfig
+class CConfigManager : public IConfigManager
 {
 	enum
 	{
@@ -45,16 +45,16 @@ class CConfig : public IConfig
 	int m_FlagMask;
 	CCallback m_aCallbacks[MAX_CALLBACKS];
 	int m_NumCallbacks;
-	CConfiguration m_Values;
+	CConfig m_Values;
 
 public:
-	CConfig();
+	CConfigManager();
 
 	virtual void Init(int FlagMask);
 	virtual void Reset();
 	virtual void RestoreStrings();
 	virtual void Save(const char *pFilename);
-	virtual CConfiguration *Values() { return &m_Values; }
+	virtual CConfig *Values() { return &m_Values; }
 
 	virtual void RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData);
 

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -712,19 +712,19 @@ CConsole::~CConsole()
 
 void CConsole::Init()
 {
-	m_pConfig = Kernel()->RequestInterface<IConfig>();
+	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 
 	// TODO: this should disappear
 	#define MACRO_CONFIG_INT(Name,ScriptName,Def,Min,Max,Flags,Desc) \
 	{ \
-		static CIntVariableData Data = { this, &m_pConfig->Values()->m_##Name, Min, Max }; \
+		static CIntVariableData Data = { this, &m_pConfig->m_##Name, Min, Max }; \
 		Register(#ScriptName, "?i", Flags, IntVariableCommand, &Data, Desc); \
 	}
 
 	#define MACRO_CONFIG_STR(Name,ScriptName,Len,Def,Flags,Desc) \
 	{ \
-		static CStrVariableData Data = { this, m_pConfig->Values()->m_##Name, Len }; \
+		static CStrVariableData Data = { this, m_pConfig->m_##Name, Len }; \
 		Register(#ScriptName, "?r", Flags, StrVariableCommand, &Data, Desc); \
 	}
 

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -47,7 +47,7 @@ class CConsole : public IConsole
 	};
 
 	CExecFile *m_pFirstExec;
-	class IConfig *m_pConfig;
+	class CConfig *m_pConfig;
 	class IStorage *m_pStorage;
 	int m_AccessLevel;
 

--- a/src/engine/shared/econ.cpp
+++ b/src/engine/shared/econ.cpp
@@ -60,7 +60,7 @@ void CEcon::ConLogout(IConsole::IResult *pResult, void *pUserData)
 		pThis->m_NetConsole.Drop(pThis->m_UserClientID, "Logout");
 }
 
-void CEcon::Init(IConfig *pConfig, IConsole *pConsole, CNetBan *pNetBan)
+void CEcon::Init(CConfig *pConfig, IConsole *pConsole, CNetBan *pNetBan)
 {
 	m_pConfig = pConfig;
 	m_pConsole = pConsole;
@@ -71,32 +71,32 @@ void CEcon::Init(IConfig *pConfig, IConsole *pConsole, CNetBan *pNetBan)
 	m_Ready = false;
 	m_UserClientID = -1;
 
-	if(m_pConfig->Values()->m_EcPort == 0 || m_pConfig->Values()->m_EcPassword[0] == 0)
+	if(m_pConfig->m_EcPort == 0 || m_pConfig->m_EcPassword[0] == 0)
 		return;
 
 	NETADDR BindAddr;
-	if(m_pConfig->Values()->m_EcBindaddr[0] && net_host_lookup(m_pConfig->Values()->m_EcBindaddr, &BindAddr, NETTYPE_ALL) == 0)
+	if(m_pConfig->m_EcBindaddr[0] && net_host_lookup(m_pConfig->m_EcBindaddr, &BindAddr, NETTYPE_ALL) == 0)
 	{
 		// got bindaddr
 		BindAddr.type = NETTYPE_ALL;
-		BindAddr.port = m_pConfig->Values()->m_EcPort;
+		BindAddr.port = m_pConfig->m_EcPort;
 	}
 	else
 	{
 		mem_zero(&BindAddr, sizeof(BindAddr));
 		BindAddr.type = NETTYPE_ALL;
-		BindAddr.port = m_pConfig->Values()->m_EcPort;
+		BindAddr.port = m_pConfig->m_EcPort;
 	}
 
 	if(m_NetConsole.Open(BindAddr, pNetBan, NewClientCallback, DelClientCallback, this))
 	{
 		m_Ready = true;
 		char aBuf[128];
-		str_format(aBuf, sizeof(aBuf), "bound to %s:%d", m_pConfig->Values()->m_EcBindaddr, m_pConfig->Values()->m_EcPort);
+		str_format(aBuf, sizeof(aBuf), "bound to %s:%d", m_pConfig->m_EcBindaddr, m_pConfig->m_EcPort);
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD,"econ", aBuf);
 
 		Console()->Chain("ec_output_level", ConchainEconOutputLevelUpdate, this);
-		m_PrintCBIndex = Console()->RegisterPrintCallback(m_pConfig->Values()->m_EcOutputLevel, SendLineCB, this);
+		m_PrintCBIndex = Console()->RegisterPrintCallback(m_pConfig->m_EcOutputLevel, SendLineCB, this);
 
 		Console()->Register("logout", "", CFGFLAG_ECON, ConLogout, this, "Logout of econ");
 	}
@@ -119,7 +119,7 @@ void CEcon::Update()
 		dbg_assert(m_aClients[ClientID].m_State != CClient::STATE_EMPTY, "got message from empty slot");
 		if(m_aClients[ClientID].m_State == CClient::STATE_CONNECTED)
 		{
-			if(str_comp(aBuf, m_pConfig->Values()->m_EcPassword) == 0)
+			if(str_comp(aBuf, m_pConfig->m_EcPassword) == 0)
 			{
 				m_aClients[ClientID].m_State = CClient::STATE_AUTHED;
 				m_NetConsole.Send(ClientID, "Authentication successful. External console access granted.");
@@ -135,8 +135,8 @@ void CEcon::Update()
 				m_NetConsole.Send(ClientID, aMsg);
 				if(m_aClients[ClientID].m_AuthTries >= MAX_AUTH_TRIES)
 				{
-					if(m_pConfig->Values()->m_EcBantime)
-						m_NetConsole.NetBan()->BanAddr(m_NetConsole.ClientAddr(ClientID), m_pConfig->Values()->m_EcBantime*60, "Too many authentication tries");
+					if(m_pConfig->m_EcBantime)
+						m_NetConsole.NetBan()->BanAddr(m_NetConsole.ClientAddr(ClientID), m_pConfig->m_EcBantime*60, "Too many authentication tries");
 					m_NetConsole.Drop(ClientID, "Too many authentication tries");
 				}
 			}
@@ -155,7 +155,7 @@ void CEcon::Update()
 	for(int i = 0; i < NET_MAX_CONSOLE_CLIENTS; ++i)
 	{
 		if(m_aClients[i].m_State == CClient::STATE_CONNECTED &&
-			time_get() > m_aClients[i].m_TimeConnected + m_pConfig->Values()->m_EcAuthTimeout * time_freq())
+			time_get() > m_aClients[i].m_TimeConnected + m_pConfig->m_EcAuthTimeout * time_freq())
 			m_NetConsole.Drop(i, "authentication timeout");
 	}
 }

--- a/src/engine/shared/econ.h
+++ b/src/engine/shared/econ.h
@@ -27,7 +27,7 @@ class CEcon
 	};
 	CClient m_aClients[NET_MAX_CONSOLE_CLIENTS];
 
-	IConfig *m_pConfig;
+	CConfig *m_pConfig;
 	IConsole *m_pConsole;
 	CNetConsole m_NetConsole;
 
@@ -45,7 +45,7 @@ class CEcon
 public:
 	IConsole *Console() { return m_pConsole; }
 
-	void Init(IConfig *pConfig, IConsole *pConsole, class CNetBan *pNetBan);
+	void Init(CConfig *pConfig, IConsole *pConsole, class CNetBan *pNetBan);
 	void Update();
 	void Send(int ClientID, const char *pLine);
 	void Shutdown();

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -20,7 +20,7 @@ static int HostLookupThread(void *pUser)
 class CEngine : public IEngine
 {
 public:
-	IConfig *m_pConfig;
+	CConfig *m_pConfig;
 	IConsole *m_pConsole;
 	IStorage *m_pStorage;
 	bool m_Logging;
@@ -73,7 +73,7 @@ public:
 
 	void Init()
 	{
-		m_pConfig = Kernel()->RequestInterface<IConfig>();
+		m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 		m_pConsole = Kernel()->RequestInterface<IConsole>();
 		m_pStorage = Kernel()->RequestInterface<IStorage>();
 
@@ -88,15 +88,15 @@ public:
 	void InitLogfile()
 	{
 		// open logfile if needed
-		if(m_pConfig->Values()->m_Logfile[0])
+		if(m_pConfig->m_Logfile[0])
 		{
 			char aBuf[32];
-			if(m_pConfig->Values()->m_LogfileTimestamp)
+			if(m_pConfig->m_LogfileTimestamp)
 				str_timestamp(aBuf, sizeof(aBuf));
 			else
 				aBuf[0] = 0;
 			char aLogFilename[128];			
-			str_format(aLogFilename, sizeof(aLogFilename), "dumps/%s%s.txt", m_pConfig->Values()->m_Logfile, aBuf);
+			str_format(aLogFilename, sizeof(aLogFilename), "dumps/%s%s.txt", m_pConfig->m_Logfile, aBuf);
 			IOHANDLE Handle = m_pStorage->OpenFile(aLogFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
 			if(Handle)
 				dbg_logger_filehandle(Handle);
@@ -114,7 +114,7 @@ public:
 
 	void AddJob(CJob *pJob, JOBFUNC pfnFunc, void *pData)
 	{
-		if(m_pConfig->Values()->m_Debug)
+		if(m_pConfig->m_Debug)
 			dbg_msg("engine", "job added");
 		m_JobPool.Add(pJob, pfnFunc, pData);
 	}

--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -70,7 +70,7 @@ int CNetRecvUnpacker::FetchChunk(CNetChunk *pChunk)
 					continue;
 
 				// out of sequence, request resend
-				if(CNetBase::Config()->Values()->m_Debug)
+				if(CNetBase::Config()->m_Debug)
 					dbg_msg("conn", "asking for resend %d %d", Header.m_Sequence, (m_pConnection->m_Ack+1)%NET_MAX_SEQUENCE);
 				m_pConnection->SignalResend();
 				continue; // take the next chunk in the packet
@@ -195,7 +195,7 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 	// check the size
 	if(Size < NET_PACKETHEADERSIZE || Size > NET_MAX_PACKETSIZE)
 	{
-		if(m_pConfig->Values()->m_Debug)
+		if(m_pConfig->m_Debug)
 			dbg_msg("network", "packet too small, size=%d", Size);
 		return -1;
 	}
@@ -208,7 +208,7 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 	{
 		if(Size < NET_PACKETHEADERSIZE_CONNLESS)
 		{
-			if(m_pConfig->Values()->m_Debug)
+			if(m_pConfig->m_Debug)
 				dbg_msg("net", "connless packet too small, size=%d", Size);
 			return -1;
 		}
@@ -233,7 +233,7 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 	{
 		if(Size - NET_PACKETHEADERSIZE > NET_MAX_PAYLOAD)
 		{
-			if(m_pConfig->Values()->m_Debug)
+			if(m_pConfig->m_Debug)
 				dbg_msg("network", "packet payload too big, size=%d", Size);
 			return -1;
 		}
@@ -257,7 +257,7 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 	// check for errors
 	if(pPacket->m_DataSize < 0)
 	{
-		if(m_pConfig->Values()->m_Debug)
+		if(m_pConfig->m_Debug)
 			dbg_msg("network", "error during packet decoding");
 		return -1;
 	}
@@ -369,7 +369,7 @@ int CNetBase::IsSeqInBackroom(int Seq, int Ack)
 IOHANDLE CNetBase::ms_DataLogSent = 0;
 IOHANDLE CNetBase::ms_DataLogRecv = 0;
 CHuffman CNetBase::ms_Huffman;
-IConfig *CNetBase::m_pConfig = 0;	// todo: fix me
+CConfig *CNetBase::m_pConfig = 0; // todo: fix me
 
 void CNetBase::OpenLog(IOHANDLE DataLogSent, IOHANDLE DataLogRecv)
 {
@@ -433,7 +433,7 @@ static const unsigned gs_aFreqTable[256+1] = {
 	12,18,18,27,20,18,15,19,11,17,33,12,18,15,19,18,16,26,17,18,
 	9,10,25,22,22,17,20,16,6,16,15,20,14,18,24,335,1517};
 
-void CNetBase::Init(IConfig *pConfig)
+void CNetBase::Init(CConfig *pConfig)
 {
 	m_pConfig = pConfig;
 	ms_Huffman.Init(gs_aFreqTable);

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -531,15 +531,15 @@ public:
 // TODO: both, fix these. This feels like a junk class for stuff that doesn't fit anywere
 class CNetBase
 {
-	static class IConfig *m_pConfig;
+	static class CConfig *m_pConfig;
 	static IOHANDLE ms_DataLogSent;
 	static IOHANDLE ms_DataLogRecv;
 	static CHuffman ms_Huffman;
 public:
-	static IConfig *Config() { return m_pConfig; }
+	static CConfig *Config() { return m_pConfig; }
 	static void OpenLog(IOHANDLE DataLogSent, IOHANDLE DataLogRecv);
 	static void CloseLog();
-	static void Init(class IConfig *pConfig);
+	static void Init(class CConfig *pConfig);
 	static int Compress(const void *pData, int DataSize, void *pOutput, int OutputSize);
 	static int Decompress(const void *pData, int DataSize, void *pOutput, int OutputSize);
 

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -286,7 +286,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr)
 					SetError(Str);
 				}
 
-				if(CNetBase::Config()->Values()->m_Debug)
+				if(CNetBase::Config()->m_Debug)
 					dbg_msg("conn", "closed reason='%s'", Str);
 			}
 			return 0;
@@ -304,7 +304,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr)
 					SendControlWithToken(NET_CTRLMSG_CONNECT);
 					dbg_msg("connection", "got token, replying, token=%x mytoken=%x", m_PeerToken, m_Token);
 				}
-				else if(CNetBase::Config()->Values()->m_Debug)
+				else if(CNetBase::Config()->m_Debug)
 					dbg_msg("connection", "got token, token=%x", m_PeerToken);
 			}
 			else
@@ -325,7 +325,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr)
 						m_LastRecvTime = Now;
 						m_LastUpdateTime = Now;
 						SendControl(NET_CTRLMSG_CONNECTACCEPT, 0, 0);
-						if(CNetBase::Config()->Values()->m_Debug)
+						if(CNetBase::Config()->m_Debug)
 							dbg_msg("connection", "got connection, sending connect+accept");
 					}
 				}
@@ -337,7 +337,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr)
 						m_LastRecvTime = Now;
 						SendControl(NET_CTRLMSG_ACCEPT, 0, 0);
 						m_State = NET_CONNSTATE_ONLINE;
-						if(CNetBase::Config()->Values()->m_Debug)
+						if(CNetBase::Config()->m_Debug)
 							dbg_msg("connection", "got connect+accept, sending accept. connection online");
 					}
 				}
@@ -350,7 +350,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr)
 		{
 			m_LastRecvTime = Now;
 			m_State = NET_CONNSTATE_ONLINE;
-			if(CNetBase::Config()->Values()->m_Debug)
+			if(CNetBase::Config()->m_Debug)
 				dbg_msg("connection", "connecting online");
 		}
 	}
@@ -410,7 +410,7 @@ int CNetConnection::Update()
 		if(time_get()-m_LastSendTime > time_freq()/2) // flush connection after 500ms if needed
 		{
 			int NumFlushedChunks = Flush();
-			if(NumFlushedChunks && CNetBase::Config()->Values()->m_Debug)
+			if(NumFlushedChunks && CNetBase::Config()->m_Debug)
 				dbg_msg("connection", "flushed connection due to timeout. %d chunks.", NumFlushedChunks);
 		}
 

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -23,7 +23,7 @@ protected:
 	class CUI *UI() const { return m_pClient->UI(); }
 	class ISound *Sound() const { return m_pClient->Sound(); }
 	class CRenderTools *RenderTools() const { return m_pClient->RenderTools(); }
-	class IConfig *Config() const { return m_pClient->Config(); }
+	class CConfig *Config() const { return m_pClient->Config(); }
 	class IConsole *Console() const { return m_pClient->Console(); }
 	class IDemoPlayer *DemoPlayer() const { return m_pClient->DemoPlayer(); }
 	class IDemoRecorder *DemoRecorder() const { return m_pClient->DemoRecorder(); }

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -264,9 +264,9 @@ void CBinds::SetDefaults()
 void CBinds::OnConsoleInit()
 {
 	// bindings
-	IConfig *pConfig = Kernel()->RequestInterface<IConfig>();
-	if(pConfig)
-		pConfig->RegisterCallback(ConfigSaveCallback, this);
+	IConfigManager *pConfigManager = Kernel()->RequestInterface<IConfigManager>();
+	if(pConfigManager)
+		pConfigManager->RegisterCallback(ConfigSaveCallback, this);
 
 	Console()->Register("bind", "sr", CFGFLAG_CLIENT, ConBind, this, "Bind key to execute the command");
 	Console()->Register("unbind", "s", CFGFLAG_CLIENT, ConUnbind, this, "Unbind key");
@@ -398,7 +398,7 @@ const char *CBinds::GetModifierName(int m)
 	}
 }
 
-void CBinds::ConfigSaveCallback(IConfig *pConfig, void *pUserData)
+void CBinds::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
 {
 	CBinds *pSelf = (CBinds *)pUserData;
 
@@ -426,7 +426,7 @@ void CBinds::ConfigSaveCallback(IConfig *pConfig, void *pUserData)
 			*pDst++ = '"';
 			*pDst++ = 0;
 
-			pConfig->WriteLine(aBuffer);
+			pConfigManager->WriteLine(aBuffer);
 		}
 	}
 
@@ -438,7 +438,7 @@ void CBinds::ConfigSaveCallback(IConfig *pConfig, void *pUserData)
 		{
 			// explicitly unbind keys that were unbound by the user
 			str_format(aBuffer, sizeof(aBuffer), "unbind %s%s ", GetModifierName(Modifier), pSelf->Input()->KeyName(Key));
-			pConfig->WriteLine(aBuffer);
+			pConfigManager->WriteLine(aBuffer);
 		}
 	}
 }

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -15,7 +15,7 @@ class CBinds : public CComponent
 	static void ConDumpBinds(IConsole::IResult *pResult, void *pUserData);
 	class IConsole *GetConsole() const { return Console(); }
 
-	static void ConfigSaveCallback(class IConfig *pConfig, void *pUserData);
+	static void ConfigSaveCallback(class IConfigManager *pConfigManager, void *pUserData);
 
 public:
 	CBinds();

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -41,10 +41,10 @@ inline bool IsCharWhitespace(char c)
 
 void CBroadcast::RenderServerBroadcast()
 {
-	if(!Config()->Values()->m_ClShowServerBroadcast || m_pClient->m_MuteServerBroadcast)
+	if(!Config()->m_ClShowServerBroadcast || m_pClient->m_MuteServerBroadcast)
 		return;
 
-	const bool ColoredBroadcastEnabled = Config()->Values()->m_ClColoredBroadcast;
+	const bool ColoredBroadcastEnabled = Config()->m_ClColoredBroadcast;
 	const float Height = 300;
 	const float Width = Height*Graphics()->ScreenAspect();
 
@@ -259,7 +259,7 @@ void CBroadcast::OnReset()
 void CBroadcast::OnMessage(int MsgType, void* pRawMsg)
 {
 	// process server broadcast message
-	if(MsgType == NETMSGTYPE_SV_BROADCAST && Config()->Values()->m_ClShowServerBroadcast &&
+	if(MsgType == NETMSGTYPE_SV_BROADCAST && Config()->m_ClShowServerBroadcast &&
 	   !m_pClient->m_MuteServerBroadcast)
 	{
 		CNetMsg_Sv_Broadcast *pMsg = (CNetMsg_Sv_Broadcast *)pRawMsg;

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -63,10 +63,10 @@ void CCamera::OnRender()
 			vec2 CameraOffset(0, 0);
 
 			float l = length(m_pClient->m_pControls->m_MousePos);
-			if(Config()->Values()->m_ClDynamicCamera && l > 0.0001f) // make sure that this isn't 0
+			if(Config()->m_ClDynamicCamera && l > 0.0001f) // make sure that this isn't 0
 			{
-				float DeadZone = Config()->Values()->m_ClMouseDeadzone;
-				float FollowFactor = Config()->Values()->m_ClMouseFollowfactor/100.0f;
+				float DeadZone = Config()->m_ClMouseDeadzone;
+				float FollowFactor = Config()->m_ClMouseFollowfactor/100.0f;
 				float OffsetAmount = max(l-DeadZone, 0.0f) * FollowFactor;
 
 				CameraOffset = normalize(m_pClient->m_pControls->m_MousePos)*OffsetAmount;
@@ -83,22 +83,22 @@ void CCamera::OnRender()
 		m_Zoom = 0.7f;
 		static vec2 Dir = vec2(1.0f, 0.0f);
 
-		if(distance(m_Center, m_RotationCenter) <= (float)Config()->Values()->m_ClRotationRadius+0.5f)
+		if(distance(m_Center, m_RotationCenter) <= (float)Config()->m_ClRotationRadius+0.5f)
 		{
 			// do little rotation
-			float RotPerTick = 360.0f/(float)Config()->Values()->m_ClRotationSpeed * Client()->RenderFrameTime();
+			float RotPerTick = 360.0f/(float)Config()->m_ClRotationSpeed * Client()->RenderFrameTime();
 			Dir = rotate(Dir, RotPerTick);
-			m_Center = m_RotationCenter+Dir*(float)Config()->Values()->m_ClRotationRadius;
+			m_Center = m_RotationCenter+Dir*(float)Config()->m_ClRotationRadius;
 		}
 		else
 		{
 			// positions for the animation
 			Dir = normalize(m_AnimationStartPos - m_RotationCenter);
-			vec2 TargetPos = m_RotationCenter + Dir * (float)Config()->Values()->m_ClRotationRadius;
+			vec2 TargetPos = m_RotationCenter + Dir * (float)Config()->m_ClRotationRadius;
 			float Distance = distance(m_AnimationStartPos, TargetPos);
 
 			// move time
-			m_MoveTime += Client()->RenderFrameTime()*Config()->Values()->m_ClCameraSpeed / 10.0f;
+			m_MoveTime += Client()->RenderFrameTime()*Config()->m_ClCameraSpeed / 10.0f;
 			float XVal = 1 - m_MoveTime;
 			XVal = pow(XVal, 7.0f);
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -535,10 +535,10 @@ void CChat::OnMessage(int MsgType, void *pRawMsg)
 
 void CChat::AddLine(const char *pLine, int ClientID, int Mode, int TargetID)
 {
-	if(*pLine == 0 || (ClientID >= 0 && (!Config()->Values()->m_ClShowsocial || !m_pClient->m_aClients[ClientID].m_Active || // unknown client
+	if(*pLine == 0 || (ClientID >= 0 && (!Config()->m_ClShowsocial || !m_pClient->m_aClients[ClientID].m_Active || // unknown client
 		m_pClient->m_aClients[ClientID].m_ChatIgnore ||
-		Config()->Values()->m_ClFilterchat == 2 ||
-		(m_pClient->m_LocalClientID != ClientID && Config()->Values()->m_ClFilterchat == 1 && !m_pClient->m_aClients[ClientID].m_Friend))))
+		Config()->m_ClFilterchat == 2 ||
+		(m_pClient->m_LocalClientID != ClientID && Config()->m_ClFilterchat == 1 && !m_pClient->m_aClients[ClientID].m_Friend))))
 		return;
 
 	if(Mode == CHAT_WHISPER)
@@ -550,8 +550,8 @@ void CChat::AddLine(const char *pLine, int ClientID, int Mode, int TargetID)
 		if(ClientID != m_pClient->m_LocalClientID && TargetID != m_pClient->m_LocalClientID)
 			return;
 		// ignore and chat filter
-		if(m_pClient->m_aClients[TargetID].m_ChatIgnore || Config()->Values()->m_ClFilterchat == 2 ||
-			(m_pClient->m_LocalClientID != TargetID && Config()->Values()->m_ClFilterchat == 1 && !m_pClient->m_aClients[TargetID].m_Friend))
+		if(m_pClient->m_aClients[TargetID].m_ChatIgnore || Config()->m_ClFilterchat == 2 ||
+			(m_pClient->m_LocalClientID != TargetID && Config()->m_ClFilterchat == 1 && !m_pClient->m_aClients[TargetID].m_Friend))
 			return;
 	}
 

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -374,7 +374,7 @@ void CGameConsole::OnRender()
 		Progress = 1.0f;
 	}
 
-	if (m_ConsoleState == CONSOLE_OPEN && Config()->Values()->m_ClEditor)
+	if (m_ConsoleState == CONSOLE_OPEN && Config()->m_ClEditor)
 		Toggle(CONSOLETYPE_LOCAL);
 
 	if (m_ConsoleState == CONSOLE_CLOSED)
@@ -743,7 +743,7 @@ void CGameConsole::OnConsoleInit()
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 
 	//
-	m_PrintCBIndex = Console()->RegisterPrintCallback(Config()->Values()->m_ConsoleOutputLevel, ClientConsolePrintCallback, this);
+	m_PrintCBIndex = Console()->RegisterPrintCallback(Config()->m_ConsoleOutputLevel, ClientConsolePrintCallback, this);
 
 	Console()->Register("toggle_local_console", "", CFGFLAG_CLIENT, ConToggleLocalConsole, this, "Toggle local console");
 	Console()->Register("toggle_remote_console", "", CFGFLAG_CLIENT, ConToggleRemoteConsole, this, "Toggle remote console");

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -102,7 +102,7 @@ void CControls::OnMessage(int Msg, void *pRawMsg)
 	if(Msg == NETMSGTYPE_SV_WEAPONPICKUP)
 	{
 		CNetMsg_Sv_WeaponPickup *pMsg = (CNetMsg_Sv_WeaponPickup *)pRawMsg;
-		if(Config()->Values()->m_ClAutoswitchWeapons)
+		if(Config()->m_ClAutoswitchWeapons)
 			m_InputData.m_WantedWeapon = pMsg->m_Weapon+1;
 	}
 }
@@ -155,7 +155,7 @@ int CControls::SnapInput(int *pData)
 			m_InputData.m_Direction = 1;
 
 		// stress testing
-		if(Config()->Values()->m_DbgStress)
+		if(Config()->m_DbgStress)
 		{
 			float t = Client()->LocalTime();
 			mem_zero(&m_InputData, sizeof(m_InputData));
@@ -228,14 +228,14 @@ void CControls::ClampMousePos()
 	else
 	{
 		float MouseMax;
-		if(Config()->Values()->m_ClDynamicCamera)
+		if(Config()->m_ClDynamicCamera)
 		{
 			float CameraMaxDistance = 200.0f;
-			float FollowFactor = Config()->Values()->m_ClMouseFollowfactor/100.0f;
-			MouseMax = min(CameraMaxDistance/FollowFactor + Config()->Values()->m_ClMouseDeadzone, (float)Config()->Values()->m_ClMouseMaxDistanceDynamic);
+			float FollowFactor = Config()->m_ClMouseFollowfactor/100.0f;
+			MouseMax = min(CameraMaxDistance/FollowFactor + Config()->m_ClMouseDeadzone, (float)Config()->m_ClMouseMaxDistanceDynamic);
 		}
 		else
-			MouseMax = (float)Config()->Values()->m_ClMouseMaxDistanceStatic;
+			MouseMax = (float)Config()->m_ClMouseMaxDistanceStatic;
 
 		if(length(m_MousePos) > MouseMax)
 			m_MousePos = normalize(m_MousePos)*MouseMax;

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -73,7 +73,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 					CCountryFlag CountryFlag;
 					CountryFlag.m_CountryCode = CountryCode;
 					str_copy(CountryFlag.m_aCountryCodeString, pCountryName, sizeof(CountryFlag.m_aCountryCodeString));
-					if(Config()->Values()->m_ClLoadCountryFlags)
+					if(Config()->m_ClLoadCountryFlags)
 					{
 						// load the graphic file
 						CImageInfo Info;
@@ -96,7 +96,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 					m_aCountryFlags.add_unsorted(CountryFlag);
 
 					// print message
-					if(Config()->Values()->m_Debug)
+					if(Config()->m_Debug)
 					{
 						str_format(aBuf, sizeof(aBuf), "loaded country flag '%s'", pCountryName);
 						Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "countryflags", aBuf);

--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -19,7 +19,7 @@
 
 void CDebugHud::RenderNetCorrections()
 {
-	if(!Config()->Values()->m_Debug || Config()->Values()->m_DbgGraphs || !m_pClient->m_Snap.m_pLocalCharacter || !m_pClient->m_Snap.m_pLocalPrevCharacter)
+	if(!Config()->m_Debug || Config()->m_DbgGraphs || !m_pClient->m_Snap.m_pLocalCharacter || !m_pClient->m_Snap.m_pLocalPrevCharacter)
 		return;
 
 	float Width = 300*Graphics()->ScreenAspect();
@@ -76,7 +76,7 @@ void CDebugHud::RenderNetCorrections()
 void CDebugHud::RenderTuning()
 {
 	// render tuning debugging
-	if(!Config()->Values()->m_DbgTuning)
+	if(!Config()->m_DbgTuning)
 		return;
 
 	CTuningParams StandardTuning;

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -213,7 +213,7 @@ void CHud::RenderScoreHud()
 						// draw name of the flag holder
 						int ID = FlagCarrier[t]%MAX_CLIENTS;
 						char aName[64];
-						str_format(aName, sizeof(aName), "%s", Config()->Values()->m_ClShowsocial ? m_pClient->m_aClients[ID].m_aName : "");
+						str_format(aName, sizeof(aName), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[ID].m_aName : "");
 						float w = TextRender()->TextWidth(0, 8.0f, aName, -1, -1.0f) + RenderTools()->GetClientIdRectSize(8.0f);
 
 						CTextCursor Cursor;
@@ -312,7 +312,7 @@ void CHud::RenderScoreHud()
 					// draw name
 					int ID = aPlayerInfo[t].m_ClientID;
 					char aName[64];
-					str_format(aName, sizeof(aName), "%s", Config()->Values()->m_ClShowsocial ? m_pClient->m_aClients[ID].m_aName : "");
+					str_format(aName, sizeof(aName), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[ID].m_aName : "");
 					float w = TextRender()->TextWidth(0, 8.0f, aName, -1, -1.0f) + RenderTools()->GetClientIdRectSize(8.0f);
 
 					CTextCursor Cursor;
@@ -408,7 +408,7 @@ void CHud::RenderWarmupTimer()
 
 void CHud::RenderFps()
 {
-	if(Config()->Values()->m_ClShowfps)
+	if(Config()->m_ClShowfps)
 	{
 		// calculate avg. fps
 		float FPS = 1.0f / Client()->RenderFrameTime();
@@ -432,7 +432,7 @@ void CHud::RenderConnectionWarning()
 void CHud::RenderTeambalanceWarning()
 {
 	// render prompt about team-balance
-	if(m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS && Config()->Values()->m_ClWarningTeambalance && m_pClient->m_ServerSettings.m_TeamBalance &&
+	if(m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS && Config()->m_ClWarningTeambalance && m_pClient->m_ServerSettings.m_TeamBalance &&
 		absolute(m_pClient->m_GameInfo.m_aTeamSize[TEAM_RED]-m_pClient->m_GameInfo.m_aTeamSize[TEAM_BLUE]) >= NUM_TEAMS)
 	{
 		bool Flash = time_get()/(time_freq()/2)%2 == 0;
@@ -655,7 +655,7 @@ void CHud::RenderSpectatorHud()
 	char aName[64];
 	const int SpecID = m_pClient->m_Snap.m_SpecInfo.m_SpectatorID;
 	const int SpecMode = m_pClient->m_Snap.m_SpecInfo.m_SpecMode;
-	str_format(aName, sizeof(aName), "%s", Config()->Values()->m_ClShowsocial ? m_pClient->m_aClients[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID].m_aName : "");
+	str_format(aName, sizeof(aName), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID].m_aName : "");
 	char aBuf[128];
 
 	CTextCursor Cursor;
@@ -809,7 +809,7 @@ void CHud::OnRender()
 	m_Height = 300.0f;
 	Graphics()->MapScreen(0.0f, 0.0f, m_Width, m_Height);
 
-	if(Config()->Values()->m_ClShowhud)
+	if(Config()->m_ClShowhud)
 	{
 		if(m_pClient->m_Snap.m_pLocalCharacter && !(m_pClient->m_Snap.m_pGameData->m_GameStateFlags&(GAMESTATEFLAG_ROUNDOVER|GAMESTATEFLAG_GAMEOVER)))
 		{

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -43,13 +43,13 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 		// unpack messages
 		CInfoMsg Kill;
 		Kill.m_Player1ID = pMsg->m_Victim;
-		str_format(Kill.m_aPlayer1Name, sizeof(Kill.m_aPlayer1Name), "%s", Config()->Values()->m_ClShowsocial ? m_pClient->m_aClients[Kill.m_Player1ID].m_aName : "");
+		str_format(Kill.m_aPlayer1Name, sizeof(Kill.m_aPlayer1Name), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[Kill.m_Player1ID].m_aName : "");
 		Kill.m_Player1RenderInfo = m_pClient->m_aClients[Kill.m_Player1ID].m_RenderInfo;
 
 		Kill.m_Player2ID = pMsg->m_Killer;
 		if (Kill.m_Player2ID >= 0)
 		{
-			str_format(Kill.m_aPlayer2Name, sizeof(Kill.m_aPlayer2Name), "%s", Config()->Values()->m_ClShowsocial ? m_pClient->m_aClients[Kill.m_Player2ID].m_aName : "");
+			str_format(Kill.m_aPlayer2Name, sizeof(Kill.m_aPlayer2Name), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[Kill.m_Player2ID].m_aName : "");
 			Kill.m_Player2RenderInfo = m_pClient->m_aClients[Kill.m_Player2ID].m_RenderInfo;
 		}
 		else
@@ -127,7 +127,7 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 		{
 			CInfoMsg Finish;
 			Finish.m_Player1ID = pMsg->m_ClientID;
-			str_format(Finish.m_aPlayer1Name, sizeof(Finish.m_aPlayer1Name), "%s", Config()->Values()->m_ClShowsocial ? m_pClient->m_aClients[pMsg->m_ClientID].m_aName : "");
+			str_format(Finish.m_aPlayer1Name, sizeof(Finish.m_aPlayer1Name), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[pMsg->m_ClientID].m_aName : "");
 			Finish.m_Player1RenderInfo = m_pClient->m_aClients[Finish.m_Player1ID].m_RenderInfo;
 
 			Finish.m_Time = pMsg->m_Time;
@@ -141,7 +141,7 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 
 void CInfoMessages::OnRender()
 {
-	if(!Config()->Values()->m_ClShowhud)
+	if(!Config()->m_ClShowhud)
 		return;
 
 	float Width = 400*3.0f*Graphics()->ScreenAspect();

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -39,31 +39,31 @@ void CMapLayers::OnStateChange(int NewState, int OldState)
 
 void CMapLayers::LoadBackgroundMap()
 {
-	if(!Config()->Values()->m_ClShowMenuMap)
+	if(!Config()->m_ClShowMenuMap)
 		return;
 
 	int HourOfTheDay = time_houroftheday();
 	char aBuf[128];
 	// check for the appropriate day/night map
-	str_format(aBuf, sizeof(aBuf), "ui/themes/%s_%s.map", Config()->Values()->m_ClMenuMap, (HourOfTheDay >= 6 && HourOfTheDay < 18) ? "day" : "night");
+	str_format(aBuf, sizeof(aBuf), "ui/themes/%s_%s.map", Config()->m_ClMenuMap, (HourOfTheDay >= 6 && HourOfTheDay < 18) ? "day" : "night");
 	if(!m_pMenuMap->Load(aBuf, m_pClient->Storage()))
 	{
 		// fall back on generic map
-		str_format(aBuf, sizeof(aBuf), "ui/themes/%s.map", Config()->Values()->m_ClMenuMap);
+		str_format(aBuf, sizeof(aBuf), "ui/themes/%s.map", Config()->m_ClMenuMap);
 		if(!m_pMenuMap->Load(aBuf, m_pClient->Storage()))
 		{
 			// fall back on day/night alternative map
-			str_format(aBuf, sizeof(aBuf), "ui/themes/%s_%s.map", Config()->Values()->m_ClMenuMap, (HourOfTheDay >= 6 && HourOfTheDay < 18) ? "night" : "day");
+			str_format(aBuf, sizeof(aBuf), "ui/themes/%s_%s.map", Config()->m_ClMenuMap, (HourOfTheDay >= 6 && HourOfTheDay < 18) ? "night" : "day");
 			if(!m_pMenuMap->Load(aBuf, m_pClient->Storage()))
 			{
-				str_format(aBuf, sizeof(aBuf), "map '%s' not found", Config()->Values()->m_ClMenuMap);
+				str_format(aBuf, sizeof(aBuf), "map '%s' not found", Config()->m_ClMenuMap);
 				Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", aBuf);
 				return;
 			}
 		}
 	}
 
-	str_format(aBuf, sizeof(aBuf), "loaded map '%s'", Config()->Values()->m_ClMenuMap);
+	str_format(aBuf, sizeof(aBuf), "loaded map '%s'", Config()->m_ClMenuMap);
 	Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", aBuf);
 
 	m_pMenuLayers->Init(Kernel(), m_pMenuMap);
@@ -373,7 +373,7 @@ void CMapLayers::OnRender()
 	{
 		CMapItemGroup *pGroup = pLayers->GetGroup(g);
 
-		if(!Config()->Values()->m_GfxNoclip && pGroup->m_Version >= 2 && pGroup->m_UseClipping)
+		if(!Config()->m_GfxNoclip && pGroup->m_Version >= 2 && pGroup->m_UseClipping)
 		{
 			// set clipping
 			float Points[4];
@@ -423,7 +423,7 @@ void CMapLayers::OnRender()
 				continue;
 
 			// skip rendering if detail layers is not wanted
-			if(!(pLayer->m_Flags&LAYERFLAG_DETAIL && !Config()->Values()->m_GfxHighDetail && !IsGameLayer && (Client()->State() == IClient::STATE_ONLINE || Client()->State() == IClient::STATE_DEMOPLAYBACK)))
+			if(!(pLayer->m_Flags&LAYERFLAG_DETAIL && !Config()->m_GfxHighDetail && !IsGameLayer && (Client()->State() == IClient::STATE_ONLINE || Client()->State() == IClient::STATE_DEMOPLAYBACK)))
 			{
 				if(pLayer->m_Type == LAYERTYPE_TILES && Input()->KeyIsPressed(KEY_LCTRL) && Input()->KeyIsPressed(KEY_LSHIFT) && Input()->KeyPress(KEY_KP_0))
 				{
@@ -495,11 +495,11 @@ void CMapLayers::OnRender()
 				}
 			}
 		}
-		if(!Config()->Values()->m_GfxNoclip)
+		if(!Config()->m_GfxNoclip)
 			Graphics()->ClipDisable();
 	}
 
-	if(!Config()->Values()->m_GfxNoclip)
+	if(!Config()->m_GfxNoclip)
 		Graphics()->ClipDisable();
 
 	// reset the screen like it was before

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -255,7 +255,7 @@ int CMenus::DoButton_MenuTabTop(CButtonContainer *pBC, const char *pText, int Ch
 	float Fade = ButtonFade(pBC, Seconds, Checked);
 	float FadeVal = (Fade/Seconds)*FontAlpha;
 
-	RenderTools()->DrawUIRect(pRect, vec4(0.0f+FadeVal, 0.0f+FadeVal, 0.0f+FadeVal, Config()->Values()->m_ClMenuAlpha/100.0f*Alpha+FadeVal*0.5f), Corners, r);
+	RenderTools()->DrawUIRect(pRect, vec4(0.0f+FadeVal, 0.0f+FadeVal, 0.0f+FadeVal, Config()->m_ClMenuAlpha/100.0f*Alpha+FadeVal*0.5f), Corners, r);
 	CUIRect Temp;
 	pRect->HMargin(pRect->h>=20.0f?2.0f:1.0f, &Temp);
 	Temp.HMargin((Temp.h*FontFactor)/2.0f, &Temp);
@@ -1020,8 +1020,8 @@ void CMenus::RenderMenubar(CUIRect Rect)
 		CUIRect Left, Right;
 		Box.VSplitLeft(ButtonWidth*4.0f + Spacing*3.0f, &Left, 0);
 		Box.VSplitRight(ButtonWidth*1.5f + Spacing, 0, &Right);
-		RenderTools()->DrawUIRect4(&Left, vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
-		RenderTools()->DrawUIRect4(&Right, vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
+		RenderTools()->DrawUIRect4(&Left, vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
+		RenderTools()->DrawUIRect4(&Right, vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
 
 		Left.HSplitBottom(25.0f, 0, &Left);
 		Right.HSplitBottom(25.0f, 0, &Right);
@@ -1074,28 +1074,28 @@ void CMenus::RenderMenubar(CUIRect Rect)
 
 		// render header background
 		if(Client()->State() == IClient::STATE_OFFLINE)
-			RenderTools()->DrawUIRect4(&Box, vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
+			RenderTools()->DrawUIRect4(&Box, vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
 
 		Box.HSplitBottom(25.0f, 0, &Box);
 
 		Box.VSplitLeft(ButtonWidth, &Button, &Box);
 		static CButtonContainer s_GeneralButton;
-		if(DoButton_MenuTabTop(&s_GeneralButton, Localize("General"), Client()->State() == IClient::STATE_OFFLINE && Config()->Values()->m_UiSettingsPage==SETTINGS_GENERAL, &Button,
-			Config()->Values()->m_UiSettingsPage == SETTINGS_GENERAL ? 1.0f : NotActiveAlpha, 1.0f, Corners))
+		if(DoButton_MenuTabTop(&s_GeneralButton, Localize("General"), Client()->State() == IClient::STATE_OFFLINE && Config()->m_UiSettingsPage==SETTINGS_GENERAL, &Button,
+			Config()->m_UiSettingsPage == SETTINGS_GENERAL ? 1.0f : NotActiveAlpha, 1.0f, Corners))
 		{
 			m_pClient->m_pCamera->ChangePosition(CCamera::POS_SETTINGS_GENERAL);
-			Config()->Values()->m_UiSettingsPage = SETTINGS_GENERAL;
+			Config()->m_UiSettingsPage = SETTINGS_GENERAL;
 		}
 
 		Box.VSplitLeft(Spacing, 0, &Box); // little space
 		Box.VSplitLeft(ButtonWidth, &Button, &Box);
 		{
 			static CButtonContainer s_PlayerButton;
-			if(DoButton_MenuTabTop(&s_PlayerButton, Localize("Player"), Client()->State() == IClient::STATE_OFFLINE && Config()->Values()->m_UiSettingsPage == SETTINGS_PLAYER, &Button,
-				Config()->Values()->m_UiSettingsPage == SETTINGS_PLAYER ? 1.0f : NotActiveAlpha, 1.0f, Corners))
+			if(DoButton_MenuTabTop(&s_PlayerButton, Localize("Player"), Client()->State() == IClient::STATE_OFFLINE && Config()->m_UiSettingsPage == SETTINGS_PLAYER, &Button,
+				Config()->m_UiSettingsPage == SETTINGS_PLAYER ? 1.0f : NotActiveAlpha, 1.0f, Corners))
 			{
 				m_pClient->m_pCamera->ChangePosition(CCamera::POS_SETTINGS_PLAYER);
-				Config()->Values()->m_UiSettingsPage = SETTINGS_PLAYER;
+				Config()->m_UiSettingsPage = SETTINGS_PLAYER;
 			}
 		}
 
@@ -1103,11 +1103,11 @@ void CMenus::RenderMenubar(CUIRect Rect)
 		Box.VSplitLeft(ButtonWidth, &Button, &Box);
 		{
 			static CButtonContainer s_TeeButton;
-			if(DoButton_MenuTabTop(&s_TeeButton, Localize("Tee"), Client()->State() == IClient::STATE_OFFLINE && Config()->Values()->m_UiSettingsPage == SETTINGS_TEE, &Button,
-				Config()->Values()->m_UiSettingsPage == SETTINGS_TEE ? 1.0f : NotActiveAlpha, 1.0f, Corners))
+			if(DoButton_MenuTabTop(&s_TeeButton, Localize("Tee"), Client()->State() == IClient::STATE_OFFLINE && Config()->m_UiSettingsPage == SETTINGS_TEE, &Button,
+				Config()->m_UiSettingsPage == SETTINGS_TEE ? 1.0f : NotActiveAlpha, 1.0f, Corners))
 			{
 				m_pClient->m_pCamera->ChangePosition(CCamera::POS_SETTINGS_TEE);
-				Config()->Values()->m_UiSettingsPage = SETTINGS_TEE;
+				Config()->m_UiSettingsPage = SETTINGS_TEE;
 			}
 		}
 
@@ -1115,31 +1115,31 @@ void CMenus::RenderMenubar(CUIRect Rect)
 		Box.VSplitLeft(Spacing, 0, &Box); // little space
 		Box.VSplitLeft(ButtonWidth, &Button, &Box);
 		static CButtonContainer s_ControlsButton;
-		if(DoButton_MenuTabTop(&s_ControlsButton, Localize("Controls"), Client()->State() == IClient::STATE_OFFLINE && Config()->Values()->m_UiSettingsPage==SETTINGS_CONTROLS, &Button,
-			Config()->Values()->m_UiSettingsPage == SETTINGS_CONTROLS ? 1.0f : NotActiveAlpha, 1.0f, Corners))
+		if(DoButton_MenuTabTop(&s_ControlsButton, Localize("Controls"), Client()->State() == IClient::STATE_OFFLINE && Config()->m_UiSettingsPage==SETTINGS_CONTROLS, &Button,
+			Config()->m_UiSettingsPage == SETTINGS_CONTROLS ? 1.0f : NotActiveAlpha, 1.0f, Corners))
 		{
 			m_pClient->m_pCamera->ChangePosition(CCamera::POS_SETTINGS_CONTROLS);
-			Config()->Values()->m_UiSettingsPage = SETTINGS_CONTROLS;
+			Config()->m_UiSettingsPage = SETTINGS_CONTROLS;
 		}
 
 		Box.VSplitLeft(Spacing, 0, &Box); // little space
 		Box.VSplitLeft(ButtonWidth, &Button, &Box);
 		static CButtonContainer s_GraphicsButton;
-		if(DoButton_MenuTabTop(&s_GraphicsButton, Localize("Graphics"), Client()->State() == IClient::STATE_OFFLINE && Config()->Values()->m_UiSettingsPage==SETTINGS_GRAPHICS, &Button,
-			Config()->Values()->m_UiSettingsPage == SETTINGS_GRAPHICS ? 1.0f : NotActiveAlpha, 1.0f, Corners))
+		if(DoButton_MenuTabTop(&s_GraphicsButton, Localize("Graphics"), Client()->State() == IClient::STATE_OFFLINE && Config()->m_UiSettingsPage==SETTINGS_GRAPHICS, &Button,
+			Config()->m_UiSettingsPage == SETTINGS_GRAPHICS ? 1.0f : NotActiveAlpha, 1.0f, Corners))
 		{
 			m_pClient->m_pCamera->ChangePosition(CCamera::POS_SETTINGS_GRAPHICS);
-			Config()->Values()->m_UiSettingsPage = SETTINGS_GRAPHICS;
+			Config()->m_UiSettingsPage = SETTINGS_GRAPHICS;
 		}
 
 		Box.VSplitLeft(Spacing, 0, &Box); // little space
 		Box.VSplitLeft(ButtonWidth, &Button, &Box);
 		static CButtonContainer s_SoundButton;
-		if(DoButton_MenuTabTop(&s_SoundButton, Localize("Sound"), Client()->State() == IClient::STATE_OFFLINE && Config()->Values()->m_UiSettingsPage==SETTINGS_SOUND, &Button,
-			Config()->Values()->m_UiSettingsPage == SETTINGS_SOUND ? 1.0f : NotActiveAlpha, 1.0f, Corners))
+		if(DoButton_MenuTabTop(&s_SoundButton, Localize("Sound"), Client()->State() == IClient::STATE_OFFLINE && Config()->m_UiSettingsPage==SETTINGS_SOUND, &Button,
+			Config()->m_UiSettingsPage == SETTINGS_SOUND ? 1.0f : NotActiveAlpha, 1.0f, Corners))
 		{
 			m_pClient->m_pCamera->ChangePosition(CCamera::POS_SETTINGS_SOUND);
-			Config()->Values()->m_UiSettingsPage = SETTINGS_SOUND;
+			Config()->m_UiSettingsPage = SETTINGS_SOUND;
 		}
 	}
 	else if((Client()->State() == IClient::STATE_OFFLINE && m_MenuPage >= PAGE_INTERNET && m_MenuPage <= PAGE_LAN) || (Client()->State() == IClient::STATE_ONLINE && m_GamePage >= PAGE_INTERNET && m_GamePage <= PAGE_LAN))
@@ -1154,7 +1154,7 @@ void CMenus::RenderMenubar(CUIRect Rect)
 
 		// render header backgrounds
 		if(Client()->State() == IClient::STATE_OFFLINE)
-			RenderTools()->DrawUIRect4(&Left, vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
+			RenderTools()->DrawUIRect4(&Left, vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
 
 		Left.HSplitBottom(25.0f, 0, &Left);
 
@@ -1166,7 +1166,7 @@ void CMenus::RenderMenubar(CUIRect Rect)
 			m_pClient->m_pCamera->ChangePosition(CCamera::POS_INTERNET);
 			ServerBrowser()->SetType(IServerBrowser::TYPE_INTERNET);
 			NewPage = PAGE_INTERNET;
-			Config()->Values()->m_UiBrowserPage = PAGE_INTERNET;
+			Config()->m_UiBrowserPage = PAGE_INTERNET;
 		}
 
 		Left.VSplitLeft(Spacing, 0, &Left); // little space
@@ -1178,7 +1178,7 @@ void CMenus::RenderMenubar(CUIRect Rect)
 			m_pClient->m_pCamera->ChangePosition(CCamera::POS_LAN);
 			ServerBrowser()->SetType(IServerBrowser::TYPE_LAN);
 			NewPage = PAGE_LAN;
-			Config()->Values()->m_UiBrowserPage = PAGE_LAN;
+			Config()->m_UiBrowserPage = PAGE_LAN;
 		}
 
 		if(Client()->State() == IClient::STATE_OFFLINE)
@@ -1194,7 +1194,7 @@ void CMenus::RenderMenubar(CUIRect Rect)
 		if(m_MenuPage == PAGE_DEMOS)
 		{
 			// render header background
-			RenderTools()->DrawUIRect4(&Box, vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
+			RenderTools()->DrawUIRect4(&Box, vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
 
 			Box.HSplitBottom(25.0f, 0, &Box);
 
@@ -1286,7 +1286,7 @@ void CMenus::RenderBackButton(CUIRect MainView)
 	// render background
 	MainView.HSplitBottom(60.0f, 0, &MainView);
 	MainView.VSplitLeft(ButtonWidth, &MainView, 0);
-	RenderTools()->DrawUIRect4(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
+	RenderTools()->DrawUIRect4(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
 
 	// back to main menu
 	CUIRect Button;
@@ -1462,14 +1462,14 @@ void CMenus::UpdatedFilteredVideoModes()
 
 void CMenus::UpdateVideoModeSettings()
 {
-	m_NumModes = Graphics()->GetVideoModes(m_aModes, MAX_RESOLUTIONS, Config()->Values()->m_GfxScreen);
+	m_NumModes = Graphics()->GetVideoModes(m_aModes, MAX_RESOLUTIONS, Config()->m_GfxScreen);
 	UpdateVideoFormats();
 
 	bool Found = false;
 	for(int i = 0; i < m_NumVideoFormats; i++)
 	{
-		int G = gcd(Config()->Values()->m_GfxScreenWidth, Config()->Values()->m_GfxScreenHeight);
-		if(m_aVideoFormats[i].m_WidthValue == Config()->Values()->m_GfxScreenWidth/G && m_aVideoFormats[i].m_HeightValue == Config()->Values()->m_GfxScreenHeight/G)
+		int G = gcd(Config()->m_GfxScreenWidth, Config()->m_GfxScreenHeight);
+		if(m_aVideoFormats[i].m_WidthValue == Config()->m_GfxScreenWidth/G && m_aVideoFormats[i].m_HeightValue == Config()->m_GfxScreenHeight/G)
 		{
 			m_CurrentVideoFormat = i;
 			Found = true;
@@ -1498,11 +1498,11 @@ void CMenus::OnInit()
 	// clear filter lists
 	//m_lFilters.clear();
 
-	if(Config()->Values()->m_ClShowWelcome)
+	if(Config()->m_ClShowWelcome)
 		m_Popup = POPUP_LANGUAGE;
-	Config()->Values()->m_ClShowWelcome = 0;
-	if(Config()->Values()->m_ClSkipStartMenu)
-		SetMenuPage(Config()->Values()->m_UiBrowserPage);
+	Config()->m_ClShowWelcome = 0;
+	if(Config()->m_ClSkipStartMenu)
+		SetMenuPage(Config()->m_UiBrowserPage);
 
 	Console()->Chain("br_filter_string", ConchainServerbrowserUpdate, this);
 	Console()->Chain("add_favorite", ConchainServerbrowserUpdate, this);
@@ -1518,7 +1518,7 @@ void CMenus::OnInit()
 	// setup load amount
 	m_LoadCurrent = 0;
 	m_LoadTotal = g_pData->m_NumImages;
-	if(!Config()->Values()->m_SndAsyncLoading)
+	if(!Config()->m_SndAsyncLoading)
 		m_LoadTotal += g_pData->m_NumSounds;
 }
 
@@ -1546,7 +1546,7 @@ int CMenus::Render()
 		// refresh server browser before we are in browser menu to save time
 		m_pClient->m_pCamera->ChangePosition(CCamera::POS_START);
 		ServerBrowser()->Refresh(IServerBrowser::REFRESHFLAG_INTERNET|IServerBrowser::REFRESHFLAG_LAN);
-		ServerBrowser()->SetType(Config()->Values()->m_UiBrowserPage == PAGE_LAN ? IServerBrowser::TYPE_LAN : IServerBrowser::TYPE_INTERNET);
+		ServerBrowser()->SetType(Config()->m_UiBrowserPage == PAGE_LAN ? IServerBrowser::TYPE_LAN : IServerBrowser::TYPE_INTERNET);
 
 		m_pClient->m_pSounds->Enqueue(CSounds::CHN_MUSIC, SOUND_MENU);
 		s_First = false;
@@ -1582,7 +1582,7 @@ int CMenus::Render()
 			else if(Client()->State() == IClient::STATE_ONLINE && m_GamePage >= PAGE_INTERNET && m_GamePage <= PAGE_LAN)
 				BarHeight += 3.0f + 25.0f;
 			float VMargin = Screen.w/2-365.0f;
-			if(Config()->Values()->m_UiWideview)
+			if(Config()->m_UiWideview)
 				VMargin = min(VMargin, 60.0f);
 
 			Screen.VMargin(VMargin, &MainView);
@@ -1632,8 +1632,8 @@ int CMenus::Render()
 				Row.VSplitRight(5.0f, &Row, 0);
 				Row.VSplitRight(TopOffset, &Row, &Button);
 				static CButtonContainer s_WideButton;
-				if((m_MenuPage == PAGE_INTERNET || m_MenuPage == PAGE_LAN || m_MenuPage == PAGE_DEMOS) && DoButton_MenuTabTop(&s_WideButton, Config()->Values()->m_UiWideview ? "\xe2\x96\xaa" : "\xe2\x96\xac", false, &Button, 1.0f, 1.0f, CUI::CORNER_B))
-					Config()->Values()->m_UiWideview ^= 1;
+				if((m_MenuPage == PAGE_INTERNET || m_MenuPage == PAGE_LAN || m_MenuPage == PAGE_DEMOS) && DoButton_MenuTabTop(&s_WideButton, Config()->m_UiWideview ? "\xe2\x96\xaa" : "\xe2\x96\xac", false, &Button, 1.0f, 1.0f, CUI::CORNER_B))
+					Config()->m_UiWideview ^= 1;
 			}
 
 			// render current page
@@ -1862,7 +1862,7 @@ int CMenus::Render()
 
 			Box.HSplitTop(20.0f, &EditBox, &Box);
 			static float s_OffsetPassword = 0.0f;
-			DoEditBoxOption(Config()->Values()->m_Password, Config()->Values()->m_Password, sizeof(Config()->Values()->m_Password), &EditBox, Localize("Password"), ButtonWidth, &s_OffsetPassword, true);
+			DoEditBoxOption(Config()->m_Password, Config()->m_Password, sizeof(Config()->m_Password), &EditBox, Localize("Password"), ButtonWidth, &s_OffsetPassword, true);
 
 			Box.HSplitTop(2.0f, 0, &Box);
 			Box.HSplitTop(20.0f, &Save, &Box);
@@ -1872,8 +1872,8 @@ int CMenus::Render()
 			const bool Favorite = ServerInfo.m_Favorite;
 			const int OnValue = Favorite ? 1 : 2;
 			const char *pSaveText = Favorite ? Localize("Save password") : Localize("Save password and server as favorite");
-			if(DoButton_CheckBox(&Config()->Values()->m_ClSaveServerPasswords, pSaveText, Config()->Values()->m_ClSaveServerPasswords == OnValue, &Save))
-				Config()->Values()->m_ClSaveServerPasswords = Config()->Values()->m_ClSaveServerPasswords == OnValue ? 0 : OnValue;
+			if(DoButton_CheckBox(&Config()->m_ClSaveServerPasswords, pSaveText, Config()->m_ClSaveServerPasswords == OnValue, &Save))
+				Config()->m_ClSaveServerPasswords = Config()->m_ClSaveServerPasswords == OnValue ? 0 : OnValue;
 
 			// buttons
 			BottomBar.VSplitMid(&Abort, &TryAgain);
@@ -2267,13 +2267,13 @@ int CMenus::Render()
 			Box.HSplitTop(ButtonHeight, &EditBox, &Box);
 
 			static float s_OffsetName = 0.0f;
-			DoEditBoxOption(Config()->Values()->m_PlayerName, Config()->Values()->m_PlayerName, sizeof(Config()->Values()->m_PlayerName), &EditBox, Localize("Nickname"), ButtonWidth, &s_OffsetName);
+			DoEditBoxOption(Config()->m_PlayerName, Config()->m_PlayerName, sizeof(Config()->m_PlayerName), &EditBox, Localize("Nickname"), ButtonWidth, &s_OffsetName);
 
 			// button
 			static CButtonContainer s_EnterButton;
 			if(DoButton_Menu(&s_EnterButton, pButtonText, 0, &BottomBar) || m_EnterPressed)
 			{
-				if(Config()->Values()->m_PlayerName[0])
+				if(Config()->m_PlayerName[0])
 					m_Popup = POPUP_NONE;
 				else
 					PopupMessage(Localize("Error"), Localize("Nickname is empty."), Localize("Ok"), POPUP_FIRST_LAUNCH);
@@ -2449,8 +2449,8 @@ void CMenus::OnStateChange(int NewState, int OldState)
 			if(str_find(Client()->ErrorString(), "password"))
 			{
 				m_Popup = POPUP_PASSWORD;
-				UI()->SetHotItem(&Config()->Values()->m_Password);
-				UI()->SetActiveItem(&Config()->Values()->m_Password);
+				UI()->SetHotItem(&Config()->m_Password);
+				UI()->SetActiveItem(&Config()->m_Password);
 			}
 			else
 				m_Popup = POPUP_DISCONNECTED;
@@ -2548,7 +2548,7 @@ void CMenus::OnRender()
 	Graphics()->WrapNormal();
 
 	// render debug information
-	if(Config()->Values()->m_Debug)
+	if(Config()->m_Debug)
 	{
 		CUIRect Screen = *UI()->Screen();
 		Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
@@ -2643,9 +2643,9 @@ void CMenus::ToggleMusic()
 {
 	if(Client()->State() == IClient::STATE_OFFLINE)
 	{
-		if(Config()->Values()->m_SndMusic && !m_pClient->m_pSounds->IsPlaying(SOUND_MENU))
+		if(Config()->m_SndMusic && !m_pClient->m_pSounds->IsPlaying(SOUND_MENU))
 			m_pClient->m_pSounds->Play(CSounds::CHN_MUSIC, SOUND_MENU, 1.0f);
-		else if(!Config()->Values()->m_SndMusic && m_pClient->m_pSounds->IsPlaying(SOUND_MENU))
+		else if(!Config()->m_SndMusic && m_pClient->m_pSounds->IsPlaying(SOUND_MENU))
 			m_pClient->m_pSounds->Stop(SOUND_MENU);
 	}
 }
@@ -2665,7 +2665,7 @@ void CMenus::SetMenuPage(int NewPage)
 		{
 		case PAGE_START: CameraPos = CCamera::POS_START; break;
 		case PAGE_DEMOS: CameraPos = CCamera::POS_DEMOS; break;
-		case PAGE_SETTINGS: CameraPos = CCamera::POS_SETTINGS_GENERAL+Config()->Values()->m_UiSettingsPage; break;
+		case PAGE_SETTINGS: CameraPos = CCamera::POS_SETTINGS_GENERAL+Config()->m_UiSettingsPage; break;
 		case PAGE_INTERNET: CameraPos = CCamera::POS_INTERNET; break;
 		case PAGE_LAN: CameraPos = CCamera::POS_LAN;
 		}

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -690,8 +690,8 @@ private:
 	void RenderMenubar(CUIRect r);
 	void RenderNews(CUIRect MainView);
 	void RenderBackButton(CUIRect MainView);
-	inline float GetListHeaderHeight() const { return ms_ListheaderHeight + (Config()->Values()->m_UiWideview ? 3.0f : 0.0f); }
-	inline float GetListHeaderHeightFactor() const { return 1.0f + (Config()->Values()->m_UiWideview ? (3.0f/ms_ListheaderHeight) : 0.0f); }
+	inline float GetListHeaderHeight() const { return ms_ListheaderHeight + (Config()->m_UiWideview ? 3.0f : 0.0f); }
+	inline float GetListHeaderHeightFactor() const { return 1.0f + (Config()->m_UiWideview ? (3.0f/ms_ListheaderHeight) : 0.0f); }
 
 	// found in menus_demo.cpp
 	void RenderDemoPlayer(CUIRect MainView);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -474,17 +474,17 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 			
 			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
 
-			if(Config()->Values()->m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_SERVERNAME))
+			if(Config()->m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_SERVERNAME))
 			{
 				// highlight the part that matches
-				const char *pStr = str_find_nocase(pEntry->m_aName, Config()->Values()->m_BrFilterString);
+				const char *pStr = str_find_nocase(pEntry->m_aName, Config()->m_BrFilterString);
 				if(pStr)
 				{
 					TextRender()->TextEx(&Cursor, pEntry->m_aName, (int)(pStr-pEntry->m_aName));
 					TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextAlpha);
-					TextRender()->TextEx(&Cursor, pStr, str_length(Config()->Values()->m_BrFilterString));
+					TextRender()->TextEx(&Cursor, pStr, str_length(Config()->m_BrFilterString));
 					TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
-					TextRender()->TextEx(&Cursor, pStr+str_length(Config()->Values()->m_BrFilterString), -1);
+					TextRender()->TextEx(&Cursor, pStr+str_length(Config()->m_BrFilterString), -1);
 				}
 				else
 					TextRender()->TextEx(&Cursor, pEntry->m_aName, -1);
@@ -506,17 +506,17 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 
 			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
 
-			if(Config()->Values()->m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_MAPNAME))
+			if(Config()->m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_MAPNAME))
 			{
 				// highlight the part that matches
-				const char *pStr = str_find_nocase(pEntry->m_aMap, Config()->Values()->m_BrFilterString);
+				const char *pStr = str_find_nocase(pEntry->m_aMap, Config()->m_BrFilterString);
 				if(pStr)
 				{
 					TextRender()->TextEx(&Cursor, pEntry->m_aMap, (int)(pStr-pEntry->m_aMap));
 					TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextAlpha);
-					TextRender()->TextEx(&Cursor, pStr, str_length(Config()->Values()->m_BrFilterString));
+					TextRender()->TextEx(&Cursor, pStr, str_length(Config()->m_BrFilterString));
 					TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
-					TextRender()->TextEx(&Cursor, pStr+str_length(Config()->Values()->m_BrFilterString), -1);
+					TextRender()->TextEx(&Cursor, pStr+str_length(Config()->m_BrFilterString), -1);
 				}
 				else
 					TextRender()->TextEx(&Cursor, pEntry->m_aMap, -1);
@@ -557,7 +557,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 			}
 
 			str_format(aTemp, sizeof(aTemp), "%d/%d", Num, Max);
-			if(Config()->Values()->m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_PLAYER))
+			if(Config()->m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_PLAYER))
 				TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextAlpha);
 			Button.y += 2.0f;
 
@@ -621,17 +621,17 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 			Cursor.m_LineWidth = Button.w;
 			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
 
-			if(Config()->Values()->m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_GAMETYPE))
+			if(Config()->m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_GAMETYPE))
 			{
 				// highlight the part that matches
-				const char *pStr = str_find_nocase(pEntry->m_aGameType, Config()->Values()->m_BrFilterString);
+				const char *pStr = str_find_nocase(pEntry->m_aGameType, Config()->m_BrFilterString);
 				if(pStr)
 				{
 					TextRender()->TextEx(&Cursor, pEntry->m_aGameType, (int)(pStr-pEntry->m_aGameType));
 					TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextAlpha);
-					TextRender()->TextEx(&Cursor, pStr, str_length(Config()->Values()->m_BrFilterString));
+					TextRender()->TextEx(&Cursor, pStr, str_length(Config()->m_BrFilterString));
 					TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
-					TextRender()->TextEx(&Cursor, pStr+str_length(Config()->Values()->m_BrFilterString), -1);
+					TextRender()->TextEx(&Cursor, pStr+str_length(Config()->m_BrFilterString), -1);
 				}
 				else
 					TextRender()->TextEx(&Cursor, pEntry->m_aGameType, -1);
@@ -883,17 +883,17 @@ void CMenus::RenderServerbrowserOverlay()
 				TextRender()->SetCursor(&Cursor, Name.x, Name.y+(Name.h-FontSize)/4.0f, FontSize, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
 				Cursor.m_LineWidth = Name.w;
 				const char *pName = pInfo->m_aClients[i].m_aName;
-				if(Config()->Values()->m_BrFilterString[0])
+				if(Config()->m_BrFilterString[0])
 				{
 					// highlight the part that matches
-					const char *s = str_find_nocase(pName, Config()->Values()->m_BrFilterString);
+					const char *s = str_find_nocase(pName, Config()->m_BrFilterString);
 					if(s)
 					{
 						TextRender()->TextEx(&Cursor, pName, (int)(s-pName));
 						TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextColor.a);
-						TextRender()->TextEx(&Cursor, s, str_length(Config()->Values()->m_BrFilterString));
+						TextRender()->TextEx(&Cursor, s, str_length(Config()->m_BrFilterString));
 						TextRender()->TextColor(TextColor.r, TextColor.g, TextColor.b, TextColor.a);
-						TextRender()->TextEx(&Cursor, s+str_length(Config()->Values()->m_BrFilterString), -1);
+						TextRender()->TextEx(&Cursor, s+str_length(Config()->m_BrFilterString), -1);
 					}
 					else
 						TextRender()->TextEx(&Cursor, pName, -1);
@@ -905,17 +905,17 @@ void CMenus::RenderServerbrowserOverlay()
 				TextRender()->SetCursor(&Cursor, Clan.x, Clan.y+(Clan.h-FontSize)/4.0f, FontSize, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
 				Cursor.m_LineWidth = Clan.w;
 				const char *pClan = pInfo->m_aClients[i].m_aClan;
-				if(Config()->Values()->m_BrFilterString[0])
+				if(Config()->m_BrFilterString[0])
 				{
 					// highlight the part that matches
-					const char *s = str_find_nocase(pClan, Config()->Values()->m_BrFilterString);
+					const char *s = str_find_nocase(pClan, Config()->m_BrFilterString);
 					if(s)
 					{
 						TextRender()->TextEx(&Cursor, pClan, (int)(s-pClan));
 						TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextColor.a);
-						TextRender()->TextEx(&Cursor, s, str_length(Config()->Values()->m_BrFilterString));
+						TextRender()->TextEx(&Cursor, s, str_length(Config()->m_BrFilterString));
 						TextRender()->TextColor(TextColor.r, TextColor.g, TextColor.b, TextColor.a);
-						TextRender()->TextEx(&Cursor, s+str_length(Config()->Values()->m_BrFilterString), -1);
+						TextRender()->TextEx(&Cursor, s+str_length(Config()->m_BrFilterString), -1);
 					}
 					else
 						TextRender()->TextEx(&Cursor, pClan, -1);
@@ -974,7 +974,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	const float HeightFactor = GetListHeaderHeightFactor();
 
 	// background
-	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), (Client()->State() == IClient::STATE_OFFLINE) ? CUI::CORNER_ALL : CUI::CORNER_B|CUI::CORNER_TR, 5.0f);
+	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), (Client()->State() == IClient::STATE_OFFLINE) ? CUI::CORNER_ALL : CUI::CORNER_B|CUI::CORNER_TR, 5.0f);
 
 	// make room for scrollbar
 	{
@@ -1022,15 +1022,15 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		if(i == COL_BROWSER_FLAG)
 			continue;
 
-		if(DoButton_GridHeader(ms_aBrowserCols[i].m_Caption, ms_aBrowserCols[i].m_Caption, Config()->Values()->m_BrSort == ms_aBrowserCols[i].m_Sort, ms_aBrowserCols[i].m_Align, &ms_aBrowserCols[i].m_Rect))
+		if(DoButton_GridHeader(ms_aBrowserCols[i].m_Caption, ms_aBrowserCols[i].m_Caption, Config()->m_BrSort == ms_aBrowserCols[i].m_Sort, ms_aBrowserCols[i].m_Align, &ms_aBrowserCols[i].m_Rect))
 		{
 			if(ms_aBrowserCols[i].m_Sort != -1)
 			{
-				if(Config()->Values()->m_BrSort == ms_aBrowserCols[i].m_Sort)
-					Config()->Values()->m_BrSortOrder ^= 1;
+				if(Config()->m_BrSort == ms_aBrowserCols[i].m_Sort)
+					Config()->m_BrSortOrder ^= 1;
 				else
-					Config()->Values()->m_BrSortOrder = 0;
-				Config()->Values()->m_BrSort = ms_aBrowserCols[i].m_Sort;
+					Config()->m_BrSortOrder = 0;
+				Config()->m_BrSort = ms_aBrowserCols[i].m_Sort;
 			}
 			ServerBrowserSortingOnUpdate();
 		}
@@ -1040,7 +1040,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 	{
 		int Column = COL_BROWSER_PING;
-		switch(Config()->Values()->m_BrSort)
+		switch(Config()->m_BrSort)
 		{
 			case IServerBrowser::SORT_NAME:
 				Column = COL_BROWSER_NAME;
@@ -1283,7 +1283,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 					m_aSelectedFilters[BrowserType] = FilterIndex;
 					m_aSelectedServers[BrowserType] = ServerIndex;
 					m_AddressSelection &= ~(ADDR_SELECTION_CHANGE|ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND);
-					if(Config()->Values()->m_UiAutoswitchInfotab)
+					if(Config()->m_UiAutoswitchInfotab)
 						m_SidebarTab = 0;
 					UpdateServerBrowserAddress(); // update now instead of using flag because of connect
 					if(Input()->MouseDoubleClick())
@@ -1329,7 +1329,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	UI()->DoLabel(&Label, Localize("Search:"), FontSize, CUI::ALIGN_LEFT);
 	EditBox.VSplitRight(EditBox.h, &EditBox, &Button);
 	static float s_ClearOffset = 0.0f;
-	if(DoEditBox(&Config()->Values()->m_BrFilterString, &EditBox, Config()->Values()->m_BrFilterString, sizeof(Config()->Values()->m_BrFilterString), FontSize, &s_ClearOffset, false, CUI::CORNER_ALL))
+	if(DoEditBox(&Config()->m_BrFilterString, &EditBox, Config()->m_BrFilterString, sizeof(Config()->m_BrFilterString), FontSize, &s_ClearOffset, false, CUI::CORNER_ALL))
 	{
 		Client()->ServerBrowserUpdate();
 		ServerBrowserFilterOnUpdate();
@@ -1340,8 +1340,8 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		static CButtonContainer s_ClearButton;
 		if(DoButton_SpriteID(&s_ClearButton, IMAGE_TOOLICONS, SPRITE_TOOL_X_A, false, &Button, CUI::CORNER_ALL, 5.0f, true))
 		{
-			Config()->Values()->m_BrFilterString[0] = 0;
-			UI()->SetActiveItem(&Config()->Values()->m_BrFilterString);
+			Config()->m_BrFilterString[0] = 0;
+			UI()->SetActiveItem(&Config()->m_BrFilterString);
 			Client()->ServerBrowserUpdate();
 		}
 	}
@@ -1356,7 +1356,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	if(BrowserType == IServerBrowser::TYPE_INTERNET)
 	{
 		static float s_InternetAddressOffset = 0.0f;
-		if(DoEditBox(&Config()->Values()->m_UiServerAddress, &EditBox, Config()->Values()->m_UiServerAddress, sizeof(Config()->Values()->m_UiServerAddress), FontSize, &s_InternetAddressOffset, false, CUI::CORNER_ALL))
+		if(DoEditBox(&Config()->m_UiServerAddress, &EditBox, Config()->m_UiServerAddress, sizeof(Config()->m_UiServerAddress), FontSize, &s_InternetAddressOffset, false, CUI::CORNER_ALL))
 		{
 			m_AddressSelection |= ADDR_SELECTION_CHANGE | ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND | ADDR_SELECTION_REVEAL;
 		}
@@ -1364,7 +1364,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	else if(BrowserType == IServerBrowser::TYPE_LAN)
 	{
 		static float s_LanAddressOffset = 0.0f;
-		if(DoEditBox(&Config()->Values()->m_UiServerAddressLan, &EditBox, Config()->Values()->m_UiServerAddressLan, sizeof(Config()->Values()->m_UiServerAddressLan), FontSize, &s_LanAddressOffset, false, CUI::CORNER_ALL))
+		if(DoEditBox(&Config()->m_UiServerAddressLan, &EditBox, Config()->m_UiServerAddressLan, sizeof(Config()->m_UiServerAddressLan), FontSize, &s_LanAddressOffset, false, CUI::CORNER_ALL))
 		{
 			m_AddressSelection |= ADDR_SELECTION_CHANGE | ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND | ADDR_SELECTION_REVEAL;
 		}
@@ -1426,7 +1426,7 @@ void CMenus::RenderServerbrowserSidebar(CUIRect View)
 	CUIRect Header, Button;
 
 	// background
-	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_ALL, 5.0f);
+	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_ALL, 5.0f);
 
 	// handle Tab key
 	if(m_TabPressed)
@@ -2158,17 +2158,17 @@ void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int 
 			TextRender()->SetCursor(&Cursor, Name.x, Name.y, FontSize - 2, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 			Cursor.m_LineWidth = Name.w;
 			const char *pName = pInfo->m_aClients[i].m_aName;
-			if(Config()->Values()->m_BrFilterString[0])
+			if(Config()->m_BrFilterString[0])
 			{
 				// highlight the part that matches
-				const char *s = str_find_nocase(pName, Config()->Values()->m_BrFilterString);
+				const char *s = str_find_nocase(pName, Config()->m_BrFilterString);
 				if(s)
 				{
 					TextRender()->TextEx(&Cursor, pName, (int)(s - pName));
 					TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextColor.a);
-					TextRender()->TextEx(&Cursor, s, str_length(Config()->Values()->m_BrFilterString));
+					TextRender()->TextEx(&Cursor, s, str_length(Config()->m_BrFilterString));
 					TextRender()->TextColor(TextColor.r, TextColor.g, TextColor.b, TextColor.a);
-					TextRender()->TextEx(&Cursor, s + str_length(Config()->Values()->m_BrFilterString), -1);
+					TextRender()->TextEx(&Cursor, s + str_length(Config()->m_BrFilterString), -1);
 				}
 				else
 					TextRender()->TextEx(&Cursor, pName, -1);
@@ -2180,17 +2180,17 @@ void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int 
 			TextRender()->SetCursor(&Cursor, Clan.x, Clan.y, FontSize - 2, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 			Cursor.m_LineWidth = Clan.w;
 			const char *pClan = pInfo->m_aClients[i].m_aClan;
-			if(Config()->Values()->m_BrFilterString[0])
+			if(Config()->m_BrFilterString[0])
 			{
 				// highlight the part that matches
-				const char *s = str_find_nocase(pClan, Config()->Values()->m_BrFilterString);
+				const char *s = str_find_nocase(pClan, Config()->m_BrFilterString);
 				if(s)
 				{
 					TextRender()->TextEx(&Cursor, pClan, (int)(s - pClan));
 					TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextColor.a);
-					TextRender()->TextEx(&Cursor, s, str_length(Config()->Values()->m_BrFilterString));
+					TextRender()->TextEx(&Cursor, s, str_length(Config()->m_BrFilterString));
 					TextRender()->TextColor(TextColor.r, TextColor.g, TextColor.b, TextColor.a);
-					TextRender()->TextEx(&Cursor, s + str_length(Config()->Values()->m_BrFilterString), -1);
+					TextRender()->TextEx(&Cursor, s + str_length(Config()->m_BrFilterString), -1);
 				}
 				else
 					TextRender()->TextEx(&Cursor, pClan, -1);
@@ -2242,7 +2242,7 @@ void CMenus::RenderServerbrowserBottomBox(CUIRect MainView)
 	float ButtonWidth = MainView.w/2.0f-Spacing/2.0f;
 
 	// render background
-	RenderTools()->DrawUIRect4(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
+	RenderTools()->DrawUIRect4(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
 
 	// back to main menu
 	CUIRect Button;
@@ -2395,9 +2395,9 @@ const char *CMenus::GetServerBrowserAddress()
 {
 	const int Type = ServerBrowser()->GetType();
 	if(Type == IServerBrowser::TYPE_INTERNET)
-		return Config()->Values()->m_UiServerAddress;
+		return Config()->m_UiServerAddress;
 	else if(Type == IServerBrowser::TYPE_LAN)
-		return Config()->Values()->m_UiServerAddressLan;
+		return Config()->m_UiServerAddressLan;
 	return 0;
 }
 
@@ -2405,9 +2405,9 @@ void CMenus::SetServerBrowserAddress(const char *pAddress)
 {
 	const int Type = ServerBrowser()->GetType();
 	if(Type == IServerBrowser::TYPE_INTERNET)
-		str_copy(Config()->Values()->m_UiServerAddress, pAddress, sizeof(Config()->Values()->m_UiServerAddress));
+		str_copy(Config()->m_UiServerAddress, pAddress, sizeof(Config()->m_UiServerAddress));
 	else if(Type == IServerBrowser::TYPE_LAN)
-		str_copy(Config()->Values()->m_UiServerAddressLan, pAddress, sizeof(Config()->Values()->m_UiServerAddressLan));
+		str_copy(Config()->m_UiServerAddressLan, pAddress, sizeof(Config()->m_UiServerAddressLan));
 }
 
 void CMenus::ServerBrowserFilterOnUpdate()

--- a/src/game/client/components/menus_callback.cpp
+++ b/src/game/client/components/menus_callback.cpp
@@ -139,16 +139,16 @@ float CMenus::RenderSettingsControlsMouse(CUIRect View)
 	View.HSplitTop(Spacing, 0, &View);
 	View.HSplitTop(ButtonHeight, &Button, &View);
 	static int s_ButtonInpGrab = 0;
-	if(DoButton_CheckBox(&s_ButtonInpGrab, Localize("Use OS mouse acceleration"), !Config()->Values()->m_InpGrab, &Button))
+	if(DoButton_CheckBox(&s_ButtonInpGrab, Localize("Use OS mouse acceleration"), !Config()->m_InpGrab, &Button))
 	{
-		Config()->Values()->m_InpGrab ^= 1;
+		Config()->m_InpGrab ^= 1;
 	}
 	View.HSplitTop(Spacing, 0, &View);
 	View.HSplitTop(ButtonHeight, &Button, &View);
-	DoScrollbarOption(&Config()->Values()->m_InpMousesens, &Config()->Values()->m_InpMousesens, &Button, Localize("Ingame mouse sens."), 1, 500, &LogarithmicScrollbarScale);
+	DoScrollbarOption(&Config()->m_InpMousesens, &Config()->m_InpMousesens, &Button, Localize("Ingame mouse sens."), 1, 500, &LogarithmicScrollbarScale);
 	View.HSplitTop(Spacing, 0, &View);
 	View.HSplitTop(ButtonHeight, &Button, &View);
-	DoScrollbarOption(&Config()->Values()->m_UiMousesens, &Config()->Values()->m_UiMousesens, &Button, Localize("Menu mouse sens."), 1, 500, &LogarithmicScrollbarScale);
+	DoScrollbarOption(&Config()->m_UiMousesens, &Config()->m_UiMousesens, &Button, Localize("Menu mouse sens."), 1, 500, &LogarithmicScrollbarScale);
 
 	return BackgroundHeight;
 }
@@ -157,7 +157,7 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 {
 	UpdateBindKeys(m_pClient->m_pBinds);
 
-	bool JoystickEnabled = Config()->Values()->m_JoystickEnable;
+	bool JoystickEnabled = Config()->m_JoystickEnable;
 	int NumJoysticks = m_pClient->Input()->NumJoysticks();
 	int NumOptions = 2; // expandable header & message
 	if(JoystickEnabled && NumJoysticks > 0)
@@ -180,9 +180,9 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 	View.HSplitTop(Spacing, 0, &View);
 	View.HSplitTop(ButtonHeight, &Button, &View);
 	static int s_ButtonJoystickEnable = 0;
-	if(DoButton_CheckBox(&s_ButtonJoystickEnable, Localize("Enable joystick"), Config()->Values()->m_JoystickEnable, &Button))
+	if(DoButton_CheckBox(&s_ButtonJoystickEnable, Localize("Enable joystick"), Config()->m_JoystickEnable, &Button))
 	{
-		Config()->Values()->m_JoystickEnable ^= 1;
+		Config()->m_JoystickEnable ^= 1;
 	}
 	if(JoystickEnabled)
 	{
@@ -204,11 +204,11 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 
 			View.HSplitTop(Spacing, 0, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);
-			DoScrollbarOption(&Config()->Values()->m_JoystickSens, &Config()->Values()->m_JoystickSens, &Button, Localize("Joystick sens."), 1, 500, &LogarithmicScrollbarScale);
+			DoScrollbarOption(&Config()->m_JoystickSens, &Config()->m_JoystickSens, &Button, Localize("Joystick sens."), 1, 500, &LogarithmicScrollbarScale);
 
 			View.HSplitTop(Spacing, 0, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);
-			DoScrollbarOption(&Config()->Values()->m_JoystickTolerance, &Config()->Values()->m_JoystickTolerance, &Button, Localize("Joystick jitter tolerance"), 0, 50);
+			DoScrollbarOption(&Config()->m_JoystickTolerance, &Config()->m_JoystickTolerance, &Button, Localize("Joystick jitter tolerance"), 0, 50);
 
 			// shrink view and draw background
 			View.HSplitTop(Spacing, 0, &View);
@@ -387,7 +387,7 @@ void CMenus::DoJoystickAxisPicker(CUIRect View)
 	static int s_aActive[g_MaxJoystickAxes][2];
 	for(int i = 0; i < min(m_pClient->Input()->GetJoystickNumAxes(), g_MaxJoystickAxes); i++)
 	{
-		bool Active = Config()->Values()->m_JoystickX == i || Config()->Values()->m_JoystickY == i;
+		bool Active = Config()->m_JoystickX == i || Config()->m_JoystickY == i;
 
 		View.HSplitTop(Spacing, 0, &View);
 		View.HSplitTop(ButtonHeight, &Row, &View);
@@ -407,16 +407,16 @@ void CMenus::DoJoystickAxisPicker(CUIRect View)
 		Row.VSplitLeft(StatusMargin, 0, &Row);
 		Row.VSplitLeft(StatusWidth, &Button, &Row);
 		Button.HMargin((ButtonHeight-14.0f)/2.0f, &Button);
-		DoJoystickBar(&Button, (m_pClient->Input()->GetJoystickAxisValue(i)+1.0f)/2.0f, Config()->Values()->m_JoystickTolerance/50.0f, Active);
+		DoJoystickBar(&Button, (m_pClient->Input()->GetJoystickAxisValue(i)+1.0f)/2.0f, Config()->m_JoystickTolerance/50.0f, Active);
 
 		// Bind to X,Y
 		Row.VSplitLeft(2*StatusMargin, 0, &Row);
 		Row.VSplitLeft(BindWidth, &Button, &Row);
-		if(DoButton_CheckBox(&s_aActive[i][0], "X", Config()->Values()->m_JoystickX == i, &Button, Config()->Values()->m_JoystickY == i))
-			Config()->Values()->m_JoystickX = i;
+		if(DoButton_CheckBox(&s_aActive[i][0], "X", Config()->m_JoystickX == i, &Button, Config()->m_JoystickY == i))
+			Config()->m_JoystickX = i;
 		Row.VSplitLeft(BindWidth, &Button, &Row);
-		if(DoButton_CheckBox(&s_aActive[i][1], "Y", Config()->Values()->m_JoystickY == i, &Button, Config()->Values()->m_JoystickX == i))
-			Config()->Values()->m_JoystickY = i;
+		if(DoButton_CheckBox(&s_aActive[i][1], "Y", Config()->m_JoystickY == i, &Button, Config()->m_JoystickX == i))
+			Config()->m_JoystickY = i;
 		Row.VSplitLeft(StatusMargin, 0, &Row);
 	}
 }

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -50,7 +50,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	MainView.VSplitRight(450.0f, &MainView, 0);
 
 	if (m_SeekBarActive || m_MenuActive) // only draw the background if SeekBar or Menu is active
-		RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_T, 10.0f);
+		RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_T, 10.0f);
 
 	MainView.Margin(5.0f, &MainView);
 
@@ -331,7 +331,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 
 	// cut view
 	MainView.HSplitBottom(80.0f, &MainView, &BottomView);
-	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_ALL, 5.0f);
+	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_ALL, 5.0f);
 	BottomView.HSplitTop(20.f, 0, &BottomView);
 
 	static int s_Inited = 0;
@@ -443,7 +443,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	float BackgroundWidth = ButtonWidth*(float)NumButtons+(float)(NumButtons-1)*Spacing;
 
 	BottomView.VSplitRight(BackgroundWidth, 0, &BottomView);
-	RenderTools()->DrawUIRect4(&BottomView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
+	RenderTools()->DrawUIRect4(&BottomView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
 
 	BottomView.HSplitTop(25.0f, &BottomView, 0);
 	BottomView.VSplitLeft(ButtonWidth, &Button, &BottomView);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -64,7 +64,7 @@ void CMenus::RenderGame(CUIRect MainView)
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	float NoteHeight = !Info.m_aNotification[0] ? 0.0f : 45.0f;
 	MainView.HSplitTop(20.0f+20.0f+2*Spacing+ NoteHeight, &MainView, 0);
-	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_ALL, 5.0f);
+	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_ALL, 5.0f);
 
 	// game options
 	MainView.HSplitTop(20.0f, &Label, &MainView);
@@ -214,7 +214,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 	CUIRect Label, Row;
 	MainView.HSplitBottom(80.0f, &MainView, 0);
 	MainView.HSplitTop(20.0f, 0, &MainView);
-	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_ALL, 5.0f);
+	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_ALL, 5.0f);
 
 	// player options
 	MainView.HSplitTop(ButtonHeight, &Label, &MainView);
@@ -294,7 +294,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 			Row.VSplitLeft(2*Spacing, 0, &Row);
 			Row.VSplitLeft(NameWidth, &Label, &Row);
 			Label.y += 2.0f;
-			if(Config()->Values()->m_ClShowUserId)
+			if(Config()->m_ClShowUserId)
 			{
 				CTextCursor Cursor;
 				TextRender()->SetCursor(&Cursor, Label.x, Label.y, ButtonHeight*ms_FontmodHeight*0.8f, TEXTFLAG_RENDER);
@@ -302,18 +302,18 @@ void CMenus::RenderPlayers(CUIRect MainView)
 				Label.VSplitLeft(ButtonHeight, 0, &Label);
 			}
 			char aBuf[64];
-			str_format(aBuf, sizeof(aBuf), "%s", Config()->Values()->m_ClShowsocial ? m_pClient->m_aClients[i].m_aName : "");
+			str_format(aBuf, sizeof(aBuf), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[i].m_aName : "");
 			UI()->DoLabel(&Label, aBuf, ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 			Row.VSplitLeft(Spacing, 0, &Row);
 			Row.VSplitLeft(ClanWidth, &Label, &Row);
 			Label.y += 2.0f;
-			str_format(aBuf, sizeof(aBuf), "%s", Config()->Values()->m_ClShowsocial ? m_pClient->m_aClients[i].m_aClan : "");
+			str_format(aBuf, sizeof(aBuf), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[i].m_aClan : "");
 			UI()->DoLabel(&Label, aBuf, ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 
 			// ignore button
 			Row.VSplitRight(ButtonHeight/2, &Row, 0);
 			Row.VSplitRight(ButtonHeight, &Row, &Label);
-			if(Config()->Values()->m_ClFilterchat == 2 || (Config()->Values()->m_ClFilterchat == 1 && !m_pClient->m_aClients[i].m_Friend))
+			if(Config()->m_ClFilterchat == 2 || (Config()->m_ClFilterchat == 1 && !m_pClient->m_aClients[i].m_Friend))
 				DoButton_Toggle(&s_aPlayerIDs[i][0], 1, &Label, false);
 			else
 				if(DoButton_Toggle(&s_aPlayerIDs[i][0], m_pClient->m_aClients[i].m_ChatIgnore, &Label, true))
@@ -355,7 +355,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	// render background
 	MainView.HSplitBottom(80.0f, &MainView, 0);
 	MainView.HSplitTop(20.0f, 0, &MainView);
-	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_ALL, 5.0f);
+	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_ALL, 5.0f);
 
 	CUIRect ServerInfo, GameInfo, Motd, Label;
 
@@ -573,7 +573,7 @@ void CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 			RenderTools()->RenderTee(CAnimState::GetIdle(), &Info, EMOTE_NORMAL, vec2(1.0f, 0.0f), vec2(Label.x + Label.h / 2, Label.y + Label.h / 2));
 
 			Row.VSplitLeft(2*Spacing, 0, &Row);
-			if(Config()->Values()->m_ClShowUserId)
+			if(Config()->m_ClShowUserId)
 			{
 				Row.VSplitLeft(Row.h, &Label, &Row);
 				Label.y += 2.0f;
@@ -586,12 +586,12 @@ void CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 			Row.VSplitLeft(NameWidth, &Label, &Row);
 			Label.y += 2.0f;
 			char aBuf[64];
-			str_format(aBuf, sizeof(aBuf), "%s", Config()->Values()->m_ClShowsocial ? m_pClient->m_aClients[aPlayerIDs[i]].m_aName : "");
+			str_format(aBuf, sizeof(aBuf), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[aPlayerIDs[i]].m_aName : "");
 			UI()->DoLabel(&Label, aBuf, Label.h*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 			Row.VSplitLeft(Spacing, 0, &Row);
 			Row.VSplitLeft(ClanWidth, &Label, &Row);
 			Label.y += 2.0f;
-			str_format(aBuf, sizeof(aBuf), "%s", Config()->Values()->m_ClShowsocial ? m_pClient->m_aClients[aPlayerIDs[i]].m_aClan : "");
+			str_format(aBuf, sizeof(aBuf), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[aPlayerIDs[i]].m_aClan : "");
 			UI()->DoLabel(&Label, aBuf, Label.h*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 		}
 	}
@@ -663,7 +663,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 		// only print notice
 		CUIRect Bar;
 		MainView.HSplitTop(45.0f, &Bar, &MainView);
-		RenderTools()->DrawUIRect(&Bar, vec4(0.0f, 0.0f, 0.0f, 0.25f+Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_ALL, 5.0f);
+		RenderTools()->DrawUIRect(&Bar, vec4(0.0f, 0.0f, 0.0f, 0.25f+Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_ALL, 5.0f);
 		Bar.HMargin(15.0f, &Bar);
 		UI()->DoLabel(&Bar, pNotification, 14.0f, CUI::ALIGN_CENTER);
 		return;
@@ -708,7 +708,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	{
 		MainView.HSplitTop(20.0f+45.0f, &MainView, 0);
 	}
-	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
+	RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	if(pNotification && !Authed)
 	{

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -329,7 +329,7 @@ void CMenus::RenderHSLPicker(CUIRect MainView)
 				*CSkins::ms_apColorVariables[p] = NewVal;
 		}
 		if(UseAlpha)
-			Config()->Values()->m_PlayerColorMarking = (Alp << 24) + NewVal;
+			Config()->m_PlayerColorMarking = (Alp << 24) + NewVal;
 		m_SkinModified = true;
 	}
 }
@@ -364,7 +364,7 @@ void CMenus::RenderSkinSelection(CUIRect MainView)
 		const CSkins::CSkin *s = s_paSkinList[i];
 		if(s == 0)
 			continue;
-		if(!str_comp(s->m_aName, Config()->Values()->m_PlayerSkin))
+		if(!str_comp(s->m_aName, Config()->m_PlayerSkin))
 		{
 			m_pSelectedSkin = s;
 			OldSelected = i;
@@ -398,7 +398,7 @@ void CMenus::RenderSkinSelection(CUIRect MainView)
 	if(NewSelected != -1 && NewSelected != OldSelected)
 	{
 		m_pSelectedSkin = s_paSkinList[NewSelected];
-		mem_copy(Config()->Values()->m_PlayerSkin, m_pSelectedSkin->m_aName, sizeof(Config()->Values()->m_PlayerSkin));
+		mem_copy(Config()->m_PlayerSkin, m_pSelectedSkin->m_aName, sizeof(Config()->m_PlayerSkin));
 		for(int p = 0; p < NUM_SKINPARTS; p++)
 		{
 			mem_copy(CSkins::ms_apSkinVariables[p], m_pSelectedSkin->m_apParts[p]->m_aName, 24);
@@ -488,7 +488,7 @@ void CMenus::RenderSkinPartSelection(CUIRect MainView)
 	{
 		const CSkins::CSkinPart *s = s_paList[m_TeePartSelected][NewSelected];
 		mem_copy(CSkins::ms_apSkinVariables[m_TeePartSelected], s->m_aName, 24);
-		Config()->Values()->m_PlayerSkin[0] = 0;
+		Config()->m_PlayerSkin[0] = 0;
 		m_SkinModified = true;
 	}
 	OldSelected = NewSelected;
@@ -698,7 +698,7 @@ void CMenus::RenderLanguageSelection(CUIRect MainView, bool Header)
 		LoadLanguageIndexfile(Storage(), Console(), &s_Languages);
 		for(int i = 0; i < s_Languages.size(); i++)
 		{
-			if(str_comp(s_Languages[i].m_FileName, Config()->Values()->m_ClLanguagefile) == 0)
+			if(str_comp(s_Languages[i].m_FileName, Config()->m_ClLanguagefile) == 0)
 			{
 				s_SelectedLanguage = i;
 				break;
@@ -746,7 +746,7 @@ void CMenus::RenderLanguageSelection(CUIRect MainView, bool Header)
 	if(OldSelected != s_SelectedLanguage)
 	{
 		m_ActiveListBox = ACTLB_LANG;
-		str_copy(Config()->Values()->m_ClLanguagefile, s_Languages[s_SelectedLanguage].m_FileName, sizeof(Config()->Values()->m_ClLanguagefile));
+		str_copy(Config()->m_ClLanguagefile, s_Languages[s_SelectedLanguage].m_FileName, sizeof(Config()->m_ClLanguagefile));
 		g_Localization.Load(s_Languages[s_SelectedLanguage].m_FileName, Storage(), Console());
 	}
 }
@@ -758,13 +758,13 @@ void CMenus::RenderThemeSelection(CUIRect MainView, bool Header)
 
 	if(m_lThemes.size() == 0) // not loaded yet
 	{
-		if(!Config()->Values()->m_ClShowMenuMap)
-			str_copy(Config()->Values()->m_ClMenuMap, "", sizeof(Config()->Values()->m_ClMenuMap)); // cl_menu_map otherwise resets to default on loading
+		if(!Config()->m_ClShowMenuMap)
+			str_copy(Config()->m_ClMenuMap, "", sizeof(Config()->m_ClMenuMap)); // cl_menu_map otherwise resets to default on loading
 		m_lThemes.add(CTheme("", false, false)); // no theme
 		Storage()->ListDirectory(IStorage::TYPE_ALL, "ui/themes", ThemeScan, (CMenus*)this);
 		Storage()->ListDirectory(IStorage::TYPE_ALL, "ui/themes", ThemeIconScan, (CMenus*)this);
 		for(int i = 0; i < m_lThemes.size(); i++)
-			if(str_comp(m_lThemes[i].m_Name, Config()->Values()->m_ClMenuMap) == 0)
+			if(str_comp(m_lThemes[i].m_Name, Config()->m_ClMenuMap) == 0)
 			{
 				s_SelectedTheme = i;
 				break;
@@ -837,11 +837,11 @@ void CMenus::RenderThemeSelection(CUIRect MainView, bool Header)
 	if(OldSelected != s_SelectedTheme)
 	{
 		m_ActiveListBox = ACTLB_THEME;
-		str_copy(Config()->Values()->m_ClMenuMap, m_lThemes[s_SelectedTheme].m_Name, sizeof(Config()->Values()->m_ClMenuMap));
+		str_copy(Config()->m_ClMenuMap, m_lThemes[s_SelectedTheme].m_Name, sizeof(Config()->m_ClMenuMap));
 		if(m_lThemes[s_SelectedTheme].m_Name[0])
-			Config()->Values()->m_ClShowMenuMap = 1;
+			Config()->m_ClShowMenuMap = 1;
 		else
-			Config()->Values()->m_ClShowMenuMap = 0;
+			Config()->m_ClShowMenuMap = 0;
 		m_pClient->m_pMapLayersBackGround->BackgroundMapUpdate();
 	}
 }
@@ -855,7 +855,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	BottomView.HSplitTop(20.f, 0, &BottomView);
 
 	// render game menu backgrounds
-	int NumOptions = max(Config()->Values()->m_ClNameplates ? 6 : 3, Config()->Values()->m_ClShowsocial ? 5 : 4);
+	int NumOptions = max(Config()->m_ClNameplates ? 6 : 3, Config()->m_ClShowsocial ? 5 : 4);
 	float ButtonHeight = 20.0f;
 	float Spacing = 2.0f;
 	float BackgroundHeight = (float)(NumOptions+1)*ButtonHeight+(float)NumOptions*Spacing;
@@ -864,15 +864,15 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		Background = MainView;
 	else
 		MainView.HSplitTop(20.0f, 0, &Background);
-	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), this->Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
+	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), this->Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	MainView.HSplitTop(BackgroundHeight, &Game, &MainView);
 	RenderTools()->DrawUIRect(&Game, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
 	// render client menu background
 	NumOptions = 4;
-	if(Config()->Values()->m_ClAutoDemoRecord) NumOptions += 1;
-	if(Config()->Values()->m_ClAutoScreenshot) NumOptions += 1;
+	if(Config()->m_ClAutoDemoRecord) NumOptions += 1;
+	if(Config()->m_ClAutoScreenshot) NumOptions += 1;
 	BackgroundHeight = (float)(NumOptions+1)*ButtonHeight+(float)NumOptions*Spacing;
 
 	MainView.HSplitTop(10.0f, 0, &MainView);
@@ -893,81 +893,81 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	GameLeft.HSplitTop(Spacing, 0, &GameLeft);
 	GameLeft.HSplitTop(ButtonHeight, &Button, &GameLeft);
 	static int s_DynamicCameraButton = 0;
-	if(DoButton_CheckBox(&s_DynamicCameraButton, Localize("Dynamic Camera"), Config()->Values()->m_ClDynamicCamera, &Button))
+	if(DoButton_CheckBox(&s_DynamicCameraButton, Localize("Dynamic Camera"), Config()->m_ClDynamicCamera, &Button))
 	{
-		if(Config()->Values()->m_ClDynamicCamera)
+		if(Config()->m_ClDynamicCamera)
 		{
-			Config()->Values()->m_ClDynamicCamera = 0;
+			Config()->m_ClDynamicCamera = 0;
 			// force to defaults when using the GUI
-			Config()->Values()->m_ClMouseMaxDistanceStatic = 400;
-			// Config()->Values()->m_ClMouseFollowfactor = 0;
-			// Config()->Values()->m_ClMouseDeadzone = 0;
+			Config()->m_ClMouseMaxDistanceStatic = 400;
+			// Config()->m_ClMouseFollowfactor = 0;
+			// Config()->m_ClMouseDeadzone = 0;
 		}
 		else
 		{
-			Config()->Values()->m_ClDynamicCamera = 1;
+			Config()->m_ClDynamicCamera = 1;
 			// force to defaults when using the GUI
-			Config()->Values()->m_ClMouseMaxDistanceDynamic = 1000;
-			Config()->Values()->m_ClMouseFollowfactor = 60;
-			Config()->Values()->m_ClMouseDeadzone = 300;
+			Config()->m_ClMouseMaxDistanceDynamic = 1000;
+			Config()->m_ClMouseFollowfactor = 60;
+			Config()->m_ClMouseDeadzone = 300;
 		}
 	}
 
 	GameLeft.HSplitTop(Spacing, 0, &GameLeft);
 	GameLeft.HSplitTop(ButtonHeight, &Button, &GameLeft);
 	static int s_AutoswitchWeapons = 0;
-	if(DoButton_CheckBox(&s_AutoswitchWeapons, Localize("Switch weapon on pickup"), Config()->Values()->m_ClAutoswitchWeapons, &Button))
-		Config()->Values()->m_ClAutoswitchWeapons ^= 1;
+	if(DoButton_CheckBox(&s_AutoswitchWeapons, Localize("Switch weapon on pickup"), Config()->m_ClAutoswitchWeapons, &Button))
+		Config()->m_ClAutoswitchWeapons ^= 1;
 
 	GameLeft.HSplitTop(Spacing, 0, &GameLeft);
 	GameLeft.HSplitTop(ButtonHeight, &Button, &GameLeft);
 	static int s_Nameplates = 0;
-	if(DoButton_CheckBox(&s_Nameplates, Localize("Show name plates"), Config()->Values()->m_ClNameplates, &Button))
-		Config()->Values()->m_ClNameplates ^= 1;
+	if(DoButton_CheckBox(&s_Nameplates, Localize("Show name plates"), Config()->m_ClNameplates, &Button))
+		Config()->m_ClNameplates ^= 1;
 
-	if(Config()->Values()->m_ClNameplates)
+	if(Config()->m_ClNameplates)
 	{
 		GameLeft.HSplitTop(Spacing, 0, &GameLeft);
 		GameLeft.HSplitTop(ButtonHeight, &Button, &GameLeft);
 		Button.VSplitLeft(ButtonHeight, 0, &Button);
 		static int s_NameplatesAlways = 0;
-		if(DoButton_CheckBox(&s_NameplatesAlways, Localize("Always show name plates"), Config()->Values()->m_ClNameplatesAlways, &Button))
-			Config()->Values()->m_ClNameplatesAlways ^= 1;
+		if(DoButton_CheckBox(&s_NameplatesAlways, Localize("Always show name plates"), Config()->m_ClNameplatesAlways, &Button))
+			Config()->m_ClNameplatesAlways ^= 1;
 
 		GameLeft.HSplitTop(Spacing, 0, &GameLeft);
 		GameLeft.HSplitTop(ButtonHeight, &Button, &GameLeft);
 		Button.VSplitLeft(ButtonHeight, 0, &Button);
-		DoScrollbarOption(&Config()->Values()->m_ClNameplatesSize, &Config()->Values()->m_ClNameplatesSize, &Button, Localize("Size"), 0, 100);
+		DoScrollbarOption(&Config()->m_ClNameplatesSize, &Config()->m_ClNameplatesSize, &Button, Localize("Size"), 0, 100);
 
 		GameLeft.HSplitTop(Spacing, 0, &GameLeft);
 		GameLeft.HSplitTop(ButtonHeight, &Button, &GameLeft);
 		Button.VSplitLeft(ButtonHeight, 0, &Button);
 		static int s_NameplatesTeamcolors = 0;
-		if(DoButton_CheckBox(&s_NameplatesTeamcolors, Localize("Use team colors for name plates"), Config()->Values()->m_ClNameplatesTeamcolors, &Button))
-			Config()->Values()->m_ClNameplatesTeamcolors ^= 1;
+		if(DoButton_CheckBox(&s_NameplatesTeamcolors, Localize("Use team colors for name plates"), Config()->m_ClNameplatesTeamcolors, &Button))
+			Config()->m_ClNameplatesTeamcolors ^= 1;
 	}
 
 	// right side
 	GameRight.HSplitTop(Spacing, 0, &GameRight);
 	GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
 	static int s_Showhud = 0;
-	if(DoButton_CheckBox(&s_Showhud, Localize("Show ingame HUD"), Config()->Values()->m_ClShowhud, &Button))
-		Config()->Values()->m_ClShowhud ^= 1;
+	if(DoButton_CheckBox(&s_Showhud, Localize("Show ingame HUD"), Config()->m_ClShowhud, &Button))
+		Config()->m_ClShowhud ^= 1;
 
 	GameRight.HSplitTop(Spacing, 0, &GameRight);
 	GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
 	static int s_ShowUserId = 0;
-	if(DoButton_CheckBox(&s_ShowUserId, Localize("Show user IDs"), Config()->Values()->m_ClShowUserId, &Button))
-		Config()->Values()->m_ClShowUserId ^= 1;
+	if(DoButton_CheckBox(&s_ShowUserId, Localize("Show user IDs"), Config()->m_ClShowUserId, &Button))
+		Config()->m_ClShowUserId ^= 1;
 
 	GameRight.HSplitTop(Spacing, 0, &GameRight);
 	GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
 	static int s_Showsocial = 0;
-	if(DoButton_CheckBox(&s_Showsocial, Localize("Show social"), Config()->Values()->m_ClShowsocial, &Button))
-		Config()->Values()->m_ClShowsocial ^= 1;
+	if(DoButton_CheckBox(&s_Showsocial, Localize("Show social"), Config()->m_ClShowsocial, &Button))
+		Config()->m_ClShowsocial ^= 1;
 
 	// show chat messages button
-	if(Config()->Values()->m_ClShowsocial)
+	if(Config()->m_ClShowsocial)
 	{
 		GameRight.HSplitTop(Spacing, 0, &GameRight);
 		GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
@@ -983,23 +983,23 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		UI()->DoLabel(&Text, aBuf, Text.h*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 
 		Button.VSplitLeft(119.0f, &Button, 0);
-		if(Config()->Values()->m_ClFilterchat == 0)
+		if(Config()->m_ClFilterchat == 0)
 			str_format(aBuf, sizeof(aBuf), Localize("everyone", "Show chat messages from:"));
-		else if(Config()->Values()->m_ClFilterchat == 1)
+		else if(Config()->m_ClFilterchat == 1)
 			str_format(aBuf, sizeof(aBuf), Localize("friends only", "Show chat messages from:"));
-		else if(Config()->Values()->m_ClFilterchat == 2)
+		else if(Config()->m_ClFilterchat == 2)
 			str_format(aBuf, sizeof(aBuf), Localize("no one", "Show chat messages from:"));
 		static CButtonContainer s_ButtonFilterchat;
 		if(DoButton_Menu(&s_ButtonFilterchat, aBuf, 0, &Button))
-			Config()->Values()->m_ClFilterchat = (Config()->Values()->m_ClFilterchat + 1) % 3;
+			Config()->m_ClFilterchat = (Config()->m_ClFilterchat + 1) % 3;
 	}
 
 	GameRight.HSplitTop(Spacing, 0, &GameRight);
 	GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
 	static int s_EnableColoredBroadcasts = 0;
 	if(DoButton_CheckBox(&s_EnableColoredBroadcasts, Localize("Enable colored server broadcasts"),
-						 Config()->Values()->m_ClColoredBroadcast, &Button))
-		Config()->Values()->m_ClColoredBroadcast ^= 1;
+						 Config()->m_ClColoredBroadcast, &Button))
+		Config()->m_ClColoredBroadcast ^= 1;
 
 	// render client menu
 	Client.HSplitTop(ButtonHeight, &Label, &Client);
@@ -1009,39 +1009,39 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	Client.HSplitTop(Spacing, 0, &Client);
 	Client.HSplitTop(ButtonHeight, &Button, &Client);
 	static int s_SkipMainMenu = 0;
-	if(DoButton_CheckBox(&s_SkipMainMenu, Localize("Skip the main menu"), Config()->Values()->m_ClSkipStartMenu, &Button))
-		Config()->Values()->m_ClSkipStartMenu ^= 1;
+	if(DoButton_CheckBox(&s_SkipMainMenu, Localize("Skip the main menu"), Config()->m_ClSkipStartMenu, &Button))
+		Config()->m_ClSkipStartMenu ^= 1;
 
 	Client.HSplitTop(Spacing, 0, &Client);
 	Client.HSplitTop(ButtonHeight, &Button, &Client);
-	DoScrollbarOption(&Config()->Values()->m_ClMenuAlpha, &Config()->Values()->m_ClMenuAlpha, &Button, Localize("Menu background transparency"), 0, 75);
+	DoScrollbarOption(&Config()->m_ClMenuAlpha, &Config()->m_ClMenuAlpha, &Button, Localize("Menu background transparency"), 0, 75);
 
 	Client.HSplitTop(Spacing, 0, &Client);
 	Client.HSplitTop(ButtonHeight, &Button, &Client);
 	static int s_AutoDemoRecord = 0;
-	if(DoButton_CheckBox(&s_AutoDemoRecord, Localize("Automatically record demos"), Config()->Values()->m_ClAutoDemoRecord, &Button))
-		Config()->Values()->m_ClAutoDemoRecord ^= 1;
+	if(DoButton_CheckBox(&s_AutoDemoRecord, Localize("Automatically record demos"), Config()->m_ClAutoDemoRecord, &Button))
+		Config()->m_ClAutoDemoRecord ^= 1;
 
-	if(Config()->Values()->m_ClAutoDemoRecord)
+	if(Config()->m_ClAutoDemoRecord)
 	{
 		Client.HSplitTop(Spacing, 0, &Client);
 		Client.HSplitTop(ButtonHeight, &Button, &Client);
 		Button.VSplitLeft(ButtonHeight, 0, &Button);
-		DoScrollbarOption(&Config()->Values()->m_ClAutoDemoMax, &Config()->Values()->m_ClAutoDemoMax, &Button, Localize("Max"), 0, 1000, &LogarithmicScrollbarScale, true);
+		DoScrollbarOption(&Config()->m_ClAutoDemoMax, &Config()->m_ClAutoDemoMax, &Button, Localize("Max"), 0, 1000, &LogarithmicScrollbarScale, true);
 	}
 
 	Client.HSplitTop(Spacing, 0, &Client);
 	Client.HSplitTop(ButtonHeight, &Button, &Client);
 	static int s_AutoScreenshot = 0;
-	if(DoButton_CheckBox(&s_AutoScreenshot, Localize("Automatically take game over screenshot"), Config()->Values()->m_ClAutoScreenshot, &Button))
-		Config()->Values()->m_ClAutoScreenshot ^= 1;
+	if(DoButton_CheckBox(&s_AutoScreenshot, Localize("Automatically take game over screenshot"), Config()->m_ClAutoScreenshot, &Button))
+		Config()->m_ClAutoScreenshot ^= 1;
 
-	if(Config()->Values()->m_ClAutoScreenshot)
+	if(Config()->m_ClAutoScreenshot)
 	{
 		Client.HSplitTop(Spacing, 0, &Client);
 		Client.HSplitTop(ButtonHeight, &Button, &Client);
 		Button.VSplitLeft(ButtonHeight, 0, &Button);
-		DoScrollbarOption(&Config()->Values()->m_ClAutoScreenshotMax, &Config()->Values()->m_ClAutoScreenshotMax, &Button, Localize("Max"), 0, 1000, &LogarithmicScrollbarScale, true);
+		DoScrollbarOption(&Config()->m_ClAutoScreenshotMax, &Config()->m_ClAutoScreenshotMax, &Button, Localize("Max"), 0, 1000, &LogarithmicScrollbarScale, true);
 	}
 
 	MainView.HSplitTop(10.0f, 0, &MainView);
@@ -1059,41 +1059,41 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	float ButtonWidth = (BottomView.w/6.0f)-(Spacing*5.0)/6.0f;
 
 	BottomView.VSplitRight(ButtonWidth, 0, &BottomView);
-	RenderTools()->DrawUIRect4(&BottomView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
+	RenderTools()->DrawUIRect4(&BottomView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
 
 	BottomView.HSplitTop(25.0f, &BottomView, 0);
 	Button = BottomView;
 	static CButtonContainer s_ResetButton;
 	if(DoButton_Menu(&s_ResetButton, Localize("Reset"), 0, &Button))
 	{
-		Config()->Values()->m_ClDynamicCamera = 0;
-		Config()->Values()->m_ClMouseMaxDistanceStatic = 400;
-		Config()->Values()->m_ClMouseMaxDistanceDynamic = 1000;
-		Config()->Values()->m_ClMouseFollowfactor = 60;
-		Config()->Values()->m_ClMouseDeadzone = 300;
-		Config()->Values()->m_ClAutoswitchWeapons = 1;
-		Config()->Values()->m_ClShowhud = 1;
-		Config()->Values()->m_ClFilterchat = 0;
-		Config()->Values()->m_ClNameplates = 1;
-		Config()->Values()->m_ClNameplatesAlways = 1;
-		Config()->Values()->m_ClNameplatesSize = 50;
-		Config()->Values()->m_ClNameplatesTeamcolors = 1;
-		Config()->Values()->m_ClAutoDemoRecord = 0;
-		Config()->Values()->m_ClAutoDemoMax = 10;
-		Config()->Values()->m_ClAutoScreenshot = 0;
-		Config()->Values()->m_ClAutoScreenshotMax = 10;
+		Config()->m_ClDynamicCamera = 0;
+		Config()->m_ClMouseMaxDistanceStatic = 400;
+		Config()->m_ClMouseMaxDistanceDynamic = 1000;
+		Config()->m_ClMouseFollowfactor = 60;
+		Config()->m_ClMouseDeadzone = 300;
+		Config()->m_ClAutoswitchWeapons = 1;
+		Config()->m_ClShowhud = 1;
+		Config()->m_ClFilterchat = 0;
+		Config()->m_ClNameplates = 1;
+		Config()->m_ClNameplatesAlways = 1;
+		Config()->m_ClNameplatesSize = 50;
+		Config()->m_ClNameplatesTeamcolors = 1;
+		Config()->m_ClAutoDemoRecord = 0;
+		Config()->m_ClAutoDemoMax = 10;
+		Config()->m_ClAutoScreenshot = 0;
+		Config()->m_ClAutoScreenshotMax = 10;
 	}
 }
 
 void CMenus::RenderSettingsPlayer(CUIRect MainView)
 {
-	static int s_PlayerCountry = Config()->Values()->m_PlayerCountry;
+	static int s_PlayerCountry = Config()->m_PlayerCountry;
 	static char s_aPlayerName[256] = {0};
 	static char s_aPlayerClan[256] = {0};
 	if(!s_aPlayerName[0])
-		str_copy(s_aPlayerName, Config()->Values()->m_PlayerName, sizeof(s_aPlayerName));
+		str_copy(s_aPlayerName, Config()->m_PlayerName, sizeof(s_aPlayerName));
 	if(!s_aPlayerClan[0])
-		str_copy(s_aPlayerClan, Config()->Values()->m_PlayerClan, sizeof(s_aPlayerClan));
+		str_copy(s_aPlayerClan, Config()->m_PlayerClan, sizeof(s_aPlayerClan));
 
 	CUIRect Button, Left, Right, TopView, Label, Background;
 
@@ -1107,7 +1107,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 		Background = MainView;
 	else
 		MainView.HSplitTop(20.0f, 0, &Background);
-	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
+	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	MainView.HSplitTop(BackgroundHeight, &TopView, &MainView);
 	RenderTools()->DrawUIRect(&TopView, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
@@ -1126,12 +1126,12 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	// left menu
 	Left.HSplitTop(ButtonHeight, &Button, &Left);
 	static float s_OffsetName = 0.0f;
-	DoEditBoxOption(Config()->Values()->m_PlayerName, Config()->Values()->m_PlayerName, sizeof(Config()->Values()->m_PlayerName), &Button, Localize("Name"),  100.0f, &s_OffsetName);
+	DoEditBoxOption(Config()->m_PlayerName, Config()->m_PlayerName, sizeof(Config()->m_PlayerName), &Button, Localize("Name"),  100.0f, &s_OffsetName);
 
 	// right menu
 	Right.HSplitTop(ButtonHeight, &Button, &Right);
 	static float s_OffsetClan = 0.0f;
-	DoEditBoxOption(Config()->Values()->m_PlayerClan, Config()->Values()->m_PlayerClan, sizeof(Config()->Values()->m_PlayerClan), &Button, Localize("Clan"),  100.0f, &s_OffsetClan);
+	DoEditBoxOption(Config()->m_PlayerClan, Config()->m_PlayerClan, sizeof(Config()->m_PlayerClan), &Button, Localize("Clan"),  100.0f, &s_OffsetClan);
 
 	// country flag selector
 	MainView.HSplitTop(10.0f, 0, &MainView);
@@ -1145,7 +1145,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 		const CCountryFlags::CCountryFlag *pEntry = m_pClient->m_pCountryFlags->GetByIndex(i);
 		if(pEntry->m_Blocked)
 			continue;
-		if(pEntry->m_CountryCode == Config()->Values()->m_PlayerCountry)
+		if(pEntry->m_CountryCode == Config()->m_PlayerCountry)
 			OldSelected = i;
 
 		CListboxItem Item = s_ListBox.DoNextItem(pEntry, OldSelected == i);
@@ -1178,14 +1178,14 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 
 	const int NewSelected = s_ListBox.DoEnd();
 	if(OldSelected != NewSelected)
-		Config()->Values()->m_PlayerCountry = m_pClient->m_pCountryFlags->GetByIndex(NewSelected, true)->m_CountryCode;
+		Config()->m_PlayerCountry = m_pClient->m_pCountryFlags->GetByIndex(NewSelected, true)->m_CountryCode;
 
 
 	// check if the new settings require a server reload
 	m_NeedRestartPlayer = !(
-		s_PlayerCountry == Config()->Values()->m_PlayerCountry &&
-		!str_comp(s_aPlayerClan, Config()->Values()->m_PlayerClan) &&
-		!str_comp(s_aPlayerName, Config()->Values()->m_PlayerName)
+		s_PlayerCountry == Config()->m_PlayerCountry &&
+		!str_comp(s_aPlayerClan, Config()->m_PlayerClan) &&
+		!str_comp(s_aPlayerName, Config()->m_PlayerName)
 		);
 }
 
@@ -1245,7 +1245,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	static bool s_CustomSkinMenu = false;
 	static char s_aPlayerSkin[256] = {0};
 	if(!s_aPlayerSkin[0])
-		str_copy(s_aPlayerSkin, Config()->Values()->m_PlayerSkin, sizeof(s_aPlayerSkin));
+		str_copy(s_aPlayerSkin, Config()->m_PlayerSkin, sizeof(s_aPlayerSkin));
 
 	CUIRect Button, Label, BottomView, Preview, Background;
 
@@ -1266,7 +1266,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		Background = MainView;
 	else
 		MainView.HSplitTop(20.0f, 0, &Background);
-	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
+	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	MainView.HSplitTop(BackgroundHeight, &Preview, &MainView);
 	RenderTools()->DrawUIRect(&Preview, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
@@ -1401,7 +1401,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		RenderTools()->DrawUIRect(&Preview, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
 		Preview.y += 2.0f;
-		UI()->DoLabel(&Preview, Config()->Values()->m_PlayerSkin, ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
+		UI()->DoLabel(&Preview, Config()->m_PlayerSkin, ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 	}
 
 	MainView.HSplitTop(10.0f, 0, &MainView);
@@ -1416,7 +1416,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	float BackgroundWidth = s_CustomSkinMenu||(m_pSelectedSkin && (m_pSelectedSkin->m_Flags&CSkins::SKINFLAG_STANDARD) == 0) ? ButtonWidth*2.0f+SpacingW : ButtonWidth;
 
 	BottomView.VSplitRight(BackgroundWidth, 0, &BottomView);
-	RenderTools()->DrawUIRect4(&BottomView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
+	RenderTools()->DrawUIRect4(&BottomView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
 
 	BottomView.HSplitTop(25.0f, &BottomView, 0);
 	if(s_CustomSkinMenu)
@@ -1447,8 +1447,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	}
 }
 
-//typedef void (*pfnAssignFuncCallback)(CConfiguration *pConfig, int Value);
-
 void CMenus::RenderSettingsControls(CUIRect MainView)
 {
 	// cut view
@@ -1458,7 +1456,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 		Background = MainView;
 	else
 		MainView.HSplitTop(20.0f, 0, &Background);
-	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
+	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	BottomView.HSplitTop(20.f, 0, &BottomView);
 
@@ -1528,7 +1526,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 	float ButtonWidth = (BottomView.w/6.0f)-(Spacing*5.0)/6.0f;
 
 	BottomView.VSplitRight(ButtonWidth, 0, &BottomView);
-	RenderTools()->DrawUIRect4(&BottomView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
+	RenderTools()->DrawUIRect4(&BottomView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
 
 	BottomView.HSplitTop(25.0f, &BottomView, 0);
 	Button = BottomView;
@@ -1542,48 +1540,48 @@ float CMenus::RenderSettingsControlsStats(CUIRect View)
 	CUIRect Button;
 
 	View.HSplitTop(20.0f, &Button, &View);
-	if(DoButton_CheckBox(&Config()->Values()->m_ClStatboardInfos, Localize("Frags"), Config()->Values()->m_ClStatboardInfos & TC_STATS_FRAGS, &Button))
-		Config()->Values()->m_ClStatboardInfos ^= TC_STATS_FRAGS;
+	if(DoButton_CheckBox(&Config()->m_ClStatboardInfos, Localize("Frags"), Config()->m_ClStatboardInfos & TC_STATS_FRAGS, &Button))
+		Config()->m_ClStatboardInfos ^= TC_STATS_FRAGS;
 
 	View.HSplitTop(20.0f, &Button, &View);
-	if(DoButton_CheckBox(&Config()->Values()->m_ClStatboardInfos+1, Localize("Deaths"), Config()->Values()->m_ClStatboardInfos & TC_STATS_DEATHS, &Button))
-		Config()->Values()->m_ClStatboardInfos ^= TC_STATS_DEATHS;
+	if(DoButton_CheckBox(&Config()->m_ClStatboardInfos+1, Localize("Deaths"), Config()->m_ClStatboardInfos & TC_STATS_DEATHS, &Button))
+		Config()->m_ClStatboardInfos ^= TC_STATS_DEATHS;
 
 	View.HSplitTop(20.0f, &Button, &View);
-	if(DoButton_CheckBox(&Config()->Values()->m_ClStatboardInfos+2, Localize("Suicides"), Config()->Values()->m_ClStatboardInfos & TC_STATS_SUICIDES, &Button))
-		Config()->Values()->m_ClStatboardInfos ^= TC_STATS_SUICIDES;
+	if(DoButton_CheckBox(&Config()->m_ClStatboardInfos+2, Localize("Suicides"), Config()->m_ClStatboardInfos & TC_STATS_SUICIDES, &Button))
+		Config()->m_ClStatboardInfos ^= TC_STATS_SUICIDES;
 
 	View.HSplitTop(20.0f, &Button, &View);
-	if(DoButton_CheckBox(&Config()->Values()->m_ClStatboardInfos+3, Localize("Ratio"), Config()->Values()->m_ClStatboardInfos & TC_STATS_RATIO, &Button))
-		Config()->Values()->m_ClStatboardInfos ^= TC_STATS_RATIO;
+	if(DoButton_CheckBox(&Config()->m_ClStatboardInfos+3, Localize("Ratio"), Config()->m_ClStatboardInfos & TC_STATS_RATIO, &Button))
+		Config()->m_ClStatboardInfos ^= TC_STATS_RATIO;
 
 	View.HSplitTop(20.0f, &Button, &View);
-	if(DoButton_CheckBox(&Config()->Values()->m_ClStatboardInfos+4, Localize("Net score"), Config()->Values()->m_ClStatboardInfos & TC_STATS_NET, &Button))
-		Config()->Values()->m_ClStatboardInfos ^= TC_STATS_NET;
+	if(DoButton_CheckBox(&Config()->m_ClStatboardInfos+4, Localize("Net score"), Config()->m_ClStatboardInfos & TC_STATS_NET, &Button))
+		Config()->m_ClStatboardInfos ^= TC_STATS_NET;
 
 	View.HSplitTop(20.0f, &Button, &View);
-	if(DoButton_CheckBox(&Config()->Values()->m_ClStatboardInfos+5, Localize("Frags per minute"), Config()->Values()->m_ClStatboardInfos & TC_STATS_FPM, &Button))
-		Config()->Values()->m_ClStatboardInfos ^= TC_STATS_FPM;
+	if(DoButton_CheckBox(&Config()->m_ClStatboardInfos+5, Localize("Frags per minute"), Config()->m_ClStatboardInfos & TC_STATS_FPM, &Button))
+		Config()->m_ClStatboardInfos ^= TC_STATS_FPM;
 		
 	View.HSplitTop(20.0f, &Button, &View);
-	if(DoButton_CheckBox(&Config()->Values()->m_ClStatboardInfos+6, Localize("Current spree"), Config()->Values()->m_ClStatboardInfos & TC_STATS_SPREE, &Button))
-		Config()->Values()->m_ClStatboardInfos ^= TC_STATS_SPREE;
+	if(DoButton_CheckBox(&Config()->m_ClStatboardInfos+6, Localize("Current spree"), Config()->m_ClStatboardInfos & TC_STATS_SPREE, &Button))
+		Config()->m_ClStatboardInfos ^= TC_STATS_SPREE;
 		
 	View.HSplitTop(20.0f, &Button, &View);
-	if(DoButton_CheckBox(&Config()->Values()->m_ClStatboardInfos+7, Localize("Best spree"), Config()->Values()->m_ClStatboardInfos & TC_STATS_BESTSPREE, &Button))
-		Config()->Values()->m_ClStatboardInfos ^= TC_STATS_BESTSPREE;
+	if(DoButton_CheckBox(&Config()->m_ClStatboardInfos+7, Localize("Best spree"), Config()->m_ClStatboardInfos & TC_STATS_BESTSPREE, &Button))
+		Config()->m_ClStatboardInfos ^= TC_STATS_BESTSPREE;
 
 	View.HSplitTop(20.0f, &Button, &View);
-	if(DoButton_CheckBox(&Config()->Values()->m_ClStatboardInfos+9, Localize("Weapons stats"), Config()->Values()->m_ClStatboardInfos & TC_STATS_WEAPS, &Button))
-		Config()->Values()->m_ClStatboardInfos ^= TC_STATS_WEAPS;
+	if(DoButton_CheckBox(&Config()->m_ClStatboardInfos+9, Localize("Weapons stats"), Config()->m_ClStatboardInfos & TC_STATS_WEAPS, &Button))
+		Config()->m_ClStatboardInfos ^= TC_STATS_WEAPS;
 
 	View.HSplitTop(20.0f, &Button, &View);
-	if(DoButton_CheckBox(&Config()->Values()->m_ClStatboardInfos+8, Localize("Flag grabs"), Config()->Values()->m_ClStatboardInfos & TC_STATS_FLAGGRABS, &Button))
-		Config()->Values()->m_ClStatboardInfos ^= TC_STATS_FLAGGRABS;
+	if(DoButton_CheckBox(&Config()->m_ClStatboardInfos+8, Localize("Flag grabs"), Config()->m_ClStatboardInfos & TC_STATS_FLAGGRABS, &Button))
+		Config()->m_ClStatboardInfos ^= TC_STATS_FLAGGRABS;
 
 	View.HSplitTop(20.0f, &Button, &View);
-	if(DoButton_CheckBox(&Config()->Values()->m_ClStatboardInfos+10, Localize("Flag captures"), Config()->Values()->m_ClStatboardInfos & TC_STATS_FLAGCAPTURES, &Button))
-		Config()->Values()->m_ClStatboardInfos ^= TC_STATS_FLAGCAPTURES;
+	if(DoButton_CheckBox(&Config()->m_ClStatboardInfos+10, Localize("Flag captures"), Config()->m_ClStatboardInfos & TC_STATS_FLAGCAPTURES, &Button))
+		Config()->m_ClStatboardInfos ^= TC_STATS_FLAGCAPTURES;
 
 	return 11*20.0f;
 }
@@ -1598,8 +1596,8 @@ bool CMenus::DoResolutionList(CUIRect* pRect, CListBox* pListBox,
 
 	for(int i = 0; i < lModes.size(); ++i)
 	{
-		if(Config()->Values()->m_GfxScreenWidth == lModes[i].m_Width &&
-			Config()->Values()->m_GfxScreenHeight == lModes[i].m_Height)
+		if(Config()->m_GfxScreenWidth == lModes[i].m_Width &&
+			Config()->m_GfxScreenHeight == lModes[i].m_Height)
 		{
 			OldSelected = i;
 		}
@@ -1637,8 +1635,8 @@ bool CMenus::DoResolutionList(CUIRect* pRect, CListBox* pListBox,
 	const int NewSelected = pListBox->DoEnd();
 	if(OldSelected != NewSelected)
 	{
-		Config()->Values()->m_GfxScreenWidth = lModes[NewSelected].m_Width;
-		Config()->Values()->m_GfxScreenHeight = lModes[NewSelected].m_Height;
+		Config()->m_GfxScreenWidth = lModes[NewSelected].m_Width;
+		Config()->m_GfxScreenHeight = lModes[NewSelected].m_Height;
 		return true;
 	}
 	return false;
@@ -1648,11 +1646,11 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 {
 	bool CheckSettings = false;
 
-	static int s_GfxScreenWidth = Config()->Values()->m_GfxScreenWidth;
-	static int s_GfxScreenHeight = Config()->Values()->m_GfxScreenHeight;
-	static int s_GfxFsaaSamples = Config()->Values()->m_GfxFsaaSamples;
-	static int s_GfxTextureQuality = Config()->Values()->m_GfxTextureQuality;
-	static int s_GfxTextureCompression = Config()->Values()->m_GfxTextureCompression;
+	static int s_GfxScreenWidth = Config()->m_GfxScreenWidth;
+	static int s_GfxScreenHeight = Config()->m_GfxScreenHeight;
+	static int s_GfxFsaaSamples = Config()->m_GfxFsaaSamples;
+	static int s_GfxTextureQuality = Config()->m_GfxTextureQuality;
+	static int s_GfxTextureCompression = Config()->m_GfxTextureCompression;
 
 	CUIRect Label, Button, ScreenLeft, ScreenRight, Texture, BottomView, Background;
 
@@ -1662,7 +1660,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 
 	// render screen menu background
 	int NumOptions = 3;
-	if(Graphics()->GetNumScreens() > 1 && !Config()->Values()->m_GfxFullscreen)
+	if(Graphics()->GetNumScreens() > 1 && !Config()->m_GfxFullscreen)
 		++NumOptions;
 	float ButtonHeight = 20.0f;
 	float Spacing = 2.0f;
@@ -1672,7 +1670,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		Background = MainView;
 	else
 		MainView.HSplitTop(20.0f, 0, &Background);
-	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
+	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	MainView.HSplitTop(BackgroundHeight, &ScreenLeft, &MainView);
 	RenderTools()->DrawUIRect(&ScreenLeft, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
@@ -1697,16 +1695,16 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	ScreenLeft.HSplitTop(Spacing, 0, &ScreenLeft);
 	ScreenLeft.HSplitTop(ButtonHeight, &Button, &ScreenLeft);
 	static int s_ButtonGfxFullscreen = 0;
-	if(DoButton_CheckBox(&s_ButtonGfxFullscreen, Localize("Fullscreen"), Config()->Values()->m_GfxFullscreen, &Button))
+	if(DoButton_CheckBox(&s_ButtonGfxFullscreen, Localize("Fullscreen"), Config()->m_GfxFullscreen, &Button))
 		Client()->ToggleFullscreen();
 
-	if(!Config()->Values()->m_GfxFullscreen)
+	if(!Config()->m_GfxFullscreen)
 	{
 		ScreenLeft.HSplitTop(Spacing, 0, &ScreenLeft);
 		ScreenLeft.HSplitTop(ButtonHeight, &Button, &ScreenLeft);
 		Button.VSplitLeft(ButtonHeight, 0, &Button);
 		static int s_ButtonGfxBorderless = 0;
-		if(DoButton_CheckBox(&s_ButtonGfxBorderless, Localize("Borderless window"), Config()->Values()->m_GfxBorderless, &Button))
+		if(DoButton_CheckBox(&s_ButtonGfxBorderless, Localize("Borderless window"), Config()->m_GfxBorderless, &Button))
 			Client()->ToggleWindowBordered();
 	}
 
@@ -1724,12 +1722,12 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		UI()->DoLabel(&Text, aBuf, Text.h*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 
 		Button.VSplitLeft(120.0f, &Button, 0);
-		str_format(aBuf, sizeof(aBuf), "#%d  (%dx%d)", Config()->Values()->m_GfxScreen+1, Graphics()->DesktopWidth(), Graphics()->DesktopHeight());
+		str_format(aBuf, sizeof(aBuf), "#%d  (%dx%d)", Config()->m_GfxScreen+1, Graphics()->DesktopWidth(), Graphics()->DesktopHeight());
 		static CButtonContainer s_ButtonScreenId;
 		if(DoButton_Menu(&s_ButtonScreenId, aBuf, 0, &Button))
 		{
-			Config()->Values()->m_GfxScreen = (Config()->Values()->m_GfxScreen + 1) % Graphics()->GetNumScreens();
-			Client()->SwitchWindowScreen(Config()->Values()->m_GfxScreen);
+			Config()->m_GfxScreen = (Config()->m_GfxScreen + 1) % Graphics()->GetNumScreens();
+			Client()->SwitchWindowScreen(Config()->m_GfxScreen);
 		}
 	}
 
@@ -1748,16 +1746,16 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		UI()->DoLabel(&Text, aBuf, Text.h*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 
 		Button.VSplitLeft(70.0f, &Button, 0);
-		str_format(aBuf, sizeof(aBuf), "%dx", Config()->Values()->m_GfxFsaaSamples);
+		str_format(aBuf, sizeof(aBuf), "%dx", Config()->m_GfxFsaaSamples);
 		static CButtonContainer s_ButtonGfxFsaaSamples;
 		if(DoButton_Menu(&s_ButtonGfxFsaaSamples, aBuf, 0, &Button))
 		{
-			if(!Config()->Values()->m_GfxFsaaSamples)
-				Config()->Values()->m_GfxFsaaSamples = 2;
-			else if(Config()->Values()->m_GfxFsaaSamples == 16)
-				Config()->Values()->m_GfxFsaaSamples = 0;
+			if(!Config()->m_GfxFsaaSamples)
+				Config()->m_GfxFsaaSamples = 2;
+			else if(Config()->m_GfxFsaaSamples == 16)
+				Config()->m_GfxFsaaSamples = 0;
 			else
-				Config()->Values()->m_GfxFsaaSamples *= 2;
+				Config()->m_GfxFsaaSamples *= 2;
 			CheckSettings = true;
 		}
 	}
@@ -1765,26 +1763,26 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	ScreenRight.HSplitTop(Spacing, 0, &ScreenRight);
 	ScreenRight.HSplitTop(ButtonHeight, &Button, &ScreenRight);
 	static int s_ButtonGfxVsync = 0;
-	if(DoButton_CheckBox(&s_ButtonGfxVsync, Localize("V-Sync"), Config()->Values()->m_GfxVsync, &Button))
+	if(DoButton_CheckBox(&s_ButtonGfxVsync, Localize("V-Sync"), Config()->m_GfxVsync, &Button))
 		Client()->ToggleWindowVSync();
 
 	ScreenRight.HSplitTop(Spacing, 0, &ScreenRight);
 	ScreenRight.HSplitTop(ButtonHeight, &Button, &ScreenRight);
 
 	// TODO: greyed out checkbox (not clickable)
-	if(!Config()->Values()->m_GfxVsync)
+	if(!Config()->m_GfxVsync)
 	{
 		static int s_ButtonGfxCapFps = 0;
-		if(DoButton_CheckBox(&s_ButtonGfxCapFps, Localize("Limit Fps"), Config()->Values()->m_GfxLimitFps, &Button))
+		if(DoButton_CheckBox(&s_ButtonGfxCapFps, Localize("Limit Fps"), Config()->m_GfxLimitFps, &Button))
 		{
-			Config()->Values()->m_GfxLimitFps ^= 1;
+			Config()->m_GfxLimitFps ^= 1;
 		}
 
-		if(Config()->Values()->m_GfxLimitFps > 0)
+		if(Config()->m_GfxLimitFps > 0)
 		{
 			ScreenRight.HSplitTop(Spacing, 0, &ScreenRight);
 			ScreenRight.HSplitTop(ButtonHeight, &Button, &ScreenRight);
-			DoScrollbarOption(&Config()->Values()->m_GfxMaxFps, &Config()->Values()->m_GfxMaxFps,
+			DoScrollbarOption(&Config()->m_GfxMaxFps, &Config()->m_GfxMaxFps,
 							  &Button, Localize("Max fps"), 30, 300);
 		}
 	}
@@ -1797,26 +1795,26 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	Texture.HSplitTop(Spacing, 0, &Texture);
 	Texture.HSplitTop(ButtonHeight, &Button, &Texture);
 	static int s_ButtonGfxTextureQuality = 0;
-	if(DoButton_CheckBox(&s_ButtonGfxTextureQuality, Localize("Quality Textures"), Config()->Values()->m_GfxTextureQuality, &Button))
+	if(DoButton_CheckBox(&s_ButtonGfxTextureQuality, Localize("Quality Textures"), Config()->m_GfxTextureQuality, &Button))
 	{
-		Config()->Values()->m_GfxTextureQuality ^= 1;
+		Config()->m_GfxTextureQuality ^= 1;
 		CheckSettings = true;
 	}
 
 	Texture.HSplitTop(Spacing, 0, &Texture);
 	Texture.HSplitTop(ButtonHeight, &Button, &Texture);
 	static int s_ButtonGfxTextureCompression = 0;
-	if(DoButton_CheckBox(&s_ButtonGfxTextureCompression, Localize("Texture Compression"), Config()->Values()->m_GfxTextureCompression, &Button))
+	if(DoButton_CheckBox(&s_ButtonGfxTextureCompression, Localize("Texture Compression"), Config()->m_GfxTextureCompression, &Button))
 	{
-		Config()->Values()->m_GfxTextureCompression ^= 1;
+		Config()->m_GfxTextureCompression ^= 1;
 		CheckSettings = true;
 	}
 
 	Texture.HSplitTop(Spacing, 0, &Texture);
 	Texture.HSplitTop(ButtonHeight, &Button, &Texture);
 	static int s_ButtonGfxHighDetail = 0;
-	if(DoButton_CheckBox(&s_ButtonGfxHighDetail, Localize("High Detail"), Config()->Values()->m_GfxHighDetail, &Button))
-		Config()->Values()->m_GfxHighDetail ^= 1;
+	if(DoButton_CheckBox(&s_ButtonGfxHighDetail, Localize("High Detail"), Config()->m_GfxHighDetail, &Button))
+		Config()->m_GfxHighDetail ^= 1;
 
 	// render screen modes
 	MainView.HSplitTop(10.0f, 0, &MainView);
@@ -1881,26 +1879,26 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	float ButtonWidth = (BottomView.w/6.0f)-(Spacing*5.0)/6.0f;
 
 	BottomView.VSplitRight(ButtonWidth, 0, &BottomView);
-	RenderTools()->DrawUIRect4(&BottomView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
+	RenderTools()->DrawUIRect4(&BottomView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
 
 	BottomView.HSplitTop(25.0f, &BottomView, 0);
 	Button = BottomView;
 	static CButtonContainer s_ResetButton;
 	if(DoButton_Menu(&s_ResetButton, Localize("Reset"), 0, &Button))
 	{
-		Config()->Values()->m_GfxScreenWidth = Graphics()->DesktopWidth();
-		Config()->Values()->m_GfxScreenHeight = Graphics()->DesktopHeight();
-		Config()->Values()->m_GfxBorderless = 0;
-		Config()->Values()->m_GfxFullscreen = 1;
-		Config()->Values()->m_GfxVsync = 1;
-		Config()->Values()->m_GfxFsaaSamples = 0;
-		Config()->Values()->m_GfxTextureQuality = 1;
-		Config()->Values()->m_GfxTextureCompression = 0;
-		Config()->Values()->m_GfxHighDetail = 1;
+		Config()->m_GfxScreenWidth = Graphics()->DesktopWidth();
+		Config()->m_GfxScreenHeight = Graphics()->DesktopHeight();
+		Config()->m_GfxBorderless = 0;
+		Config()->m_GfxFullscreen = 1;
+		Config()->m_GfxVsync = 1;
+		Config()->m_GfxFsaaSamples = 0;
+		Config()->m_GfxTextureQuality = 1;
+		Config()->m_GfxTextureCompression = 0;
+		Config()->m_GfxHighDetail = 1;
 
-		if(Config()->Values()->m_GfxDisplayAllModes)
+		if(Config()->m_GfxDisplayAllModes)
 		{
-			Config()->Values()->m_GfxDisplayAllModes = 0;
+			Config()->m_GfxDisplayAllModes = 0;
 			UpdateVideoModeSettings();
 		}
 
@@ -1910,11 +1908,11 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	// check if the new settings require a restart
 	if(CheckSettings)
 	{
-		if(s_GfxScreenWidth == Config()->Values()->m_GfxScreenWidth &&
-			s_GfxScreenHeight == Config()->Values()->m_GfxScreenHeight &&
-			s_GfxFsaaSamples == Config()->Values()->m_GfxFsaaSamples &&
-			s_GfxTextureQuality == Config()->Values()->m_GfxTextureQuality &&
-			s_GfxTextureCompression == Config()->Values()->m_GfxTextureCompression)
+		if(s_GfxScreenWidth == Config()->m_GfxScreenWidth &&
+			s_GfxScreenHeight == Config()->m_GfxScreenHeight &&
+			s_GfxFsaaSamples == Config()->m_GfxFsaaSamples &&
+			s_GfxTextureQuality == Config()->m_GfxTextureQuality &&
+			s_GfxTextureCompression == Config()->m_GfxTextureCompression)
 			m_NeedRestartGraphics = false;
 		else
 			m_NeedRestartGraphics = true;
@@ -1926,12 +1924,12 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 	CUIRect Label, Button, Sound, Detail, BottomView, Background;
 
 	// render sound menu background
-	int NumOptions = Config()->Values()->m_SndEnable ? 3 : 2;
+	int NumOptions = Config()->m_SndEnable ? 3 : 2;
 	float ButtonHeight = 20.0f;
 	float Spacing = 2.0f;
 	float BackgroundHeight = (float)(NumOptions+1)*ButtonHeight+(float)NumOptions*Spacing;
 	float TotalHeight = BackgroundHeight;
-	if(Config()->Values()->m_SndEnable)
+	if(Config()->m_SndEnable)
 		TotalHeight += 10.0f+2.0f*ButtonHeight+Spacing;
 
 	MainView.HSplitBottom(MainView.h-TotalHeight-20.0f, &MainView, &BottomView);
@@ -1939,13 +1937,13 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 		Background = MainView;
 	else
 		MainView.HSplitTop(20.0f, 0, &Background);
-	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
+	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	MainView.HSplitTop(BackgroundHeight, &Sound, &MainView);
 	RenderTools()->DrawUIRect(&Sound, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
 	// render detail menu background
-	if(Config()->Values()->m_SndEnable)
+	if(Config()->m_SndEnable)
 	{
 		BackgroundHeight = 2.0f*ButtonHeight+Spacing;
 
@@ -1954,8 +1952,8 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 		RenderTools()->DrawUIRect(&Detail, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 	}
 
-	static int s_SndInit = Config()->Values()->m_SndInit;
-	static int s_SndRate = Config()->Values()->m_SndRate;
+	static int s_SndInit = Config()->m_SndInit;
+	static int s_SndRate = Config()->m_SndRate;
 
 	// render sound menu
 	Sound.HSplitTop(ButtonHeight, &Label, &Sound);
@@ -1966,15 +1964,15 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 	CUIRect UseSoundButton;
 	Sound.HSplitTop(ButtonHeight, &UseSoundButton, &Sound);
 
-	if(Config()->Values()->m_SndEnable)
+	if(Config()->m_SndEnable)
 	{
 		Sound.HSplitTop(Spacing, 0, &Sound);
 		Sound.HSplitTop(ButtonHeight, &Button, &Sound);
 		Button.VSplitLeft(ButtonHeight, 0, &Button);
 		static int s_ButtonSndMusic = 0;
-		if(DoButton_CheckBox(&s_ButtonSndMusic, Localize("Play background music"), Config()->Values()->m_SndMusic, &Button))
+		if(DoButton_CheckBox(&s_ButtonSndMusic, Localize("Play background music"), Config()->m_SndMusic, &Button))
 		{
-			Config()->Values()->m_SndMusic ^= 1;
+			Config()->m_SndMusic ^= 1;
 			ToggleMusic();
 		}
 
@@ -1982,8 +1980,8 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 		Sound.HSplitTop(ButtonHeight, &Button, &Sound);
 		Button.VSplitLeft(ButtonHeight, 0, &Button);
 		static int s_ButtonSndNonactiveMute = 0;
-		if(DoButton_CheckBox(&s_ButtonSndNonactiveMute, Localize("Mute when not active"), Config()->Values()->m_SndNonactiveMute, &Button))
-			Config()->Values()->m_SndNonactiveMute ^= 1;
+		if(DoButton_CheckBox(&s_ButtonSndNonactiveMute, Localize("Mute when not active"), Config()->m_SndNonactiveMute, &Button))
+			Config()->m_SndNonactiveMute ^= 1;
 
 		// render detail menu
 		Detail.HSplitTop(ButtonHeight, &Label, &Detail);
@@ -2014,26 +2012,26 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 			Unit.y += 2.0f;
 			UI()->DoLabel(&Unit, "kHz", Unit.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 
-			if(Config()->Values()->m_SndRate != 48000 && Config()->Values()->m_SndRate != 44100)
-				Config()->Values()->m_SndRate = 48000;
-			if(Config()->Values()->m_SndRate == 48000)
+			if(Config()->m_SndRate != 48000 && Config()->m_SndRate != 44100)
+				Config()->m_SndRate = 48000;
+			if(Config()->m_SndRate == 48000)
 				str_copy(aBuf, "48.0", sizeof(aBuf));
 			else
 				str_copy(aBuf, "44.1", sizeof(aBuf));
 			static CButtonContainer s_SampleRateButton;
 			if(DoButton_Menu(&s_SampleRateButton, aBuf, 0, &Value))
 			{
-				if(Config()->Values()->m_SndRate == 48000)
-					Config()->Values()->m_SndRate = 44100;
+				if(Config()->m_SndRate == 48000)
+					Config()->m_SndRate = 44100;
 				else
-					Config()->Values()->m_SndRate = 48000;
+					Config()->m_SndRate = 48000;
 			}
 
-			m_NeedRestartSound = Config()->Values()->m_SndInit && (!s_SndInit || s_SndRate != Config()->Values()->m_SndRate);
+			m_NeedRestartSound = Config()->m_SndInit && (!s_SndInit || s_SndRate != Config()->m_SndRate);
 		}
 
 		Right.HSplitTop(ButtonHeight, &Button, &Right);
-		DoScrollbarOption(&Config()->Values()->m_SndVolume, &Config()->Values()->m_SndVolume, &Button, Localize("Volume"), 0, 100, &LogarithmicScrollbarScale);
+		DoScrollbarOption(&Config()->m_SndVolume, &Config()->m_SndVolume, &Button, Localize("Volume"), 0, 100, &LogarithmicScrollbarScale);
 	}
 	else
 	{
@@ -2041,21 +2039,21 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 		Sound.HSplitTop(ButtonHeight, &Button, &Sound);
 		Button.VSplitLeft(ButtonHeight, 0, &Button);
 		static int s_ButtonInitSounds = 0;
-		if(DoButton_CheckBox(&s_ButtonInitSounds, Localize("Load the sound system"), Config()->Values()->m_SndInit, &Button))
+		if(DoButton_CheckBox(&s_ButtonInitSounds, Localize("Load the sound system"), Config()->m_SndInit, &Button))
 		{
-			Config()->Values()->m_SndInit ^= 1;
-			m_NeedRestartSound = Config()->Values()->m_SndInit && (!s_SndInit || s_SndRate != Config()->Values()->m_SndRate);
+			Config()->m_SndInit ^= 1;
+			m_NeedRestartSound = Config()->m_SndInit && (!s_SndInit || s_SndRate != Config()->m_SndRate);
 		}
 	}
 
 	static int s_ButtonSndEnable = 0;
-	if(DoButton_CheckBox(&s_ButtonSndEnable, Localize("Use sounds"), Config()->Values()->m_SndEnable, &UseSoundButton))
+	if(DoButton_CheckBox(&s_ButtonSndEnable, Localize("Use sounds"), Config()->m_SndEnable, &UseSoundButton))
 	{
-		Config()->Values()->m_SndEnable ^= 1;
-		if(Config()->Values()->m_SndEnable)
+		Config()->m_SndEnable ^= 1;
+		if(Config()->m_SndEnable)
 		{
-			Config()->Values()->m_SndInit = 1;
-			if(Config()->Values()->m_SndMusic)
+			Config()->m_SndInit = 1;
+			if(Config()->m_SndMusic)
 				m_pClient->m_pSounds->Play(CSounds::CHN_MUSIC, SOUND_MENU, 1.0f);
 		}
 		else
@@ -2069,40 +2067,40 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 	float ButtonWidth = (BottomView.w/6.0f)-(Spacing*5.0)/6.0f;
 
 	BottomView.VSplitRight(ButtonWidth, 0, &BottomView);
-	RenderTools()->DrawUIRect4(&BottomView, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
+	RenderTools()->DrawUIRect4(&BottomView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 5.0f);
 
 	BottomView.HSplitTop(25.0f, &BottomView, 0);
 	Button = BottomView;
 	static CButtonContainer s_ResetButton;
 	if(DoButton_Menu(&s_ResetButton, Localize("Reset"), 0, &Button))
 	{
-		Config()->Values()->m_SndEnable = 1;
-		Config()->Values()->m_SndInit = 1;
-		if(!Config()->Values()->m_SndMusic)
+		Config()->m_SndEnable = 1;
+		Config()->m_SndInit = 1;
+		if(!Config()->m_SndMusic)
 		{
-			Config()->Values()->m_SndMusic = 1;
+			Config()->m_SndMusic = 1;
 			m_pClient->m_pSounds->Play(CSounds::CHN_MUSIC, SOUND_MENU, 1.0f);
 		}
-		Config()->Values()->m_SndNonactiveMute = 0;
-		Config()->Values()->m_SndRate = 48000;
-		Config()->Values()->m_SndVolume = 100;
+		Config()->m_SndNonactiveMute = 0;
+		Config()->m_SndRate = 48000;
+		Config()->m_SndVolume = 100;
 	}
 }
 
 void CMenus::RenderSettings(CUIRect MainView)
 {
 	// handle which page should be rendered
-	if(Config()->Values()->m_UiSettingsPage == SETTINGS_GENERAL)
+	if(Config()->m_UiSettingsPage == SETTINGS_GENERAL)
 		RenderSettingsGeneral(MainView);
-	else if(Config()->Values()->m_UiSettingsPage == SETTINGS_PLAYER)
+	else if(Config()->m_UiSettingsPage == SETTINGS_PLAYER)
 		RenderSettingsPlayer(MainView);
-	else if(Config()->Values()->m_UiSettingsPage == SETTINGS_TEE)
+	else if(Config()->m_UiSettingsPage == SETTINGS_TEE)
 		RenderSettingsTee(MainView);
-	else if(Config()->Values()->m_UiSettingsPage == SETTINGS_CONTROLS)
+	else if(Config()->m_UiSettingsPage == SETTINGS_CONTROLS)
 		RenderSettingsControls(MainView);
-	else if(Config()->Values()->m_UiSettingsPage == SETTINGS_GRAPHICS)
+	else if(Config()->m_UiSettingsPage == SETTINGS_GRAPHICS)
 		RenderSettingsGraphics(MainView);
-	else if(Config()->Values()->m_UiSettingsPage == SETTINGS_SOUND)
+	else if(Config()->m_UiSettingsPage == SETTINGS_SOUND)
 		RenderSettingsSound(MainView);
 
 	MainView.HSplitBottom(32.0f, 0, &MainView);
@@ -2120,7 +2118,7 @@ void CMenus::RenderSettings(CUIRect MainView)
 		// background
 		CUIRect RestartWarning;
 		MainView.HSplitTop(25.0f, &RestartWarning, 0);
-		RestartWarning.VMargin(Config()->Values()->m_UiWideview ? 210.0f : 140.0f, &RestartWarning);
+		RestartWarning.VMargin(Config()->m_UiWideview ? 210.0f : 140.0f, &RestartWarning);
 		RenderTools()->DrawUIRect(&RestartWarning, vec4(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
 		// text

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -28,7 +28,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	MainView.VMargin(MainView.w/2-190.0f, &TopMenu);
 	TopMenu.HSplitTop(365.0f, &TopMenu, &BottomMenu);
 	//TopMenu.HSplitBottom(145.0f, &TopMenu, 0);
-	RenderTools()->DrawUIRect4(&TopMenu, vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 10.0f);
+	RenderTools()->DrawUIRect4(&TopMenu, vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 10.0f);
 
 	TopMenu.HSplitTop(145.0f, 0, &TopMenu);
 
@@ -37,13 +37,13 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 
 	TopMenu.HSplitBottom(40.0f, &TopMenu, &Button);
 	static CButtonContainer s_SettingsButton;
-	if(DoButton_Menu(&s_SettingsButton, Localize("Settings"), 0, &Button, Config()->Values()->m_ClShowStartMenuImages ? "settings" : 0, CUI::CORNER_ALL, 10.0f, 0.5f) || CheckHotKey(KEY_S))
+	if(DoButton_Menu(&s_SettingsButton, Localize("Settings"), 0, &Button, Config()->m_ClShowStartMenuImages ? "settings" : 0, CUI::CORNER_ALL, 10.0f, 0.5f) || CheckHotKey(KEY_S))
 		NewPage = PAGE_SETTINGS;
 	
 	/*TopMenu.HSplitBottom(5.0f, &TopMenu, 0); // little space
 	TopMenu.HSplitBottom(40.0f, &TopMenu, &Bottom);
 	static int s_LocalServerButton = 0;
-	if(Config()->Values()->m_ClShowStartMenuImages)
+	if(Config()->m_ClShowStartMenuImages)
 	{
 		if(DoButton_MenuImage(&s_LocalServerButton, Localize("Local server"), 0, &Button, "local_server", 10.0f, 0.5f))
 		{
@@ -59,7 +59,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	TopMenu.HSplitBottom(5.0f, &TopMenu, 0); // little space
 	TopMenu.HSplitBottom(40.0f, &TopMenu, &Button);
 	static CButtonContainer s_DemoButton;
-	if(DoButton_Menu(&s_DemoButton, Localize("Demos"), 0, &Button, Config()->Values()->m_ClShowStartMenuImages ? "demos" : 0, CUI::CORNER_ALL, 10.0f, 0.5f) || CheckHotKey(KEY_D))
+	if(DoButton_Menu(&s_DemoButton, Localize("Demos"), 0, &Button, Config()->m_ClShowStartMenuImages ? "demos" : 0, CUI::CORNER_ALL, 10.0f, 0.5f) || CheckHotKey(KEY_D))
 	{
 		NewPage = PAGE_DEMOS;
 		DemolistPopulate();
@@ -71,9 +71,9 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	TopMenu.HSplitBottom(5.0f, &TopMenu, 0); // little space
 	TopMenu.HSplitBottom(40.0f, &TopMenu, &Button);
 	static CButtonContainer s_MapEditorButton;
-	if(DoButton_Menu(&s_MapEditorButton, Localize("Editor"), 0, &Button, Config()->Values()->m_ClShowStartMenuImages ? "editor" : 0, CUI::CORNER_ALL, 10.0f, 0.5f) || (!EditorHotkeyWasPressed && Client()->LocalTime() - EditorHotKeyChecktime < 0.1f && CheckHotKey(KEY_E)))
+	if(DoButton_Menu(&s_MapEditorButton, Localize("Editor"), 0, &Button, Config()->m_ClShowStartMenuImages ? "editor" : 0, CUI::CORNER_ALL, 10.0f, 0.5f) || (!EditorHotkeyWasPressed && Client()->LocalTime() - EditorHotKeyChecktime < 0.1f && CheckHotKey(KEY_E)))
 	{
-		Config()->Values()->m_ClEditor = 1;
+		Config()->m_ClEditor = 1;
 		Input()->MouseModeRelative();
 		EditorHotkeyWasPressed = true;
 	}
@@ -86,11 +86,11 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	TopMenu.HSplitBottom(5.0f, &TopMenu, 0); // little space
 	TopMenu.HSplitBottom(40.0f, &TopMenu, &Button);
 	static CButtonContainer s_PlayButton;
-	if(DoButton_Menu(&s_PlayButton, Localize("Play"), 0, &Button, Config()->Values()->m_ClShowStartMenuImages ? "play_game" : 0, CUI::CORNER_ALL, 10.0f, 0.5f) || m_EnterPressed || CheckHotKey(KEY_P))
-		NewPage = Config()->Values()->m_UiBrowserPage;
+	if(DoButton_Menu(&s_PlayButton, Localize("Play"), 0, &Button, Config()->m_ClShowStartMenuImages ? "play_game" : 0, CUI::CORNER_ALL, 10.0f, 0.5f) || m_EnterPressed || CheckHotKey(KEY_P))
+		NewPage = Config()->m_UiBrowserPage;
 	
 	BottomMenu.HSplitTop(90.0f, 0, &BottomMenu);
-	RenderTools()->DrawUIRect4(&BottomMenu, vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->Values()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 10.0f);
+	RenderTools()->DrawUIRect4(&BottomMenu, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), vec4(0.0f, 0.0f, 0.0f, 0.0f), CUI::CORNER_T, 10.0f);
 
 	BottomMenu.HSplitTop(40.0f, &Button, &TopMenu);
 	static CButtonContainer s_QuitButton;

--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -83,8 +83,8 @@ void CMotd::OnMessage(int MsgType, void *pRawMsg)
 			}
 		}
 
-		if(m_aServerMotd[0] && Config()->Values()->m_ClMotdTime)
-			m_ServerMotdTime = time_get()+time_freq()*Config()->Values()->m_ClMotdTime;
+		if(m_aServerMotd[0] && Config()->m_ClMotdTime)
+			m_ServerMotdTime = time_get()+time_freq()*Config()->m_ClMotdTime;
 		else
 			m_ServerMotdTime = 0;
 	}

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -22,17 +22,17 @@ void CNamePlates::RenderNameplate(
 	vec2 Position = mix(vec2(pPrevChar->m_X, pPrevChar->m_Y), vec2(pPlayerChar->m_X, pPlayerChar->m_Y), IntraTick);
 
 
-	float FontSize = 18.0f + 20.0f * Config()->Values()->m_ClNameplatesSize / 100.0f;
+	float FontSize = 18.0f + 20.0f * Config()->m_ClNameplatesSize / 100.0f;
 	// render name plate
 	if(m_pClient->m_LocalClientID != ClientID)
 	{
 		float a = 1;
-		if(Config()->Values()->m_ClNameplatesAlways == 0)
+		if(Config()->m_ClNameplatesAlways == 0)
 			a = clamp(1-powf(distance(m_pClient->m_pControls->m_TargetPos, Position)/200.0f,16.0f), 0.0f, 1.0f);
 
 
 		char aName[64];
-		str_format(aName, sizeof(aName), "%s", Config()->Values()->m_ClShowsocial ? m_pClient->m_aClients[ClientID].m_aName: "");
+		str_format(aName, sizeof(aName), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[ClientID].m_aName: "");
 
 		CTextCursor Cursor;
 		float tw = TextRender()->TextWidth(0, FontSize, aName, -1, -1.0f) + RenderTools()->GetClientIdRectSize(FontSize);
@@ -40,7 +40,7 @@ void CNamePlates::RenderNameplate(
 
 		TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.5f*a);
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, a);
-		if(Config()->Values()->m_ClNameplatesTeamcolors && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS)
+		if(Config()->m_ClNameplatesTeamcolors && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS)
 		{
 			if(m_pClient->m_aClients[ClientID].m_Team == TEAM_RED)
 				TextRender()->TextColor(1.0f, 0.5f, 0.5f, a);
@@ -50,7 +50,7 @@ void CNamePlates::RenderNameplate(
 
 		const vec4 IdTextColor(0.1f, 0.1f, 0.1f, a);
 		vec4 BgIdColor(1.0f, 1.0f, 1.0f, a * 0.5f);
-		if(Config()->Values()->m_ClNameplatesTeamcolors && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS)
+		if(Config()->m_ClNameplatesTeamcolors && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS)
 		{
 			if(m_pClient->m_aClients[ClientID].m_Team == TEAM_RED)
 				BgIdColor = vec4(1.0f, 0.5f, 0.5f, a * 0.5f);
@@ -71,7 +71,7 @@ void CNamePlates::RenderNameplate(
 
 void CNamePlates::OnRender()
 {
-	if (!Config()->Values()->m_ClNameplates)
+	if (!Config()->m_ClNameplates)
 		return;
 
 	for(int i = 0; i < MAX_CLIENTS; i++)

--- a/src/game/client/components/notifications.cpp
+++ b/src/game/client/components/notifications.cpp
@@ -26,7 +26,7 @@ void CNotifications::Con_SndToggle(IConsole::IResult *pResult, void *pUserData)
 {
 	CNotifications *pSelf = (CNotifications *)pUserData;
 
-	pSelf->Config()->Values()->m_SndEnable ^= 1;
+	pSelf->Config()->m_SndEnable ^= 1;
 	pSelf->m_SoundToggleTime = pSelf->Client()->LocalTime();
 }
 
@@ -53,14 +53,14 @@ void CNotifications::RenderSoundNotification()
 
 	const float Fade = min(1.0f, RemainingDisplayTime / FadeTime); // 0.0 ≤ Fade ≤ 1.0
 
-	vec4 Color = (Config()->Values()->m_SndEnable == 0) ? vec4(1.f/0xff*0xf9, 1.f/0xff*0x2b, 1.f/0xff*0x2b, 0.55f) : vec4(1.f/0xff*0x2b, 1.f/0xff*0xf9, 1.f/0xff*0x2b, 0.55f);
+	vec4 Color = (Config()->m_SndEnable == 0) ? vec4(1.f/0xff*0xf9, 1.f/0xff*0x2b, 1.f/0xff*0x2b, 0.55f) : vec4(1.f/0xff*0x2b, 1.f/0xff*0xf9, 1.f/0xff*0x2b, 0.55f);
 	Color = mix(vec4(Color.r, Color.g, Color.b, 0.0f), Color, 0.8*Fade);
 	RenderTools()->DrawUIRect(&Area, Color, CUI::CORNER_ALL, 3.0f);
 
 	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_SOUNDICONS].m_Id);
 	Graphics()->QuadsBegin();
 	Graphics()->SetColor(1.0f*Fade, 1.0f*Fade, 1.0f*Fade, 1.0f*Fade);
-	RenderTools()->SelectSprite(Config()->Values()->m_SndEnable ? SPRITE_SOUNDICON_ON : SPRITE_SOUNDICON_MUTE);
+	RenderTools()->SelectSprite(Config()->m_SndEnable ? SPRITE_SOUNDICON_ON : SPRITE_SOUNDICON_MUTE);
 	IGraphics::CQuadItem QuadItem(Area.x, Area.y, Area.w, Area.h);
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -59,7 +59,7 @@ void CPlayers::RenderHook(
 
 
 	// use preditect players if needed
-	if(m_pClient->m_LocalClientID == ClientID && Config()->Values()->m_ClPredict && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+	if(m_pClient->m_LocalClientID == ClientID && Config()->m_ClPredict && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		if(!m_pClient->m_Snap.m_pLocalCharacter ||
 			(m_pClient->m_Snap.m_pGameData && m_pClient->m_Snap.m_pGameData->m_GameStateFlags&(GAMESTATEFLAG_PAUSED|GAMESTATEFLAG_ROUNDOVER|GAMESTATEFLAG_GAMEOVER)))
@@ -196,7 +196,7 @@ void CPlayers::RenderPlayer(
 	}
 
 	// use preditect players if needed
-	if(m_pClient->m_LocalClientID == ClientID && Config()->Values()->m_ClPredict && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+	if(m_pClient->m_LocalClientID == ClientID && Config()->m_ClPredict && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		if(!m_pClient->m_Snap.m_pLocalCharacter ||
 			(m_pClient->m_Snap.m_pGameData && m_pClient->m_Snap.m_pGameData->m_GameStateFlags&(GAMESTATEFLAG_PAUSED|GAMESTATEFLAG_ROUNDOVER|GAMESTATEFLAG_GAMEOVER)))
@@ -426,7 +426,7 @@ void CPlayers::RenderPlayer(
 	}
 
 	// render the "shadow" tee
-	if(m_pClient->m_LocalClientID == ClientID && Config()->Values()->m_Debug)
+	if(m_pClient->m_LocalClientID == ClientID && Config()->m_Debug)
 	{
 		vec2 GhostPosition = mix(vec2(pPrevChar->m_X, pPrevChar->m_Y), vec2(pPlayerChar->m_X, pPlayerChar->m_Y), Client()->IntraGameTick());
 		CTeeRenderInfo Ghost = RenderInfo;

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -118,7 +118,7 @@ float CScoreboard::RenderSpectators(float x, float y, float w)
 
 		if(Multiple)
 			TextRender()->TextEx(&Cursor, ", ", -1);
-		if(Config()->Values()->m_ClShowUserId && Cursor.m_LineCount <= Cursor.m_MaxLines)
+		if(Config()->m_ClShowUserId && Cursor.m_LineCount <= Cursor.m_MaxLines)
 		{
 			Cursor.m_X += Cursor.m_FontSize;
 		}
@@ -156,7 +156,7 @@ float CScoreboard::RenderSpectators(float x, float y, float w)
 
 		if(Multiple)
 			TextRender()->TextEx(&Cursor, ", ", -1);
-		if(Config()->Values()->m_ClShowUserId && Cursor.m_LineCount <= Cursor.m_MaxLines)
+		if(Config()->m_ClShowUserId && Cursor.m_LineCount <= Cursor.m_MaxLines)
 		{
 			RenderTools()->DrawClientID(TextRender(), &Cursor, i);
 		}
@@ -194,7 +194,7 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 	float Spacing = 2.0f;
 	float PingOffset = x+Spacing, PingLength = 35.0f;
 	float CountryFlagOffset = PingOffset+PingLength, CountryFlagLength = 20.f;
-	float IdSize = Config()->Values()->m_ClShowUserId ? LineHeight : 0.0f;
+	float IdSize = Config()->m_ClShowUserId ? LineHeight : 0.0f;
 	float ReadyLength = ReadyMode ? 10.f : 0.f;
 	float TeeOffset = CountryFlagOffset+CountryFlagLength+4.0f, TeeLength = 25*TeeSizeMod;
 	float NameOffset = CountryFlagOffset+CountryFlagLength+IdSize, NameLength = 128.0f-IdSize/2-ReadyLength;
@@ -569,7 +569,7 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 				TextRender()->TextColor(1.0f, 1.0f, 0.0f, ColorAlpha);
 
 			// id
-			if(Config()->Values()->m_ClShowUserId)
+			if(Config()->m_ClShowUserId)
 			{
 				TextRender()->SetCursor(&Cursor, NameOffset+TeeLength-IdSize+Spacing, y+Spacing, FontSize, TEXTFLAG_RENDER);
 				RenderTools()->DrawClientID(TextRender(), &Cursor, pInfo->m_ClientID);

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -92,7 +92,7 @@ int CSkins::SkinPartScan(const char *pName, int IsDir, int DirType, void *pUser)
 	if(DirType != IStorage::TYPE_SAVE)
 		Part.m_Flags |= SKINFLAG_STANDARD;
 	str_truncate(Part.m_aName, sizeof(Part.m_aName), pName, str_length(pName) - 4);
-	if(pSelf->Config()->Values()->m_Debug)
+	if(pSelf->Config()->m_Debug)
 	{
 		str_format(aBuf, sizeof(aBuf), "load skin part %s", Part.m_aName);
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "skins", aBuf);
@@ -199,7 +199,7 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 	Skin.m_Flags = SpecialSkin ? SKINFLAG_SPECIAL : 0;
 	if(DirType != IStorage::TYPE_SAVE)
 		Skin.m_Flags |= SKINFLAG_STANDARD;
-	if(pSelf->Config()->Values()->m_Debug)
+	if(pSelf->Config()->m_Debug)
 	{
 		str_format(aBuf, sizeof(aBuf), "load skin %s", Skin.m_aName);
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "skins", aBuf);
@@ -212,24 +212,24 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 
 void CSkins::OnInit()
 {
-	ms_apSkinVariables[SKINPART_BODY] = Config()->Values()->m_PlayerSkinBody;
-	ms_apSkinVariables[SKINPART_MARKING] = Config()->Values()->m_PlayerSkinMarking;
-	ms_apSkinVariables[SKINPART_DECORATION] = Config()->Values()->m_PlayerSkinDecoration;
-	ms_apSkinVariables[SKINPART_HANDS] = Config()->Values()->m_PlayerSkinHands;
-	ms_apSkinVariables[SKINPART_FEET] = Config()->Values()->m_PlayerSkinFeet;
-	ms_apSkinVariables[SKINPART_EYES] = Config()->Values()->m_PlayerSkinEyes;
-	ms_apUCCVariables[SKINPART_BODY] = &Config()->Values()->m_PlayerUseCustomColorBody;
-	ms_apUCCVariables[SKINPART_MARKING] = &Config()->Values()->m_PlayerUseCustomColorMarking;
-	ms_apUCCVariables[SKINPART_DECORATION] = &Config()->Values()->m_PlayerUseCustomColorDecoration;
-	ms_apUCCVariables[SKINPART_HANDS] = &Config()->Values()->m_PlayerUseCustomColorHands;
-	ms_apUCCVariables[SKINPART_FEET] = &Config()->Values()->m_PlayerUseCustomColorFeet;
-	ms_apUCCVariables[SKINPART_EYES] = &Config()->Values()->m_PlayerUseCustomColorEyes;
-	ms_apColorVariables[SKINPART_BODY] = &Config()->Values()->m_PlayerColorBody;
-	ms_apColorVariables[SKINPART_MARKING] = &Config()->Values()->m_PlayerColorMarking;
-	ms_apColorVariables[SKINPART_DECORATION] = &Config()->Values()->m_PlayerColorDecoration;
-	ms_apColorVariables[SKINPART_HANDS] = &Config()->Values()->m_PlayerColorHands;
-	ms_apColorVariables[SKINPART_FEET] = &Config()->Values()->m_PlayerColorFeet;
-	ms_apColorVariables[SKINPART_EYES] = &Config()->Values()->m_PlayerColorEyes;
+	ms_apSkinVariables[SKINPART_BODY] = Config()->m_PlayerSkinBody;
+	ms_apSkinVariables[SKINPART_MARKING] = Config()->m_PlayerSkinMarking;
+	ms_apSkinVariables[SKINPART_DECORATION] = Config()->m_PlayerSkinDecoration;
+	ms_apSkinVariables[SKINPART_HANDS] = Config()->m_PlayerSkinHands;
+	ms_apSkinVariables[SKINPART_FEET] = Config()->m_PlayerSkinFeet;
+	ms_apSkinVariables[SKINPART_EYES] = Config()->m_PlayerSkinEyes;
+	ms_apUCCVariables[SKINPART_BODY] = &Config()->m_PlayerUseCustomColorBody;
+	ms_apUCCVariables[SKINPART_MARKING] = &Config()->m_PlayerUseCustomColorMarking;
+	ms_apUCCVariables[SKINPART_DECORATION] = &Config()->m_PlayerUseCustomColorDecoration;
+	ms_apUCCVariables[SKINPART_HANDS] = &Config()->m_PlayerUseCustomColorHands;
+	ms_apUCCVariables[SKINPART_FEET] = &Config()->m_PlayerUseCustomColorFeet;
+	ms_apUCCVariables[SKINPART_EYES] = &Config()->m_PlayerUseCustomColorEyes;
+	ms_apColorVariables[SKINPART_BODY] = &Config()->m_PlayerColorBody;
+	ms_apColorVariables[SKINPART_MARKING] = &Config()->m_PlayerColorMarking;
+	ms_apColorVariables[SKINPART_DECORATION] = &Config()->m_PlayerColorDecoration;
+	ms_apColorVariables[SKINPART_HANDS] = &Config()->m_PlayerColorHands;
+	ms_apColorVariables[SKINPART_FEET] = &Config()->m_PlayerColorFeet;
+	ms_apColorVariables[SKINPART_EYES] = &Config()->m_PlayerColorEyes;
 
 	for(int p = 0; p < NUM_SKINPARTS; p++)
 	{

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -37,7 +37,7 @@ static int LoadSoundsThread(void *pUser)
 
 ISound::CSampleHandle CSounds::GetSampleId(int SetId)
 {
-	if(!Config()->Values()->m_SndEnable || !Sound()->IsSoundEnabled() || m_WaitForSoundJob || SetId < 0 || SetId >= g_pData->m_NumSounds)
+	if(!Config()->m_SndEnable || !Sound()->IsSoundEnabled() || m_WaitForSoundJob || SetId < 0 || SetId >= g_pData->m_NumSounds)
 		return ISound::CSampleHandle();
 	
 	CDataSoundset *pSet = &g_pData->m_aSounds[SetId];
@@ -71,7 +71,7 @@ void CSounds::OnInit()
 	ClearQueue();
 
 	// load sounds
-	if(Config()->Values()->m_SndAsyncLoading)
+	if(Config()->m_SndAsyncLoading)
 	{
 		g_UserData.m_pGameClient = m_pClient;
 		g_UserData.m_Render = false;
@@ -143,7 +143,7 @@ void CSounds::Enqueue(int Channel, int SetId)
 	// add sound to the queue
 	if(m_QueuePos < QUEUE_SIZE)
 	{
-		if(Channel == CHN_MUSIC || !Config()->Values()->m_ClEditor)
+		if(Channel == CHN_MUSIC || !Config()->m_ClEditor)
 		{
 			m_aQueue[m_QueuePos].m_Channel = Channel;
 			m_aQueue[m_QueuePos++].m_SetId = SetId;
@@ -153,7 +153,7 @@ void CSounds::Enqueue(int Channel, int SetId)
 
 void CSounds::Play(int Chn, int SetId, float Vol)
 {
-	if(Chn == CHN_MUSIC && !Config()->Values()->m_SndMusic)
+	if(Chn == CHN_MUSIC && !Config()->m_SndMusic)
 		return;
 
 	ISound::CSampleHandle SampleId = GetSampleId(SetId);
@@ -169,7 +169,7 @@ void CSounds::Play(int Chn, int SetId, float Vol)
 
 void CSounds::PlayAt(int Chn, int SetId, float Vol, vec2 Pos)
 {
-	if(Chn == CHN_MUSIC && !Config()->Values()->m_SndMusic)
+	if(Chn == CHN_MUSIC && !Config()->m_SndMusic)
 		return;
 	
 	ISound::CSampleHandle SampleId = GetSampleId(SetId);

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -308,7 +308,7 @@ void CSpectator::OnRender()
 		}
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, Selected?1.0f:0.5f);
 		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), "%s", Config()->Values()->m_ClShowsocial ? m_pClient->m_aClients[i].m_aName : "");
+		str_format(aBuf, sizeof(aBuf), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[i].m_aName : "");
 
 		CTextCursor Cursor;
 		TextRender()->SetCursor(&Cursor, Width/2.0f+x+50.0f, Height/2.0f+y+5.0f, FontSize, TEXTFLAG_RENDER);

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -49,7 +49,7 @@ void CStats::OnReset()
 bool CStats::IsActive() const
 {
 	// force statboard after three seconds of game over if autostatscreenshot is on
-	if(Config()->Values()->m_ClAutoStatScreenshot && m_ScreenshotTime > -1 && m_ScreenshotTime < time_get())
+	if(Config()->m_ClAutoStatScreenshot && m_ScreenshotTime > -1 && m_ScreenshotTime < time_get())
 		return true;
 
 	return m_Active;
@@ -113,7 +113,7 @@ void CStats::OnMessage(int MsgType, void *pRawMsg)
 void CStats::OnRender()
 {
 	// auto stat screenshot stuff
-	if(Config()->Values()->m_ClAutoStatScreenshot)
+	if(Config()->m_ClAutoStatScreenshot)
 	{
 		// on game over, wait three seconds
 		if(m_ScreenshotTime < 0 && m_pClient->m_Snap.m_pGameData && m_pClient->m_Snap.m_pGameData->m_GameStateFlags&GAMESTATEFLAG_GAMEOVER)
@@ -161,16 +161,16 @@ void CStats::OnRender()
 	}
 
 	for(int i=0; i<9; i++)
-		if(Config()->Values()->m_ClStatboardInfos & (1<<i))
+		if(Config()->m_ClStatboardInfos & (1<<i))
 		{
-			if((1<<i) == (TC_STATS_DEATHS) && Config()->Values()->m_ClStatboardInfos & TC_STATS_FRAGS)
+			if((1<<i) == (TC_STATS_DEATHS) && Config()->m_ClStatboardInfos & TC_STATS_FRAGS)
 			{
 				w += 60; // some extra for the merge
 				continue;
 			}
 			else if((1<<i) == (TC_STATS_BESTSPREE))
 			{
-				if(!(Config()->Values()->m_ClStatboardInfos & TC_STATS_SPREE))
+				if(!(Config()->m_ClStatboardInfos & TC_STATS_SPREE))
 					w += 140; // Best spree is a long column name, add a bit more
 				else
 					w += 40; // The combined colunms are a bit long, add some extra
@@ -181,12 +181,12 @@ void CStats::OnRender()
 			w += 100;
 		}
 
-	if((m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS) && (Config()->Values()->m_ClStatboardInfos&TC_STATS_FLAGCAPTURES))
+	if((m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS) && (Config()->m_ClStatboardInfos&TC_STATS_FLAGCAPTURES))
 		w += 100;
 
 	bool aDisplayWeapon[NUM_WEAPONS] = {false};
 	bool NoDisplayedWeapon = true;
-	if(Config()->Values()->m_ClStatboardInfos & TC_STATS_WEAPS)
+	if(Config()->m_ClStatboardInfos & TC_STATS_WEAPS)
 	{
 		for(i=0; i<NumPlayers; i++)
 		{
@@ -221,25 +221,25 @@ void CStats::OnRender()
 	TextRender()->Text(0, x+10, y-5, 20.0f, Localize("Name"), -1.0f);
 	const char *apHeaders[] = { "K", "D", Localize("Suicides"), Localize("Ratio"), Localize("Net", "Net score"), Localize("FPM"), Localize("Spree"), Localize("Best spree"), Localize("Grabs", "Flag grabs") };
 	for(i=0; i<9; i++)
-		if(Config()->Values()->m_ClStatboardInfos & (1<<i))
+		if(Config()->m_ClStatboardInfos & (1<<i))
 		{
 			const char* pText = apHeaders[i];
 			// handle K:D merge (in the frags column)
-			if(1<<i == TC_STATS_FRAGS && Config()->Values()->m_ClStatboardInfos & TC_STATS_DEATHS)
+			if(1<<i == TC_STATS_FRAGS && Config()->m_ClStatboardInfos & TC_STATS_DEATHS)
 			{
 				pText = "K:D";
 				px += 60.0f; // some extra for the merge
 			}
-			else if(1<<i == TC_STATS_DEATHS && Config()->Values()->m_ClStatboardInfos & TC_STATS_FRAGS)
+			else if(1<<i == TC_STATS_DEATHS && Config()->m_ClStatboardInfos & TC_STATS_FRAGS)
 				continue;
 			// handle spree columns merge
 			if(1<<i == TC_STATS_BESTSPREE)
 			{
-				if(Config()->Values()->m_ClStatboardInfos & TC_STATS_SPREE)
+				if(Config()->m_ClStatboardInfos & TC_STATS_SPREE)
 					continue;
 				px += 40.0f; // some extra for the long name
 			}
-			else if(1<<i == TC_STATS_SPREE && Config()->Values()->m_ClStatboardInfos & TC_STATS_BESTSPREE)
+			else if(1<<i == TC_STATS_SPREE && Config()->m_ClStatboardInfos & TC_STATS_BESTSPREE)
 				px += 40.0f; // some extra for the merge
 			if(1<<i == TC_STATS_FLAGGRABS && !(m_pClient->m_Snap.m_pGameData && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS))
 				continue;
@@ -249,7 +249,7 @@ void CStats::OnRender()
 		}
 
 	// sprite headers now
-	if(Config()->Values()->m_ClStatboardInfos & TC_STATS_WEAPS)
+	if(Config()->m_ClStatboardInfos & TC_STATS_WEAPS)
 	{
 		Graphics()->TextureSet(g_pData->m_aImages[IMAGE_GAME].m_Id);
 		Graphics()->QuadsBegin();
@@ -270,7 +270,7 @@ void CStats::OnRender()
 			px += 10;
 	}
 
-	if(m_pClient->m_Snap.m_pGameData && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS && Config()->Values()->m_ClStatboardInfos&TC_STATS_FLAGCAPTURES)
+	if(m_pClient->m_Snap.m_pGameData && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS && Config()->m_ClStatboardInfos&TC_STATS_FLAGCAPTURES)
 	{
 		px -= 40;
 		Graphics()->TextureSet(g_pData->m_aImages[IMAGE_GAME].m_Id);
@@ -334,9 +334,9 @@ void CStats::OnRender()
 		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[apPlayers[j]].m_aName, -1);
 
 		px = 325;
-		if(Config()->Values()->m_ClStatboardInfos & TC_STATS_FRAGS)
+		if(Config()->m_ClStatboardInfos & TC_STATS_FRAGS)
 		{
-			if(Config()->Values()->m_ClStatboardInfos & TC_STATS_DEATHS)
+			if(Config()->m_ClStatboardInfos & TC_STATS_DEATHS)
 			{
 				px += 60;
 				str_format(aBuf, sizeof(aBuf), "%d:%d", pStats->m_Frags, pStats->m_Deaths);
@@ -347,21 +347,21 @@ void CStats::OnRender()
 			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1.0f);
 			px += 100;
 		}
-		else if(Config()->Values()->m_ClStatboardInfos & TC_STATS_DEATHS)
+		else if(Config()->m_ClStatboardInfos & TC_STATS_DEATHS)
 		{
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Deaths);
 			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1.0f);
 			px += 100;
 		}
-		if(Config()->Values()->m_ClStatboardInfos & TC_STATS_SUICIDES)
+		if(Config()->m_ClStatboardInfos & TC_STATS_SUICIDES)
 		{
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Suicides);
 			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1.0f);
 			px += 100;
 		}
-		if(Config()->Values()->m_ClStatboardInfos & TC_STATS_RATIO)
+		if(Config()->m_ClStatboardInfos & TC_STATS_RATIO)
 		{
 			if(pStats->m_Deaths == 0)
 				str_format(aBuf, sizeof(aBuf), "--");
@@ -371,14 +371,14 @@ void CStats::OnRender()
 			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1.0f);
 			px += 100;
 		}
-		if(Config()->Values()->m_ClStatboardInfos & TC_STATS_NET)
+		if(Config()->m_ClStatboardInfos & TC_STATS_NET)
 		{
 			str_format(aBuf, sizeof(aBuf), "%+d", pStats->m_Frags-pStats->m_Deaths);
 			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1.0f);
 			px += 100;
 		}
-		if(Config()->Values()->m_ClStatboardInfos & TC_STATS_FPM)
+		if(Config()->m_ClStatboardInfos & TC_STATS_FPM)
 		{
 			float Fpm = pStats->m_IngameTicks > 0 ? (float)(pStats->m_Frags * Client()->GameTickSpeed() * 60) / pStats->m_IngameTicks : 0.f;
 			str_format(aBuf, sizeof(aBuf), "%.1f", Fpm);
@@ -386,9 +386,9 @@ void CStats::OnRender()
 			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1.0f);
 			px += 100;
 		}
-		if(Config()->Values()->m_ClStatboardInfos & TC_STATS_SPREE)
+		if(Config()->m_ClStatboardInfos & TC_STATS_SPREE)
 		{
-			if(Config()->Values()->m_ClStatboardInfos & TC_STATS_BESTSPREE)
+			if(Config()->m_ClStatboardInfos & TC_STATS_BESTSPREE)
 			{
 				px += 40; // extra space
 				str_format(aBuf, sizeof(aBuf), "%d (%d)", pStats->m_CurrentSpree, pStats->m_BestSpree);
@@ -399,7 +399,7 @@ void CStats::OnRender()
 			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1.0f);
 			px += 100;
 		}
-		else if(Config()->Values()->m_ClStatboardInfos & TC_STATS_BESTSPREE)
+		else if(Config()->m_ClStatboardInfos & TC_STATS_BESTSPREE)
 		{
 			px += 40;
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_BestSpree);
@@ -407,7 +407,7 @@ void CStats::OnRender()
 			TextRender()->Text(0, x-tw+px, y, FontSize, aBuf, -1.0f);
 			px += 100;
 		}
-		if(m_pClient->m_Snap.m_pGameData && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS && Config()->Values()->m_ClStatboardInfos&TC_STATS_FLAGGRABS)
+		if(m_pClient->m_Snap.m_pGameData && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS && Config()->m_ClStatboardInfos&TC_STATS_FLAGGRABS)
 		{
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_FlagGrabs);
 			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);
@@ -415,7 +415,7 @@ void CStats::OnRender()
 			px += 100;
 		}
 		px -= 40;
-		if(Config()->Values()->m_ClStatboardInfos & TC_STATS_WEAPS)
+		if(Config()->m_ClStatboardInfos & TC_STATS_WEAPS)
 		{
 			const float BarHeight = 0.3f*LineHeight;
 			const float Offset = 40.0f;
@@ -462,7 +462,7 @@ void CStats::OnRender()
 				px += 10;
 		}
 
-		if(m_pClient->m_Snap.m_pGameData && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS && Config()->Values()->m_ClStatboardInfos&TC_STATS_FLAGCAPTURES)
+		if(m_pClient->m_Snap.m_pGameData && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_FLAGS && Config()->m_ClStatboardInfos&TC_STATS_FLAGCAPTURES)
 		{
 			if(pStats->m_FlagCaptures <= 0)
 			{

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -191,20 +191,20 @@ void CVoting::OnMessage(int MsgType, void *pRawMsg)
 				case VOTE_START_KICK:
 					{
 						char aName[4];
-						if(!Config()->Values()->m_ClShowsocial)
+						if(!Config()->m_ClShowsocial)
 							str_copy(aName, pMsg->m_pDescription, sizeof(aName));
-						str_format(aBuf, sizeof(aBuf), Localize("'%s' called for vote to kick '%s' (%s)"), aLabel, Config()->Values()->m_ClShowsocial ? pMsg->m_pDescription : aName, pMsg->m_pReason);
-						str_format(m_aDescription, sizeof(m_aDescription), "Kick '%s'", Config()->Values()->m_ClShowsocial ? pMsg->m_pDescription : aName);
+						str_format(aBuf, sizeof(aBuf), Localize("'%s' called for vote to kick '%s' (%s)"), aLabel, Config()->m_ClShowsocial ? pMsg->m_pDescription : aName, pMsg->m_pReason);
+						str_format(m_aDescription, sizeof(m_aDescription), "Kick '%s'", Config()->m_ClShowsocial ? pMsg->m_pDescription : aName);
 						m_pClient->m_pChat->AddLine(aBuf);
 						break;
 					}
 				case VOTE_START_SPEC:
 					{
 						char aName[4];
-						if(!Config()->Values()->m_ClShowsocial)
+						if(!Config()->m_ClShowsocial)
 							str_copy(aName, pMsg->m_pDescription, sizeof(aName));
-						str_format(aBuf, sizeof(aBuf), Localize("'%s' called for vote to move '%s' to spectators (%s)"), aLabel, Config()->Values()->m_ClShowsocial ? pMsg->m_pDescription : aName, pMsg->m_pReason);
-						str_format(m_aDescription, sizeof(m_aDescription), "Move '%s' to spectators", Config()->Values()->m_ClShowsocial ? pMsg->m_pDescription : aName);
+						str_format(aBuf, sizeof(aBuf), Localize("'%s' called for vote to move '%s' to spectators (%s)"), aLabel, Config()->m_ClShowsocial ? pMsg->m_pDescription : aName, pMsg->m_pReason);
+						str_format(m_aDescription, sizeof(m_aDescription), "Move '%s' to spectators", Config()->m_ClShowsocial ? pMsg->m_pDescription : aName);
 						m_pClient->m_pChat->AddLine(aBuf);
 					}
 				}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -131,8 +131,8 @@ const char *CGameClient::NetVersionHashUsed() const { return GAME_NETVERSION_HAS
 const char *CGameClient::NetVersionHashReal() const{ return GAME_NETVERSION_HASH; }
 int CGameClient::ClientVersion() const { return CLIENT_VERSION; }
 const char *CGameClient::GetItemName(int Type) const { return m_NetObjHandler.GetObjName(Type); }
-bool CGameClient::IsXmas() const { return Config()->Values()->m_ClShowXmasHats == 2 || (Config()->Values()->m_ClShowXmasHats == 1 && m_IsXmasDay); }
-bool CGameClient::IsEaster() const { return Config()->Values()->m_ClShowEasterEggs == 2 || (Config()->Values()->m_ClShowEasterEggs == 1 && m_IsEasterDay); }
+bool CGameClient::IsXmas() const { return Config()->m_ClShowXmasHats == 2 || (Config()->m_ClShowXmasHats == 1 && m_IsXmasDay); }
+bool CGameClient::IsEaster() const { return Config()->m_ClShowEasterEggs == 2 || (Config()->m_ClShowEasterEggs == 1 && m_IsEasterDay); }
 
 enum
 {
@@ -159,9 +159,9 @@ static int GetStrTeam(int Team, bool Teamplay)
 
 void CGameClient::GetPlayerLabel(char* aBuf, int BufferSize, int ClientID, const char* ClientName)
 {
-	if(!Config()->Values()->m_ClShowsocial)
+	if(!Config()->m_ClShowsocial)
 		str_format(aBuf, BufferSize, "%2d:", ClientID);
-	else if(Config()->Values()->m_ClShowUserId)
+	else if(Config()->m_ClShowUserId)
 		str_format(aBuf, BufferSize, "%2d: %s", ClientID, ClientName);
 	else
 		str_format(aBuf, BufferSize, "%s", ClientName);
@@ -210,7 +210,7 @@ void CGameClient::OnConsoleInit()
 	m_pTextRender = Kernel()->RequestInterface<ITextRender>();
 	m_pSound = Kernel()->RequestInterface<ISound>();
 	m_pInput = Kernel()->RequestInterface<IInput>();
-	m_pConfig = Kernel()->RequestInterface<IConfig>();
+	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 	m_pDemoPlayer = Kernel()->RequestInterface<IDemoPlayer>();
@@ -345,7 +345,7 @@ void CGameClient::OnInit()
 	int64 Start = time_get();
 
 	// set the language
-	g_Localization.Load(Config()->Values()->m_ClLanguagefile, Storage(), Console());
+	g_Localization.Load(Config()->m_ClLanguagefile, Storage(), Console());
 
 	// TODO: this should be different
 	// setup item sizes
@@ -357,7 +357,7 @@ void CGameClient::OnInit()
 
 	// load default font
 	char aFontName[256];
-	str_format(aFontName, sizeof(aFontName), "fonts/%s", Config()->Values()->m_ClFontfile);
+	str_format(aFontName, sizeof(aFontName), "fonts/%s", Config()->m_ClFontfile);
 	char aFilename[512];
 	IOHANDLE File = Storage()->OpenFile(aFontName, IOFLAG_READ, IStorage::TYPE_ALL, aFilename, sizeof(aFilename));
 	if(File)
@@ -477,7 +477,7 @@ void CGameClient::OnReset()
 void CGameClient::UpdatePositions()
 {
 	// local character position
-	if(Config()->Values()->m_ClPredict && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+	if(Config()->m_ClPredict && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		if(!m_Snap.m_pLocalCharacter ||
 			(m_Snap.m_pGameData && m_Snap.m_pGameData->m_GameStateFlags&(GAMESTATEFLAG_PAUSED|GAMESTATEFLAG_ROUNDOVER|GAMESTATEFLAG_GAMEOVER)))
@@ -760,7 +760,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 		{
 			if(m_LocalClientID != -1)
 			{
-				if(Config()->Values()->m_Debug)
+				if(Config()->m_Debug)
 					Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", "invalid local clientinfo");
 				return;
 			}
@@ -771,7 +771,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 		{
 			if(m_aClients[pMsg->m_ClientID].m_Active)
 			{
-				if(Config()->Values()->m_Debug)
+				if(Config()->m_Debug)
 					Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", "invalid clientinfo");
 				return;
 			}
@@ -832,7 +832,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 
 		if(m_LocalClientID == pMsg->m_ClientID || !m_aClients[pMsg->m_ClientID].m_Active)
 		{
-			if(Config()->Values()->m_Debug)
+			if(Config()->m_Debug)
 				Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", "invalid clientdrop");
 			return;
 		}
@@ -863,7 +863,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 
 		if(!m_aClients[pMsg->m_ClientID].m_Active)
 		{
-			if(Config()->Values()->m_Debug)
+			if(Config()->m_Debug)
 				Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", "invalid skin info");
 			return;
 		}
@@ -977,7 +977,7 @@ void CGameClient::OnEnterGame() {}
 
 void CGameClient::OnGameOver()
 {
-	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && Config()->Values()->m_ClEditor == 0)
+	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && Config()->m_ClEditor == 0)
 		Client()->AutoScreenshot_Start();
 }
 
@@ -1088,7 +1088,7 @@ void CGameClient::OnNewSnapshot()
 			const void *pData = Client()->SnapGetItem(IClient::SNAP_CURRENT, Index, &Item);
 			if(m_NetObjHandler.ValidateObj(Item.m_Type, pData, Item.m_DataSize) != 0)
 			{
-				if(Config()->Values()->m_Debug)
+				if(Config()->m_Debug)
 				{
 					char aBuf[256];
 					str_format(aBuf, sizeof(aBuf), "invalidated index=%d type=%d (%s) size=%d id=%d", Index, Item.m_Type, m_NetObjHandler.GetObjName(Item.m_Type), Item.m_DataSize, Item.m_ID);
@@ -1101,7 +1101,7 @@ void CGameClient::OnNewSnapshot()
 
 	ProcessEvents();
 
-	if(Config()->Values()->m_DbgStress)
+	if(Config()->m_DbgStress)
 	{
 		if((Client()->GameTick()%100) == 0)
 		{
@@ -1536,7 +1536,7 @@ void CGameClient::OnPredict()
 			m_PredictedChar = *World.m_apCharacters[m_LocalClientID];
 	}
 
-	if(Config()->Values()->m_Debug && Config()->Values()->m_ClPredict && m_PredictedTick == Client()->PredGameTick())
+	if(Config()->m_Debug && Config()->m_ClPredict && m_PredictedTick == Client()->PredGameTick())
 	{
 		CNetObj_CharacterCore Before = {0}, Now = {0}, BeforePrev = {0}, NowPrev = {0};
 		BeforeChar.Write(&Before);
@@ -1744,9 +1744,9 @@ void CGameClient::SendSwitchTeam(int Team)
 void CGameClient::SendStartInfo()
 {
 	CNetMsg_Cl_StartInfo Msg;
-	Msg.m_pName = Config()->Values()->m_PlayerName;
-	Msg.m_pClan = Config()->Values()->m_PlayerClan;
-	Msg.m_Country = Config()->Values()->m_PlayerCountry;
+	Msg.m_pName = Config()->m_PlayerName;
+	Msg.m_pClan = Config()->m_PlayerClan;
+	Msg.m_Country = Config()->m_PlayerCountry;
 	for(int p = 0; p < NUM_SKINPARTS; p++)
 	{
 		Msg.m_apSkinPartNames[p] = CSkins::ms_apSkinVariables[p];

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -37,7 +37,7 @@ class CGameClient : public IGameClient
 	class ITextRender *m_pTextRender;
 	class IClient *m_pClient;
 	class ISound *m_pSound;
-	class IConfig *m_pConfig;
+	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
 	class IStorage *m_pStorage;
 	class IDemoPlayer *m_pDemoPlayer;
@@ -81,7 +81,7 @@ public:
 	class ISound *Sound() const { return m_pSound; }
 	class IInput *Input() const { return m_pInput; }
 	class IStorage *Storage() const { return m_pStorage; }
-	class IConfig *Config() const { return m_pConfig; }
+	class CConfig *Config() const { return m_pConfig; }
 	class IConsole *Console() { return m_pConsole; }
 	class ITextRender *TextRender() const { return m_pTextRender; }
 	class IDemoPlayer *DemoPlayer() const { return m_pDemoPlayer; }

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -16,7 +16,7 @@
 static float gs_SpriteWScale;
 static float gs_SpriteHScale;
 
-void CRenderTools::Init(IConfig *pConfig, IGraphics *pGraphics, CUI *pUI)
+void CRenderTools::Init(CConfig *pConfig, IGraphics *pGraphics, CUI *pUI)
 {
 	m_pConfig = pConfig;
 	m_pGraphics = pGraphics;
@@ -531,7 +531,7 @@ void CRenderTools::RenderTee(CAnimState *pAnim, const CTeeRenderInfo *pInfo, int
 			}
 			else
 			{
-				bool Indicate = !pInfo->m_GotAirJump && m_pConfig->Values()->m_ClAirjumpindicator;
+				bool Indicate = !pInfo->m_GotAirJump && m_pConfig->m_ClAirjumpindicator;
 				float cs = 1.0f; // color scale
 				if(Indicate)
 					cs = 0.5f;
@@ -667,7 +667,7 @@ void CRenderTools::RenderTilemapGenerateSkip(class CLayers *pLayers)
 void CRenderTools::DrawClientID(ITextRender* pTextRender, CTextCursor* pCursor, int ID,
 								const vec4& BgColor, const vec4& TextColor)
 {
-	if(!m_pConfig->Values()->m_ClShowUserId) return;
+	if(!m_pConfig->m_ClShowUserId) return;
 
 	char aBuff[4];
 	str_format(aBuff, sizeof(aBuff), "%2d ", ID);
@@ -712,6 +712,6 @@ void CRenderTools::DrawClientID(ITextRender* pTextRender, CTextCursor* pCursor, 
 
 float CRenderTools::GetClientIdRectSize(float FontSize)
 {
-	if(!m_pConfig->Values()->m_ClShowUserId) return 0;
+	if(!m_pConfig->m_ClShowUserId) return 0;
 	return 1.4f * FontSize + 0.2f * FontSize;
 }

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -52,7 +52,7 @@ class CRenderTools
 	void DrawRoundRectExt4(float x, float y, float w, float h, vec4 ColorTopLeft, vec4 ColorTopRight, vec4 ColorBottomLeft, vec4 ColorBottomRight, float r, int Corners);
 
 
-	class IConfig *m_pConfig;
+	class CConfig *m_pConfig;
 	class IGraphics *m_pGraphics;
 	class CUI *m_pUI;
 public:
@@ -60,7 +60,7 @@ public:
 	class IGraphics *Graphics() const { return m_pGraphics; }
 	class CUI *UI() const { return m_pUI; }
 
-	void Init(class IConfig *pConfig, class IGraphics *pGraphics, class CUI *pUI);
+	void Init(class CConfig *pConfig, class IGraphics *pGraphics, class CUI *pUI);
 
 	void SelectSprite(struct CDataSprite *pSprite, int Flags=0, int sx=0, int sy=0);
 	void SelectSprite(int id, int Flags=0, int sx=0, int sy=0);

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -63,7 +63,7 @@ bool CUI::MouseInsideClip() const
 
 void CUI::ConvertMouseMove(float *x, float *y) const
 {
-	float Fac = (float)(m_pConfig->Values()->m_UiMousesens)/m_pConfig->Values()->m_InpMousesens;
+	float Fac = (float)(m_pConfig->m_UiMousesens)/m_pConfig->m_InpMousesens;
 	*x = *x*Fac;
 	*y = *y*Fac;
 }

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -44,14 +44,14 @@ class CUI
 	unsigned m_NumClips;
 	void UpdateClipping();
 
-	class IConfig *m_pConfig;
+	class CConfig *m_pConfig;
 	class IGraphics *m_pGraphics;
 	class ITextRender *m_pTextRender;
 
 public:
 	// TODO: Refactor: Fill this in
-	void Init(class IConfig *pConfig, class IGraphics *pGraphics, class ITextRender *pTextRender) { m_pConfig = pConfig; m_pGraphics = pGraphics; m_pTextRender = pTextRender; }
-	class IConfig *Config() const { return m_pConfig; }
+	void Init(class CConfig *pConfig, class IGraphics *pGraphics, class ITextRender *pTextRender) { m_pConfig = pConfig; m_pGraphics = pGraphics; m_pTextRender = pTextRender; }
+	class CConfig *Config() const { return m_pConfig; }
 	class IGraphics *Graphics() const { return m_pGraphics; }
 	class ITextRender *TextRender() const { return m_pTextRender; }
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -253,7 +253,7 @@ void CEditorImage::LoadAutoMapper()
 
 	// clean up
 	json_value_free(pJsonData);
-	if(m_pAutoMapper && m_pEditor->Config()->Values()->m_Debug)
+	if(m_pAutoMapper && m_pEditor->Config()->m_Debug)
 	{
 		str_format(aBuf, sizeof(aBuf),"loaded %s.json (%s)", m_aName, IAutoMapper::GetTypeName(m_pAutoMapper->GetType()));
 		m_pEditor->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "editor", aBuf);
@@ -666,18 +666,18 @@ void CEditor::RenderGrid(CLayerGroup *pGroup)
 	for(int i = 0; i < (int)w; i++)
 	{
 		if((i+YGridOffset) % m_GridFactor == 0)
-			GridColor = HexToRgba(Config()->Values()->m_EdColorGridOuter);
+			GridColor = HexToRgba(Config()->m_EdColorGridOuter);
 		else
-			GridColor = HexToRgba(Config()->Values()->m_EdColorGridInner);
+			GridColor = HexToRgba(Config()->m_EdColorGridInner);
 
 		Graphics()->SetColor(GridColor.r, GridColor.g, GridColor.b, GridColor.a);
 		IGraphics::CLineItem Line = IGraphics::CLineItem(LineDistance*XOffset, LineDistance*i+LineDistance*YOffset, w+aGroupPoints[2], LineDistance*i+LineDistance*YOffset);
 		Graphics()->LinesDraw(&Line, 1);
 
 		if((i+XGridOffset) % m_GridFactor == 0)
-			GridColor = HexToRgba(Config()->Values()->m_EdColorGridOuter);
+			GridColor = HexToRgba(Config()->m_EdColorGridOuter);
 		else
-			GridColor = HexToRgba(Config()->Values()->m_EdColorGridInner);
+			GridColor = HexToRgba(Config()->m_EdColorGridInner);
 
 		Graphics()->SetColor(GridColor.r, GridColor.g, GridColor.b, GridColor.a);
 		Line = IGraphics::CLineItem(LineDistance*i+LineDistance*XOffset, LineDistance*YOffset, LineDistance*i+LineDistance*XOffset, h+aGroupPoints[3]);
@@ -1301,13 +1301,13 @@ void CEditor::DoQuad(CQuad *q, int Index)
 			}
 		}
 
-		PivotColor = HexToRgba(Config()->Values()->m_EdColorQuadPivotActive);
+		PivotColor = HexToRgba(Config()->m_EdColorQuadPivotActive);
 	}
 	else if(UI()->HotItem() == pID)
 	{
 		ms_pUiGotContext = pID;
 
-		PivotColor = HexToRgba(Config()->Values()->m_EdColorQuadPivotHover);
+		PivotColor = HexToRgba(Config()->m_EdColorQuadPivotHover);
 		m_pTooltip = "Left mouse button to move. Hold shift to move pivot. Hold ctrl to rotate. Hold alt to ignore grid.";
 
 		if(UI()->MouseButton(0))
@@ -1345,7 +1345,7 @@ void CEditor::DoQuad(CQuad *q, int Index)
 		}
 	}
 	else
-		PivotColor = HexToRgba(Config()->Values()->m_EdColorQuadPivot);
+		PivotColor = HexToRgba(Config()->m_EdColorQuadPivot);
 
 	Graphics()->SetColor(PivotColor.r, PivotColor.g, PivotColor.b, PivotColor.a);
 	IGraphics::CQuadItem QuadItem(CenterX, CenterY, 5.0f*m_WorldZoom, 5.0f*m_WorldZoom);
@@ -1482,13 +1482,13 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 			}
 		}
 
-		pointColor = HexToRgba(Config()->Values()->m_EdColorQuadPointActive);
+		pointColor = HexToRgba(Config()->m_EdColorQuadPointActive);
 	}
 	else if(UI()->HotItem() == pID)
 	{
 		ms_pUiGotContext = pID;
 
-		pointColor = HexToRgba(Config()->Values()->m_EdColorQuadPointHover);
+		pointColor = HexToRgba(Config()->m_EdColorQuadPointHover);
 		m_pTooltip = "Left mouse button to move. Hold shift to move the texture. Hold alt to ignore grid.";
 
 		if(UI()->MouseButton(0))
@@ -1530,7 +1530,7 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 		}
 	}
 	else
-		pointColor = HexToRgba(Config()->Values()->m_EdColorQuadPoint);
+		pointColor = HexToRgba(Config()->m_EdColorQuadPoint);
 
 	Graphics()->SetColor(pointColor.r, pointColor.g, pointColor.b, pointColor.a);
 	IGraphics::CQuadItem QuadItem(px, py, 5.0f*m_WorldZoom, 5.0f*m_WorldZoom);
@@ -4260,7 +4260,7 @@ int CEditor::PopupMenuFile(CEditor *pEditor, CUIRect View)
 			pEditor->m_PopupEventActivated = true;
 		}
 		else
-			pEditor->Config()->Values()->m_ClEditor = 0;
+			pEditor->Config()->m_ClEditor = 0;
 		return 1;
 	}
 
@@ -4294,7 +4294,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	ExitButton.VSplitRight(13.f, 0, &ExitButton);
 	if(DoButton_Editor(&s_ExitButton, "\xE2\x9C\x95", 1, &ExitButton, 0, "[ctrl+shift+e] Exit"))
 	{
-		Config()->Values()->m_ClEditor ^= 1;
+		Config()->m_ClEditor ^= 1;
 		Input()->MouseModeRelative();
 	}
 }
@@ -4368,7 +4368,7 @@ void CEditor::Render()
 		{
 			float OldLevel = m_ZoomLevel;
 			m_ZoomLevel = clamp(m_ZoomLevel + Zoom * 20, 50, 2000);
-			if(Config()->Values()->m_EdZoomTarget)
+			if(Config()->m_EdZoomTarget)
 				ZoomMouseTarget((float)m_ZoomLevel / OldLevel);
 		}
 	}
@@ -4441,7 +4441,7 @@ void CEditor::Render()
 		RenderStatusbar(StatusBar);
 
 	// todo: fix this
-	if(Config()->Values()->m_EdShowkeys)
+	if(Config()->m_EdShowkeys)
 	{
 		Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
 		CTextCursor Cursor;
@@ -4663,7 +4663,7 @@ void CEditor::Init()
 {
 	m_pInput = Kernel()->RequestInterface<IInput>();
 	m_pClient = Kernel()->RequestInterface<IClient>();
-	m_pConfig = Kernel()->RequestInterface<IConfig>();
+	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pGraphics = Kernel()->RequestInterface<IGraphics>();
 	m_pTextRender = Kernel()->RequestInterface<ITextRender>();

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -502,7 +502,7 @@ class CEditor : public IEditor
 {
 	class IInput *m_pInput;
 	class IClient *m_pClient;
-	class IConfig *m_pConfig;
+	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
 	class IGraphics *m_pGraphics;
 	class ITextRender *m_pTextRender;
@@ -512,7 +512,7 @@ class CEditor : public IEditor
 public:
 	class IInput *Input() { return m_pInput; };
 	class IClient *Client() { return m_pClient; };
-	class IConfig *Config() { return m_pConfig; }
+	class CConfig *Config() { return m_pConfig; }
 	class IConsole *Console() { return m_pConsole; };
 	class IGraphics *Graphics() { return m_pGraphics; };
 	class ITextRender *TextRender() { return m_pTextRender; };

--- a/src/game/editor/layer_quads.cpp
+++ b/src/game/editor/layer_quads.cpp
@@ -81,7 +81,7 @@ CQuad *CLayerQuads::NewQuad()
 void CLayerQuads::BrushSelecting(CUIRect Rect)
 {
 	// draw selection rectangle
-	vec4 RectColor = HexToRgba(m_pEditor->Config()->Values()->m_EdColorSelectionQuad);
+	vec4 RectColor = HexToRgba(m_pEditor->Config()->m_EdColorSelectionQuad);
 	IGraphics::CLineItem Array[4] = {
 		IGraphics::CLineItem(Rect.x, Rect.y, Rect.x+Rect.w, Rect.y),
 		IGraphics::CLineItem(Rect.x+Rect.w, Rect.y, Rect.x+Rect.w, Rect.y+Rect.h),

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -216,7 +216,7 @@ void CLayerTiles::Clamp(RECTi *pRect)
 
 void CLayerTiles::BrushSelecting(CUIRect Rect)
 {
-	vec4 FillColor = HexToRgba(m_pEditor->Config()->Values()->m_EdColorSelectionTile);
+	vec4 FillColor = HexToRgba(m_pEditor->Config()->m_EdColorSelectionTile);
 
 	Graphics()->TextureClear();
 	m_pEditor->Graphics()->QuadsBegin();

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -795,7 +795,7 @@ int CEditor::PopupEvent(CEditor *pEditor, CUIRect View)
 	if(pEditor->DoButton_Editor(&s_OkButton, "Ok", 0, &Label, 0, 0))
 	{
 		if(pEditor->m_PopupEventType == POPEVENT_EXIT)
-			pEditor->Config()->Values()->m_ClEditor = 0;
+			pEditor->Config()->m_ClEditor = 0;
 		else if(pEditor->m_PopupEventType == POPEVENT_LOAD)
 			pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_MAP, "Load map", "Load", "maps", "", pEditor->CallbackOpenMap, pEditor);
 		else if(pEditor->m_PopupEventType == POPEVENT_LOAD_CURRENT)

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -288,7 +288,7 @@ void CCharacter::FireWeapon()
 
 	vec2 ProjStartPos = m_Pos+Direction*GetProximityRadius()*0.75f;
 
-	if(GameServer()->Config()->Values()->m_Debug)
+	if(Config()->m_Debug)
 	{
 		char aBuf[256];
 		str_format(aBuf, sizeof(aBuf), "shot player='%d:%s' team=%d weapon=%d", m_pPlayer->GetCID(), Server()->ClientName(m_pPlayer->GetCID()), m_pPlayer->GetTeam(), m_ActiveWeapon);
@@ -845,7 +845,7 @@ void CCharacter::Snap(int SnappingClient)
 	pCharacter->m_Direction = m_Input.m_Direction;
 
 	if(m_pPlayer->GetCID() == SnappingClient || SnappingClient == -1 ||
-		(!GameServer()->Config()->Values()->m_SvStrictSpectateMode && m_pPlayer->GetCID() == GameServer()->m_apPlayers[SnappingClient]->GetSpectatorID()))
+		(!Config()->m_SvStrictSpectateMode && m_pPlayer->GetCID() == GameServer()->m_apPlayers[SnappingClient]->GetSpectatorID()))
 	{
 		pCharacter->m_Health = m_Health;
 		pCharacter->m_Armor = m_Armor;

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -59,6 +59,7 @@ public:
 
 	/* Objects */
 	class CGameWorld *GameWorld()		{ return m_pGameWorld; }
+	class CConfig *Config()				{ return m_pGameWorld->Config(); }
 	class CGameContext *GameServer()	{ return m_pGameWorld->GameServer(); }
 	class IServer *Server()				{ return m_pGameWorld->Server(); }
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -264,19 +264,19 @@ void CGameContext::SendWeaponPickup(int ClientID, int Weapon)
 void CGameContext::SendMotd(int ClientID)
 {
 	CNetMsg_Sv_Motd Msg;
-	Msg.m_pMessage = Config()->Values()->m_SvMotd;
+	Msg.m_pMessage = Config()->m_SvMotd;
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
 }
 
 void CGameContext::SendSettings(int ClientID)
 {
 	CNetMsg_Sv_ServerSettings Msg;
-	Msg.m_KickVote = Config()->Values()->m_SvVoteKick;
-	Msg.m_KickMin = Config()->Values()->m_SvVoteKickMin;
-	Msg.m_SpecVote = Config()->Values()->m_SvVoteSpectate;
+	Msg.m_KickVote = Config()->m_SvVoteKick;
+	Msg.m_KickMin = Config()->m_SvVoteKickMin;
+	Msg.m_SpecVote = Config()->m_SvVoteSpectate;
 	Msg.m_TeamLock = m_LockTeams != 0;
-	Msg.m_TeamBalance = Config()->Values()->m_SvTeambalanceTime != 0;
-	Msg.m_PlayerSlots = Config()->Values()->m_SvPlayerSlots;
+	Msg.m_TeamBalance = Config()->m_SvTeambalanceTime != 0;
+	Msg.m_PlayerSlots = Config()->m_SvPlayerSlots;
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
 }
 
@@ -571,7 +571,7 @@ void CGameContext::OnClientDirectInput(int ClientID, void *pInput)
 	int NumFailures = m_NetObjHandler.NumObjFailures();
 	if(m_NetObjHandler.ValidateObj(NETOBJTYPE_PLAYERINPUT, pInput, sizeof(CNetObj_PlayerInput)) == -1)
 	{
-		if(Config()->Values()->m_Debug && NumFailures != m_NetObjHandler.NumObjFailures())
+		if(Config()->m_Debug && NumFailures != m_NetObjHandler.NumObjFailures())
 		{
 			char aBuf[128];
 			str_format(aBuf, sizeof(aBuf), "NETOBJTYPE_PLAYERINPUT failed on '%s'", m_NetObjHandler.FailedObjOn());
@@ -589,7 +589,7 @@ void CGameContext::OnClientPredictedInput(int ClientID, void *pInput)
 		int NumFailures = m_NetObjHandler.NumObjFailures();
 		if(m_NetObjHandler.ValidateObj(NETOBJTYPE_PLAYERINPUT, pInput, sizeof(CNetObj_PlayerInput)) == -1)
 		{
-			if(Config()->Values()->m_Debug && NumFailures != m_NetObjHandler.NumObjFailures())
+			if(Config()->m_Debug && NumFailures != m_NetObjHandler.NumObjFailures())
 			{
 				char aBuf[128];
 				str_format(aBuf, sizeof(aBuf), "NETOBJTYPE_PLAYERINPUT corrected on '%s'", m_NetObjHandler.FailedObjOn());
@@ -617,7 +617,7 @@ void CGameContext::OnClientEnter(int ClientID)
 	NewClientInfoMsg.m_Country = Server()->ClientCountry(ClientID);
 	NewClientInfoMsg.m_Silent = false;
 
-	if(Config()->Values()->m_SvSilentSpectatorMode && m_apPlayers[ClientID]->GetTeam() == TEAM_SPECTATORS)
+	if(Config()->m_SvSilentSpectatorMode && m_apPlayers[ClientID]->GetTeam() == TEAM_SPECTATORS)
 		NewClientInfoMsg.m_Silent = true;
 
 	for(int p = 0; p < NUM_SKINPARTS; p++)
@@ -727,7 +727,7 @@ void CGameContext::OnClientDrop(int ClientID, const char *pReason)
 		Msg.m_ClientID = ClientID;
 		Msg.m_pReason = pReason;
 		Msg.m_Silent = false;
-		if(Config()->Values()->m_SvSilentSpectatorMode && m_apPlayers[ClientID]->GetTeam() == TEAM_SPECTATORS)
+		if(Config()->m_SvSilentSpectatorMode && m_apPlayers[ClientID]->GetTeam() == TEAM_SPECTATORS)
 			Msg.m_Silent = true;
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL|MSGFLAG_NORECORD, -1);
 	}
@@ -753,7 +753,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 
 	if(!pRawMsg)
 	{
-		if(Config()->Values()->m_Debug)
+		if(Config()->m_Debug)
 		{
 			char aBuf[256];
 			str_format(aBuf, sizeof(aBuf), "dropped weird message '%s' (%d), failed on '%s'", m_NetObjHandler.GetMsgName(MsgID), MsgID, m_NetObjHandler.FailedMsgOn());
@@ -766,7 +766,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 	{
 		if(MsgID == NETMSGTYPE_CL_SAY)
 		{
-			if(Config()->Values()->m_SvSpamprotection && pPlayer->m_LastChat && pPlayer->m_LastChat+Server()->TickSpeed() > Server()->Tick())
+			if(Config()->m_SvSpamprotection && pPlayer->m_LastChat && pPlayer->m_LastChat+Server()->TickSpeed() > Server()->Tick())
 				return;
 
 			CNetMsg_Cl_Say *pMsg = (CNetMsg_Cl_Say *)pRawMsg;
@@ -798,14 +798,14 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 				*(const_cast<char *>(pEnd)) = 0;
 
 			// drop empty and autocreated spam messages (more than 20 characters per second)
-			if(Length == 0 || (Config()->Values()->m_SvSpamprotection && pPlayer->m_LastChat && pPlayer->m_LastChat + Server()->TickSpeed()*(Length/20) > Server()->Tick()))
+			if(Length == 0 || (Config()->m_SvSpamprotection && pPlayer->m_LastChat && pPlayer->m_LastChat + Server()->TickSpeed()*(Length/20) > Server()->Tick()))
 				return;
 
 			pPlayer->m_LastChat = Server()->Tick();
 
 			// don't allow spectators to disturb players during a running game in tournament mode
 			int Mode = pMsg->m_Mode;
-			if((Config()->Values()->m_SvTournamentMode == 2) &&
+			if((Config()->m_SvTournamentMode == 2) &&
 				pPlayer->GetTeam() == TEAM_SPECTATORS &&
 				m_pController->IsGameRunning() &&
 				!Server()->IsAuthed(ClientID))
@@ -831,7 +831,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			}
 			else
 			{
-				if((Config()->Values()->m_SvSpamprotection && ((pPlayer->m_LastVoteTry && pPlayer->m_LastVoteTry+Server()->TickSpeed()*3 > Now) ||
+				if((Config()->m_SvSpamprotection && ((pPlayer->m_LastVoteTry && pPlayer->m_LastVoteTry+Server()->TickSpeed()*3 > Now) ||
 					(pPlayer->m_LastVoteCall && pPlayer->m_LastVoteCall+Server()->TickSpeed()*VOTE_COOLDOWN > Now))) ||
 					pPlayer->GetTeam() == TEAM_SPECTATORS || m_VoteCloseTime)
 					return;
@@ -880,7 +880,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			}
 			else if(str_comp_nocase(pMsg->m_Type, "kick") == 0)
 			{
-				if(!Config()->Values()->m_SvVoteKick || m_pController->GetRealPlayerNum() < Config()->Values()->m_SvVoteKickMin)
+				if(!Config()->m_SvVoteKick || m_pController->GetRealPlayerNum() < Config()->m_SvVoteKickMin)
 					return;
 
 				int KickID = str_toint(pMsg->m_Value);
@@ -888,13 +888,13 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 					return;
 
 				str_format(aDesc, sizeof(aDesc), "%2d: %s", KickID, Server()->ClientName(KickID));
-				if (!Config()->Values()->m_SvVoteKickBantime)
+				if (!Config()->m_SvVoteKickBantime)
 					str_format(aCmd, sizeof(aCmd), "kick %d Kicked by vote", KickID);
 				else
 				{
 					char aAddrStr[NETADDR_MAXSTRSIZE] = {0};
 					Server()->GetClientAddr(KickID, aAddrStr, sizeof(aAddrStr));
-					str_format(aCmd, sizeof(aCmd), "ban %s %d Banned by vote", aAddrStr, Config()->Values()->m_SvVoteKickBantime);
+					str_format(aCmd, sizeof(aCmd), "ban %s %d Banned by vote", aAddrStr, Config()->m_SvVoteKickBantime);
 				}
 				char aBuf[128];
 				str_format(aBuf, sizeof(aBuf),
@@ -915,7 +915,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			}
 			else if(str_comp_nocase(pMsg->m_Type, "spectate") == 0)
 			{
-				if(!Config()->Values()->m_SvVoteSpectate)
+				if(!Config()->m_SvVoteSpectate)
 					return;
 
 				int SpectateID = str_toint(pMsg->m_Value);
@@ -923,7 +923,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 					return;
 
 				str_format(aDesc, sizeof(aDesc), "%2d: %s", SpectateID, Server()->ClientName(SpectateID));
-				str_format(aCmd, sizeof(aCmd), "set_team %d -1 %d", SpectateID, Config()->Values()->m_SvVoteSpectateRejoindelay);
+				str_format(aCmd, sizeof(aCmd), "set_team %d -1 %d", SpectateID, Config()->m_SvVoteSpectateRejoindelay);
 				char aBuf[128];
 				str_format(aBuf, sizeof(aBuf),
 					"'%d:%s' voted %s '%d:%s' reason='%s' cmd='%s' force=%d",
@@ -981,7 +981,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			CNetMsg_Cl_SetTeam *pMsg = (CNetMsg_Cl_SetTeam *)pRawMsg;
 
 			if(pPlayer->GetTeam() == pMsg->m_Team ||
-				(Config()->Values()->m_SvSpamprotection && pPlayer->m_LastSetTeam && pPlayer->m_LastSetTeam+Server()->TickSpeed()*3 > Server()->Tick()) ||
+				(Config()->m_SvSpamprotection && pPlayer->m_LastSetTeam && pPlayer->m_LastSetTeam+Server()->TickSpeed()*3 > Server()->Tick()) ||
 				(pMsg->m_Team != TEAM_SPECTATORS && m_LockTeams) || pPlayer->m_TeamChangeTick > Server()->Tick())
 				return;
 
@@ -1000,7 +1000,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 		{
 			CNetMsg_Cl_SetSpectatorMode *pMsg = (CNetMsg_Cl_SetSpectatorMode *)pRawMsg;
 
-			if(Config()->Values()->m_SvSpamprotection && pPlayer->m_LastSetSpectatorMode && pPlayer->m_LastSetSpectatorMode+Server()->TickSpeed() > Server()->Tick())
+			if(Config()->m_SvSpamprotection && pPlayer->m_LastSetSpectatorMode && pPlayer->m_LastSetSpectatorMode+Server()->TickSpeed() > Server()->Tick())
 				return;
 
 			pPlayer->m_LastSetSpectatorMode = Server()->Tick();
@@ -1011,7 +1011,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 		{
 			CNetMsg_Cl_Emoticon *pMsg = (CNetMsg_Cl_Emoticon *)pRawMsg;
 
-			if(Config()->Values()->m_SvSpamprotection && pPlayer->m_LastEmote && pPlayer->m_LastEmote+Server()->TickSpeed()*3 > Server()->Tick())
+			if(Config()->m_SvSpamprotection && pPlayer->m_LastEmote && pPlayer->m_LastEmote+Server()->TickSpeed()*3 > Server()->Tick())
 				return;
 
 			pPlayer->m_LastEmote = Server()->Tick();
@@ -1476,7 +1476,7 @@ void CGameContext::ConchainGameinfoUpdate(IConsole::IResult *pResult, void *pUse
 void CGameContext::OnConsoleInit()
 {
 	m_pServer = Kernel()->RequestInterface<IServer>();
-	m_pConfig = Kernel()->RequestInterface<IConfig>();
+	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 
 	Console()->Register("tune", "si", CFGFLAG_SERVER, ConTuneParam, this, "Tune variable to value");
@@ -1505,7 +1505,7 @@ void CGameContext::OnInit()
 {
 	// init everything
 	m_pServer = Kernel()->RequestInterface<IServer>();
-	m_pConfig = Kernel()->RequestInterface<IConfig>();
+	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_World.SetGameServer(this);
 	m_Events.SetGameServer(this);
@@ -1520,15 +1520,15 @@ void CGameContext::OnInit()
 	m_Collision.Init(&m_Layers);
 
 	// select gametype
-	if(str_comp_nocase(Config()->Values()->m_SvGametype, "mod") == 0)
+	if(str_comp_nocase(Config()->m_SvGametype, "mod") == 0)
 		m_pController = new CGameControllerMOD(this);
-	else if(str_comp_nocase(Config()->Values()->m_SvGametype, "ctf") == 0)
+	else if(str_comp_nocase(Config()->m_SvGametype, "ctf") == 0)
 		m_pController = new CGameControllerCTF(this);
-	else if(str_comp_nocase(Config()->Values()->m_SvGametype, "lms") == 0)
+	else if(str_comp_nocase(Config()->m_SvGametype, "lms") == 0)
 		m_pController = new CGameControllerLMS(this);
-	else if(str_comp_nocase(Config()->Values()->m_SvGametype, "lts") == 0)
+	else if(str_comp_nocase(Config()->m_SvGametype, "lts") == 0)
 		m_pController = new CGameControllerLTS(this);
-	else if(str_comp_nocase(Config()->Values()->m_SvGametype, "tdm") == 0)
+	else if(str_comp_nocase(Config()->m_SvGametype, "tdm") == 0)
 		m_pController = new CGameControllerTDM(this);
 	else
 		m_pController = new CGameControllerDM(this);
@@ -1564,16 +1564,16 @@ void CGameContext::OnInit()
 	Console()->Chain("sv_matches_per_map", ConchainGameinfoUpdate, this);
 
 	// clamp sv_player_slots to 0..MaxClients
-	if(Config()->Values()->m_SvMaxClients < Config()->Values()->m_SvPlayerSlots)
-		Config()->Values()->m_SvPlayerSlots = Config()->Values()->m_SvMaxClients;
+	if(Config()->m_SvMaxClients < Config()->m_SvPlayerSlots)
+		Config()->m_SvPlayerSlots = Config()->m_SvMaxClients;
 
 #ifdef CONF_DEBUG
 	// clamp dbg_dummies to 0..MAX_CLIENTS-1
-	if(MAX_CLIENTS <= Config()->Values()->m_DbgDummies)
-		Config()->Values()->m_DbgDummies = MAX_CLIENTS;
-	if(Config()->Values()->m_DbgDummies)
+	if(MAX_CLIENTS <= Config()->m_DbgDummies)
+		Config()->m_DbgDummies = MAX_CLIENTS;
+	if(Config()->m_DbgDummies)
 	{
-		for(int i = 0; i < Config()->Values()->m_DbgDummies ; i++)
+		for(int i = 0; i < Config()->m_DbgDummies ; i++)
 			OnClientConnected(MAX_CLIENTS -i-1, true, false);
 	}
 #endif

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -36,7 +36,7 @@
 class CGameContext : public IGameServer
 {
 	IServer *m_pServer;
-	class IConfig *m_pConfig;
+	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
 	CLayers m_Layers;
 	CCollision m_Collision;
@@ -71,7 +71,7 @@ class CGameContext : public IGameServer
 	bool m_Resetting;
 public:
 	IServer *Server() const { return m_pServer; }
-	class IConfig *Config() { return m_pConfig; }
+	class CConfig *Config() { return m_pConfig; }
 	class IConsole *Console() { return m_pConsole; }
 	CCollision *Collision() { return &m_Collision; }
 	CTuningParams *Tuning() { return &m_Tuning; }

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -14,6 +14,7 @@
 IGameController::IGameController(CGameContext *pGameServer)
 {
 	m_pGameServer = pGameServer;
+	m_pConfig = m_pGameServer->Config();
 	m_pServer = m_pGameServer->Server();
 
 	// balancing
@@ -30,8 +31,8 @@ IGameController::IGameController(CGameContext *pGameServer)
 	m_SuddenDeath = 0;
 	m_aTeamscore[TEAM_RED] = 0;
 	m_aTeamscore[TEAM_BLUE] = 0;
-	if(GameServer()->Config()->Values()->m_SvWarmup)
-		SetGameState(IGS_WARMUP_USER, GameServer()->Config()->Values()->m_SvWarmup);
+	if(Config()->m_SvWarmup)
+		SetGameState(IGS_WARMUP_USER, Config()->m_SvWarmup);
 	else
 		SetGameState(IGS_WARMUP_GAME, TIMER_INFINITE);
 
@@ -39,9 +40,9 @@ IGameController::IGameController(CGameContext *pGameServer)
 	m_GameFlags = 0;
 	m_pGameType = "unknown";
 	m_GameInfo.m_MatchCurrent = m_MatchCount+1;
-	m_GameInfo.m_MatchNum = (str_length(GameServer()->Config()->Values()->m_SvMaprotation) && GameServer()->Config()->Values()->m_SvMatchesPerMap) ? GameServer()->Config()->Values()->m_SvMatchesPerMap : 0;
-	m_GameInfo.m_ScoreLimit = GameServer()->Config()->Values()->m_SvScorelimit;
-	m_GameInfo.m_TimeLimit = GameServer()->Config()->Values()->m_SvTimelimit;
+	m_GameInfo.m_MatchNum = (str_length(Config()->m_SvMaprotation) && Config()->m_SvMatchesPerMap) ? Config()->m_SvMatchesPerMap : 0;
+	m_GameInfo.m_ScoreLimit = Config()->m_SvScorelimit;
+	m_GameInfo.m_TimeLimit = Config()->m_SvTimelimit;
 
 	// map
 	m_aMapWish[0] = 0;
@@ -58,22 +59,22 @@ IGameController::IGameController(CGameContext *pGameServer)
 //activity
 void IGameController::DoActivityCheck()
 {
-	if(GameServer()->Config()->Values()->m_SvInactiveKickTime == 0)
+	if(Config()->m_SvInactiveKickTime == 0)
 		return;
 
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
-		if(GameServer()->m_apPlayers[i] && !GameServer()->m_apPlayers[i]->IsDummy() && (GameServer()->m_apPlayers[i]->GetTeam() != TEAM_SPECTATORS || GameServer()->Config()->Values()->m_SvInactiveKick > 0) &&
-			!Server()->IsAuthed(i) && (GameServer()->m_apPlayers[i]->m_InactivityTickCounter > GameServer()->Config()->Values()->m_SvInactiveKickTime*Server()->TickSpeed()*60))
+		if(GameServer()->m_apPlayers[i] && !GameServer()->m_apPlayers[i]->IsDummy() && (GameServer()->m_apPlayers[i]->GetTeam() != TEAM_SPECTATORS || Config()->m_SvInactiveKick > 0) &&
+			!Server()->IsAuthed(i) && (GameServer()->m_apPlayers[i]->m_InactivityTickCounter > Config()->m_SvInactiveKickTime*Server()->TickSpeed()*60))
 		{
 			if(GameServer()->m_apPlayers[i]->GetTeam() == TEAM_SPECTATORS)
 			{
-				if(GameServer()->Config()->Values()->m_SvInactiveKickSpec)
+				if(Config()->m_SvInactiveKickSpec)
 					Server()->Kick(i, "Kicked for inactivity");
 			}
 			else
 			{
-				switch(GameServer()->Config()->Values()->m_SvInactiveKick)
+				switch(Config()->m_SvInactiveKick)
 				{
 				case 1:
 					{
@@ -88,7 +89,7 @@ void IGameController::DoActivityCheck()
 						for(int j = 0; j < MAX_CLIENTS; ++j)
 							if(GameServer()->m_apPlayers[j] && GameServer()->m_apPlayers[j]->GetTeam() == TEAM_SPECTATORS)
 								++Spectators;
-						if(Spectators >= GameServer()->Config()->Values()->m_SvMaxClients - GameServer()->Config()->Values()->m_SvPlayerSlots)
+						if(Spectators >= Config()->m_SvMaxClients - Config()->m_SvPlayerSlots)
 							Server()->Kick(i, "Kicked for inactivity");
 						else
 							DoTeamChange(GameServer()->m_apPlayers[i], TEAM_SPECTATORS);
@@ -135,7 +136,7 @@ bool IGameController::CanBeMovedOnBalance(int ClientID) const
 
 void IGameController::CheckTeamBalance()
 {
-	if(!IsTeamplay() || !GameServer()->Config()->Values()->m_SvTeambalanceTime)
+	if(!IsTeamplay() || !Config()->m_SvTeambalanceTime)
 	{
 		m_UnbalancedTick = TBALANCE_OK;
 		return;
@@ -159,7 +160,7 @@ void IGameController::CheckTeamBalance()
 
 void IGameController::DoTeamBalance()
 {
-	if(!IsTeamplay() || !GameServer()->Config()->Values()->m_SvTeambalanceTime || absolute(m_aTeamSize[TEAM_RED]-m_aTeamSize[TEAM_BLUE]) < NUM_TEAMS)
+	if(!IsTeamplay() || !Config()->m_SvTeambalanceTime || absolute(m_aTeamSize[TEAM_RED]-m_aTeamSize[TEAM_BLUE]) < NUM_TEAMS)
 		return;
 
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", "Balancing teams");
@@ -298,7 +299,7 @@ bool IGameController::OnEntity(int Index, vec2 Pos)
 		Type = PICKUP_LASER;
 		break;
 	case ENTITY_POWERUP_NINJA:
-		if(GameServer()->Config()->Values()->m_SvPowerups)
+		if(Config()->m_SvPowerups)
 			Type = PICKUP_NINJA;
 	}
 
@@ -353,7 +354,7 @@ void IGameController::OnPlayerInfoChange(CPlayer *pPlayer)
 
 void IGameController::OnPlayerReadyChange(CPlayer *pPlayer)
 {
-	if(GameServer()->Config()->Values()->m_SvPlayerReadyMode && pPlayer->GetTeam() != TEAM_SPECTATORS && !pPlayer->m_DeadSpecMode)
+	if(Config()->m_SvPlayerReadyMode && pPlayer->GetTeam() != TEAM_SPECTATORS && !pPlayer->m_DeadSpecMode)
 	{
 		// change players ready state
 		pPlayer->m_IsReadyToPlay ^= 1;
@@ -371,7 +372,7 @@ void IGameController::OnPlayerReadyChange(CPlayer *pPlayer)
 // to be called when a player changes state, spectates or disconnects
 void IGameController::CheckReadyStates(int WithoutID)
 {
-	if(GameServer()->Config()->Values()->m_SvPlayerReadyMode)
+	if(Config()->m_SvPlayerReadyMode)
 	{
 		switch(m_GameState)
 		{
@@ -524,7 +525,7 @@ void IGameController::SetGameState(EGameState GameState, int Timer)
 				{
 					m_GameState = GameState;
 					m_GameStateTimer = TIMER_INFINITE;
-					if(GameServer()->Config()->Values()->m_SvPlayerReadyMode)
+					if(Config()->m_SvPlayerReadyMode)
 					{
 						// run warmup till all players are ready
 						SetPlayersReadyState(false);
@@ -556,17 +557,17 @@ void IGameController::SetGameState(EGameState GameState, int Timer)
 		// only possible when game, pause or start countdown is running
 		if(m_GameState == IGS_GAME_RUNNING || m_GameState == IGS_GAME_PAUSED || m_GameState == IGS_START_COUNTDOWN)
 		{
-			if(GameServer()->Config()->Values()->m_SvCountdown == 0 && m_GameFlags&GAMEFLAG_SURVIVAL)
+			if(Config()->m_SvCountdown == 0 && m_GameFlags&GAMEFLAG_SURVIVAL)
 			{
 				m_GameState = GameState;
 				m_GameStateTimer = 3*Server()->TickSpeed();
 				GameServer()->m_World.m_Paused = true;
 
 			}
-			else if(GameServer()->Config()->Values()->m_SvCountdown > 0)
+			else if(Config()->m_SvCountdown > 0)
 			{
 				m_GameState = GameState;
-				m_GameStateTimer = GameServer()->Config()->Values()->m_SvCountdown*Server()->TickSpeed();
+				m_GameStateTimer = Config()->m_SvCountdown*Server()->TickSpeed();
 				GameServer()->m_World.m_Paused = true;
 			}
 			else
@@ -773,7 +774,7 @@ void IGameController::Tick()
 				if(m_MatchCount >= m_GameInfo.m_MatchNum-1)
 					CycleMap();
 
-				if(GameServer()->Config()->Values()->m_SvMatchSwap)
+				if(Config()->m_SvMatchSwap)
 					GameServer()->SwapTeams();
 				m_MatchCount++;
 				StartMatch();
@@ -791,7 +792,7 @@ void IGameController::Tick()
  			{
 			case IGS_WARMUP_USER:
 				// check if player ready mode was disabled and it waits that all players are ready -> end warmup
-				if(!GameServer()->Config()->Values()->m_SvPlayerReadyMode && m_GameStateTimer == TIMER_INFINITE)
+				if(!Config()->m_SvPlayerReadyMode && m_GameStateTimer == TIMER_INFINITE)
 					SetGameState(IGS_WARMUP_USER, 0);
 				else if(m_GameStateTimer == 3 * Server()->TickSpeed())
 					StartMatch();
@@ -822,7 +823,7 @@ void IGameController::Tick()
 		case TBALANCE_OK:
 			break;
 		default:
-			if(Server()->Tick() > m_UnbalancedTick+GameServer()->Config()->Values()->m_SvTeambalanceTime*Server()->TickSpeed()*60)
+			if(Server()->Tick() > m_UnbalancedTick+Config()->m_SvTeambalanceTime*Server()->TickSpeed()*60)
 				DoTeamBalance();
 		}
 	}
@@ -843,15 +844,15 @@ void IGameController::Tick()
 // info
 void IGameController::CheckGameInfo()
 {
-	int MatchNum = (str_length(GameServer()->Config()->Values()->m_SvMaprotation) && GameServer()->Config()->Values()->m_SvMatchesPerMap) ? GameServer()->Config()->Values()->m_SvMatchesPerMap : 0;
+	int MatchNum = (str_length(Config()->m_SvMaprotation) && Config()->m_SvMatchesPerMap) ? Config()->m_SvMatchesPerMap : 0;
 	if(MatchNum == 0)
 		m_MatchCount = 0;
 	bool GameInfoChanged = (m_GameInfo.m_MatchCurrent != m_MatchCount + 1) || (m_GameInfo.m_MatchNum != MatchNum) ||
-		(m_GameInfo.m_ScoreLimit != GameServer()->Config()->Values()->m_SvScorelimit) || (m_GameInfo.m_TimeLimit != GameServer()->Config()->Values()->m_SvTimelimit);
+		(m_GameInfo.m_ScoreLimit != Config()->m_SvScorelimit) || (m_GameInfo.m_TimeLimit != Config()->m_SvTimelimit);
 	m_GameInfo.m_MatchCurrent = m_MatchCount + 1;
 	m_GameInfo.m_MatchNum = MatchNum;
-	m_GameInfo.m_ScoreLimit = GameServer()->Config()->Values()->m_SvScorelimit;
-	m_GameInfo.m_TimeLimit = GameServer()->Config()->Values()->m_SvTimelimit;
+	m_GameInfo.m_ScoreLimit = Config()->m_SvScorelimit;
+	m_GameInfo.m_TimeLimit = Config()->m_SvTimelimit;
 	if(GameInfoChanged)
 		UpdateGameInfo(-1);
 }
@@ -866,7 +867,7 @@ bool IGameController::IsFriendlyFire(int ClientID1, int ClientID2) const
 		if(!GameServer()->m_apPlayers[ClientID1] || !GameServer()->m_apPlayers[ClientID2])
 			return false;
 
-		if(!GameServer()->Config()->Values()->m_SvTeamdamage && GameServer()->m_apPlayers[ClientID1]->GetTeam() == GameServer()->m_apPlayers[ClientID2]->GetTeam())
+		if(!Config()->m_SvTeamdamage && GameServer()->m_apPlayers[ClientID1]->GetTeam() == GameServer()->m_apPlayers[ClientID2]->GetTeam())
 			return true;
 	}
 
@@ -875,12 +876,12 @@ bool IGameController::IsFriendlyFire(int ClientID1, int ClientID2) const
 
 bool IGameController::IsFriendlyTeamFire(int Team1, int Team2) const
 {
-	return IsTeamplay() && !GameServer()->Config()->Values()->m_SvTeamdamage && Team1 == Team2;
+	return IsTeamplay() && !Config()->m_SvTeamdamage && Team1 == Team2;
 }
 
 bool IGameController::IsPlayerReadyMode() const
 {
-	return GameServer()->Config()->Values()->m_SvPlayerReadyMode != 0 && (m_GameStateTimer == TIMER_INFINITE && (m_GameState == IGS_WARMUP_USER || m_GameState == IGS_GAME_PAUSED));
+	return Config()->m_SvPlayerReadyMode != 0 && (m_GameStateTimer == TIMER_INFINITE && (m_GameState == IGS_WARMUP_USER || m_GameState == IGS_GAME_PAUSED));
 }
 
 bool IGameController::IsTeamChangeAllowed() const
@@ -944,17 +945,17 @@ void IGameController::CycleMap()
 		char aBuf[256];
 		str_format(aBuf, sizeof(aBuf), "rotating map to %s", m_aMapWish);
 		GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
-		str_copy(GameServer()->Config()->Values()->m_SvMap, m_aMapWish, sizeof(GameServer()->Config()->Values()->m_SvMap));
+		str_copy(Config()->m_SvMap, m_aMapWish, sizeof(Config()->m_SvMap));
 		m_aMapWish[0] = 0;
 		m_MatchCount = 0;
 		return;
 	}
-	if(!str_length(GameServer()->Config()->Values()->m_SvMaprotation))
+	if(!str_length(Config()->m_SvMaprotation))
 		return;
 
 	// handle maprotation
-	const char *pMapRotation = GameServer()->Config()->Values()->m_SvMaprotation;
-	const char *pCurrentMap = GameServer()->Config()->Values()->m_SvMap;
+	const char *pMapRotation = Config()->m_SvMaprotation;
+	const char *pCurrentMap = Config()->m_SvMap;
 
 	int CurrentMapLen = str_length(pCurrentMap);
 	const char *pNextMap = pMapRotation;
@@ -1003,7 +1004,7 @@ void IGameController::CycleMap()
 	char aBufMsg[256];
 	str_format(aBufMsg, sizeof(aBufMsg), "rotating map to %s", &aBuf[i]);
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
-	str_copy(GameServer()->Config()->Values()->m_SvMap, &aBuf[i], sizeof(GameServer()->Config()->Values()->m_SvMap));
+	str_copy(Config()->m_SvMap, &aBuf[i], sizeof(Config()->m_SvMap));
 }
 
 // spawn
@@ -1110,7 +1111,7 @@ bool IGameController::GetStartRespawnState() const
 // team
 bool IGameController::CanChangeTeam(CPlayer *pPlayer, int JoinTeam) const
 {
-	if(!IsTeamplay() || JoinTeam == TEAM_SPECTATORS || !GameServer()->Config()->Values()->m_SvTeambalanceTime)
+	if(!IsTeamplay() || JoinTeam == TEAM_SPECTATORS || !Config()->m_SvTeambalanceTime)
 		return true;
 
 	// simulate what would happen if the player changes team
@@ -1130,7 +1131,7 @@ bool IGameController::CanJoinTeam(int Team, int NotThisID) const
 
 	// check if there're enough player slots left
 	int TeamMod = GameServer()->m_apPlayers[NotThisID] && GameServer()->m_apPlayers[NotThisID]->GetTeam() != TEAM_SPECTATORS ? -1 : 0;
-	return TeamMod+m_aTeamSize[TEAM_RED]+m_aTeamSize[TEAM_BLUE] < GameServer()->Config()->Values()->m_SvPlayerSlots;
+	return TeamMod+m_aTeamSize[TEAM_RED]+m_aTeamSize[TEAM_BLUE] < Config()->m_SvPlayerSlots;
 }
 
 int IGameController::ClampTeam(int Team) const
@@ -1192,19 +1193,19 @@ void IGameController::DoTeamChange(CPlayer *pPlayer, int Team, bool DoChatMsg)
 
 int IGameController::GetStartTeam()
 {
-	if(GameServer()->Config()->Values()->m_SvTournamentMode)
+	if(Config()->m_SvTournamentMode)
 		return TEAM_SPECTATORS;
 
 	// determine new team
 	int Team = TEAM_RED;
 	if(IsTeamplay())
 	{
-		if(!GameServer()->Config()->Values()->m_DbgStress)	// this will force the auto balancer to work overtime aswell
+		if(!Config()->m_DbgStress)	// this will force the auto balancer to work overtime aswell
 			Team = m_aTeamSize[TEAM_RED] > m_aTeamSize[TEAM_BLUE] ? TEAM_BLUE : TEAM_RED;
 	}
 
 	// check if there're enough player slots left
-	if(m_aTeamSize[TEAM_RED]+m_aTeamSize[TEAM_BLUE] < GameServer()->Config()->Values()->m_SvPlayerSlots)
+	if(m_aTeamSize[TEAM_RED]+m_aTeamSize[TEAM_BLUE] < Config()->m_SvPlayerSlots)
 	{
 		++m_aTeamSize[Team];
 		m_UnbalancedTick = TBALANCE_CHECK;

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -16,6 +16,7 @@
 class IGameController
 {
 	class CGameContext *m_pGameServer;
+	class CConfig *m_pConfig;
 	class IServer *m_pServer;
 
 	// activity
@@ -95,6 +96,7 @@ class IGameController
 
 protected:
 	CGameContext *GameServer() const { return m_pGameServer; }
+	CConfig *Config() const { return m_pConfig; }
 	IServer *Server() const { return m_pServer; }
 
 	// game

--- a/src/game/server/gamemodes/tdm.cpp
+++ b/src/game/server/gamemodes/tdm.cpp
@@ -28,7 +28,7 @@ int CGameControllerTDM::OnCharacterDeath(class CCharacter *pVictim, class CPlaye
 			m_aTeamscore[pKiller->GetTeam()&1]++; // good shit
 	}
 
-	pVictim->GetPlayer()->m_RespawnTick = max(pVictim->GetPlayer()->m_RespawnTick, Server()->Tick()+Server()->TickSpeed()*GameServer()->Config()->Values()->m_SvRespawnDelayTDM);
+	pVictim->GetPlayer()->m_RespawnTick = max(pVictim->GetPlayer()->m_RespawnTick, Server()->Tick()+Server()->TickSpeed()*GameServer()->Config()->m_SvRespawnDelayTDM);
 
 	return 0;
 }

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -14,6 +14,7 @@
 CGameWorld::CGameWorld()
 {
 	m_pGameServer = 0x0;
+	m_pConfig = 0x0;
 	m_pServer = 0x0;
 
 	m_Paused = false;
@@ -33,6 +34,7 @@ CGameWorld::~CGameWorld()
 void CGameWorld::SetGameServer(CGameContext *pGameServer)
 {
 	m_pGameServer = pGameServer;
+	m_pConfig = m_pGameServer->Config();
 	m_pServer = m_pGameServer->Server();
 }
 

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -34,10 +34,12 @@ private:
 	CEntity *m_apFirstEntityTypes[NUM_ENTTYPES];
 
 	class CGameContext *m_pGameServer;
+	class CConfig *m_pConfig;
 	class IServer *m_pServer;
 
 public:
 	class CGameContext *GameServer() { return m_pGameServer; }
+	class CConfig *Config() { return m_pConfig; }
 	class IServer *Server() { return m_pServer; }
 
 	bool m_ResetRequested;

--- a/src/mastersrv/mastersrv.cpp
+++ b/src/mastersrv/mastersrv.cpp
@@ -294,25 +294,26 @@ int main(int argc, const char **argv) // ignore_convention
 	int FlagMask = CFGFLAG_MASTER;
 	IKernel *pKernel = IKernel::Create();
 	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
-	IConfig *pConfig = CreateConfig();
+	IConfigManager *pConfigManager = CreateConfigManager();
+	CConfig *pConfig = pConfigManager->Values();
 	m_pConsole = CreateConsole(FlagMask);
 
 	CNetBase::Init(pConfig);
 	
 	bool RegisterFail = !pKernel->RegisterInterface(pStorage);
 	RegisterFail |= !pKernel->RegisterInterface(m_pConsole);
-	RegisterFail |= !pKernel->RegisterInterface(pConfig);
+	RegisterFail |= !pKernel->RegisterInterface(pConfigManager);
 
 	if(RegisterFail)
 		return -1;
 
-	pConfig->Init(FlagMask);
+	pConfigManager->Init(FlagMask);
 	m_pConsole->Init();
 	m_NetBan.Init(m_pConsole, pStorage);
 	if(argc > 1) // ignore_convention
 		m_pConsole->ParseArguments(argc-1, &argv[1]); // ignore_convention
 
-	if(pConfig->Values()->m_Bindaddr[0] && net_host_lookup(pConfig->Values()->m_Bindaddr, &BindAddr, NETTYPE_ALL) == 0)
+	if(pConfig->m_Bindaddr[0] && net_host_lookup(pConfig->m_Bindaddr, &BindAddr, NETTYPE_ALL) == 0)
 	{
 		// got bindaddr
 		BindAddr.type = NETTYPE_ALL;

--- a/src/versionsrv/versionsrv.cpp
+++ b/src/versionsrv/versionsrv.cpp
@@ -89,18 +89,18 @@ int main(int argc, const char **argv) // ignore_convention
 	int FlagMask = 0;
 	IKernel *pKernel = IKernel::Create();
 	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
-	IConfig *pConfig = CreateConfig();
+	IConfigManager *pConfigManager = CreateConfigManager();
 	IConsole *pConsole = CreateConsole(FlagMask);
 
-	CNetBase::Init(pConfig);
+	CNetBase::Init(pConfigManager->Values());
 
 	bool RegisterFail = !pKernel->RegisterInterface(pStorage);
 	RegisterFail |= !pKernel->RegisterInterface(pConsole);
-	RegisterFail |= !pKernel->RegisterInterface(pConfig);
+	RegisterFail |= !pKernel->RegisterInterface(pConfigManager);
 
 	if(RegisterFail)
 		return -1;
-	pConfig->Init(FlagMask);
+	pConfigManager->Init(FlagMask);
 	pConsole->Init();
 
 	mem_zero(&BindAddr, sizeof(BindAddr));


### PR DESCRIPTION
Rename `CConfiguration` to `CConfig`, `CConfig` to `CConfigManager` and
expose the actual config variables to more modules directly.