### PR TITLE
Fix implicit declaration of functions _stricmp and _strnicmp

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2087,7 +2087,7 @@ char *str_skip_whitespaces(char *str)
 /* case */
 int str_comp_nocase(const char *a, const char *b)
 {
-#if defined(CONF_FAMILY_WINDOWS)
+#if defined(CONF_FAMILY_WINDOWS) && !defined(__GNUC__)
 	return _stricmp(a,b);
 #else
 	return strcasecmp(a,b);
@@ -2096,7 +2096,7 @@ int str_comp_nocase(const char *a, const char *b)
 
 int str_comp_nocase_num(const char *a, const char *b, const int num)
 {
-#if defined(CONF_FAMILY_WINDOWS)
+#if defined(CONF_FAMILY_WINDOWS) && !defined(__GNUC__)
 	return _strnicmp(a, b, num);
 #else
 	return strncasecmp(a, b, num);


### PR DESCRIPTION
Fixes these warnings on Windows 10 w/ MinGW:
```
src/base/system.c: In function 'str_comp_nocase':
src/base/system.c:2091:9: warning: implicit declaration of function '_stricmp' [-Wimplicit-function-declaration]
  return _stricmp(a,b);
         ^
src/base/system.c: In function 'str_comp_nocase_num':
src/base/system.c:2100:9: warning: implicit declaration of function '_strnicmp' [-Wimplicit-function-declaration]
  return _strnicmp(a, b, num);
         ^
```
