### PR TITLE
Fix seekbar not working at edges, pause while seeking, various code style fixes

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2617,6 +2617,14 @@ unsigned bytes_be_to_uint(const unsigned char *bytes)
 	return (bytes[0]<<24) | (bytes[1]<<16) | (bytes[2]<<8) | bytes[3];
 }
 
+void uint_to_bytes_be(unsigned char *bytes, unsigned value)
+{
+	bytes[0] = (value>>24)&0xff;
+	bytes[1] = (value>>16)&0xff;
+	bytes[2] = (value>>8)&0xff;
+	bytes[3] = value&0xff;
+}
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1666,6 +1666,16 @@ int pid();
 */
 unsigned bytes_be_to_uint(const unsigned char *bytes);
 
+/*
+	Function: uint_to_bytes_be
+		Packs an unsigned into 4 big endian bytes
+
+	Remarks:
+		- Assumes the passed array is 4 bytes
+		- Assumes unsigned is 4 bytes
+*/
+void uint_to_bytes_be(unsigned char *bytes, unsigned value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2289,7 +2289,7 @@ const char *CClient::DemoPlayer_Play(const char *pFilename, int StorageType)
 	m_NetClient.ResetErrorString();
 
 	// try to start playback
-	m_DemoPlayer.SetListner(this);
+	m_DemoPlayer.SetListener(this);
 
 	const char *pError = m_DemoPlayer.Load(Storage(), m_pConsole, pFilename, StorageType, GameClient()->NetVersion());
 	if(pError)

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -52,7 +52,7 @@ public:
 };
 
 
-class CClient : public IClient, public CDemoPlayer::IListner
+class CClient : public IClient, public CDemoPlayer::IListener
 {
 	// needed interfaces
 	IEngine *m_pEngine;

--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -19,10 +19,10 @@ struct CDemoHeader
 	unsigned char m_aMapSize[4];
 	unsigned char m_aMapCrc[4];
 	char m_aType[8];
-	char m_aLength[4];
+	unsigned char m_aLength[4];
 	char m_aTimestamp[20];
-	char m_aNumTimelineMarkers[4];
-	char m_aTimelineMarkers[MAX_TIMELINE_MARKERS][4];
+	unsigned char m_aNumTimelineMarkers[4];
+	unsigned char m_aTimelineMarkers[MAX_TIMELINE_MARKERS][4];
 };
 
 class IDemoPlayer : public IInterface

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -18,6 +18,18 @@ static const unsigned char gs_ActVersion = 4;
 static const int gs_LengthOffset = 152;
 static const int gs_NumMarkersOffset = 176;
 
+static inline void EncodeUnsigned(unsigned char *pOut, unsigned Value)
+{
+	pOut[0] = (Value>>24)&0xff;
+	pOut[1] = (Value>>16)&0xff;
+	pOut[2] = (Value>>8)&0xff;
+	pOut[3] = Value&0xff;
+}
+
+static inline unsigned DecodeUnsigned(const unsigned char *pIn)
+{
+	return ((pIn[0]<<24)&0xFF000000) | ((pIn[1]<<16)&0xFF0000) | ((pIn[2]<<8)&0xFF00) | (pIn[3]&0xFF);
+}
 
 CDemoRecorder::CDemoRecorder(class CSnapshotDelta *pSnapshotDelta)
 {
@@ -89,14 +101,8 @@ int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, con
 	str_copy(Header.m_aNetversion, pNetVersion, sizeof(Header.m_aNetversion));
 	str_copy(Header.m_aMapName, pMap, sizeof(Header.m_aMapName));
 	unsigned MapSize = io_length(MapFile);
-	Header.m_aMapSize[0] = (MapSize>>24)&0xff;
-	Header.m_aMapSize[1] = (MapSize>>16)&0xff;
-	Header.m_aMapSize[2] = (MapSize>>8)&0xff;
-	Header.m_aMapSize[3] = (MapSize)&0xff;
-	Header.m_aMapCrc[0] = (Crc>>24)&0xff;
-	Header.m_aMapCrc[1] = (Crc>>16)&0xff;
-	Header.m_aMapCrc[2] = (Crc>>8)&0xff;
-	Header.m_aMapCrc[3] = (Crc)&0xff;
+	EncodeUnsigned(Header.m_aMapSize, MapSize);
+	EncodeUnsigned(Header.m_aMapCrc, Crc);
 	str_copy(Header.m_aType, pType, sizeof(Header.m_aType));
 	// Header.m_Length - add this on stop
 	str_timestamp(Header.m_aTimestamp, sizeof(Header.m_aTimestamp));
@@ -105,9 +111,9 @@ int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, con
 	io_write(DemoFile, &Header, sizeof(Header));
 
 	// write map data
+	unsigned char aChunk[1024*64];
 	while(1)
 	{
-		unsigned char aChunk[1024*64];
 		int Bytes = io_read(MapFile, &aChunk, sizeof(aChunk));
 		if(Bytes <= 0)
 			break;
@@ -162,10 +168,7 @@ void CDemoRecorder::WriteTickMarker(int Tick, int Keyframe)
 	{
 		unsigned char aChunk[5];
 		aChunk[0] = CHUNKTYPEFLAG_TICKMARKER;
-		aChunk[1] = (Tick>>24)&0xff;
-		aChunk[2] = (Tick>>16)&0xff;
-		aChunk[3] = (Tick>>8)&0xff;
-		aChunk[4] = (Tick)&0xff;
+		EncodeUnsigned(aChunk+1, Tick);
 
 		if(Keyframe)
 			aChunk[0] |= CHUNKTICKFLAG_KEYFRAME;
@@ -186,12 +189,11 @@ void CDemoRecorder::WriteTickMarker(int Tick, int Keyframe)
 
 void CDemoRecorder::Write(int Type, const void *pData, int Size)
 {
-	char aBuffer[64*1024];
-	char aBuffer2[64*1024];
-	unsigned char aChunk[3];
-
 	if(!m_File)
 		return;
+
+	char aBuffer[64*1024];
+	char aBuffer2[64*1024];
 
 	/* pad the data with 0 so we get an alignment of 4,
 	else the compression won't work and miss some bytes */
@@ -211,6 +213,7 @@ void CDemoRecorder::Write(int Type, const void *pData, int Size)
 		return;
 	}
 
+	unsigned char aChunk[3];
 	aChunk[0] = ((Type&0x3)<<5);
 	if(Size < 30)
 	{
@@ -281,30 +284,19 @@ int CDemoRecorder::Stop()
 
 	// add the demo length to the header
 	io_seek(m_File, gs_LengthOffset, IOSEEK_START);
-	int DemoLength = Length();
-	char aLength[4];
-	aLength[0] = (DemoLength>>24)&0xff;
-	aLength[1] = (DemoLength>>16)&0xff;
-	aLength[2] = (DemoLength>>8)&0xff;
-	aLength[3] = (DemoLength)&0xff;
+	unsigned char aLength[4];
+	EncodeUnsigned(aLength, Length());
 	io_write(m_File, aLength, sizeof(aLength));
 
 	// add the timeline markers to the header
 	io_seek(m_File, gs_NumMarkersOffset, IOSEEK_START);
-	char aNumMarkers[4];
-	aNumMarkers[0] = (m_NumTimelineMarkers>>24)&0xff;
-	aNumMarkers[1] = (m_NumTimelineMarkers>>16)&0xff;
-	aNumMarkers[2] = (m_NumTimelineMarkers>>8)&0xff;
-	aNumMarkers[3] = (m_NumTimelineMarkers)&0xff;
+	unsigned char aNumMarkers[4];
+	EncodeUnsigned(aNumMarkers, m_NumTimelineMarkers);
 	io_write(m_File, aNumMarkers, sizeof(aNumMarkers));
 	for(int i = 0; i < m_NumTimelineMarkers; i++)
 	{
-		int Marker = m_aTimelineMarkers[i];
-		char aMarker[4];
-		aMarker[0] = (Marker>>24)&0xff;
-		aMarker[1] = (Marker>>16)&0xff;
-		aMarker[2] = (Marker>>8)&0xff;
-		aMarker[3] = (Marker)&0xff;
+		unsigned char aMarker[4];
+		EncodeUnsigned(aMarker, m_aTimelineMarkers[i]);
 		io_write(m_File, aMarker, sizeof(aMarker));
 	}
 
@@ -346,9 +338,9 @@ CDemoPlayer::CDemoPlayer(class CSnapshotDelta *pSnapshotDelta)
 	m_LastSnapshotDataSize = -1;
 }
 
-void CDemoPlayer::SetListner(IListner *pListner)
+void CDemoPlayer::SetListener(IListener *pListener)
 {
-	m_pListner = pListner;
+	m_pListener = pListener;
 }
 
 
@@ -370,16 +362,15 @@ int CDemoPlayer::ReadChunkHeader(int *pType, int *pSize, int *pTick)
 
 		if(Tickdelta == 0)
 		{
-			unsigned char aTickdata[4];
-			if(io_read(m_File, aTickdata, sizeof(aTickdata)) != sizeof(aTickdata))
+			unsigned char aTickData[4];
+			if(io_read(m_File, aTickData, sizeof(aTickData)) != sizeof(aTickData))
 				return -1;
-			*pTick = (aTickdata[0]<<24) | (aTickdata[1]<<16) | (aTickdata[2]<<8) | aTickdata[3];
+			*pTick = DecodeUnsigned(aTickData);
 		}
 		else
 		{
 			*pTick += Tickdelta;
 		}
-
 	}
 	else
 	{
@@ -389,18 +380,17 @@ int CDemoPlayer::ReadChunkHeader(int *pType, int *pSize, int *pTick)
 
 		if(*pSize == 30)
 		{
-			unsigned char aSizedata[1];
-			if(io_read(m_File, aSizedata, sizeof(aSizedata)) != sizeof(aSizedata))
+			unsigned char aSizeData[1];
+			if(io_read(m_File, aSizeData, sizeof(aSizeData)) != sizeof(aSizeData))
 				return -1;
-			*pSize = aSizedata[0];
-
+			*pSize = aSizeData[0];
 		}
 		else if(*pSize == 31)
 		{
-			unsigned char aSizedata[2];
-			if(io_read(m_File, aSizedata, sizeof(aSizedata)) != sizeof(aSizedata))
+			unsigned char aSizeData[2];
+			if(io_read(m_File, aSizeData, sizeof(aSizeData)) != sizeof(aSizeData))
 				return -1;
-			*pSize = (aSizedata[1]<<8) | aSizedata[0];
+			*pSize = (aSizeData[1]<<8) | aSizeData[0];
 		}
 	}
 
@@ -409,21 +399,19 @@ int CDemoPlayer::ReadChunkHeader(int *pType, int *pSize, int *pTick)
 
 void CDemoPlayer::ScanFile()
 {
-	long StartPos;
 	CHeap Heap;
 	CKeyFrameSearch *pFirstKey = 0;
 	CKeyFrameSearch *pCurrentKey = 0;
-	//DEMOREC_CHUNK chunk;
-	int ChunkSize, ChunkType, ChunkTick = 0;
-	int i;
+	int ChunkTick = 0;
 
-	StartPos = io_tell(m_File);
+	long StartPos = io_tell(m_File);
 	m_Info.m_SeekablePoints = 0;
 
 	while(1)
 	{
 		long CurrentPos = io_tell(m_File);
 
+		int ChunkSize, ChunkType;
 		if(ReadChunkHeader(&ChunkType, &ChunkSize, &ChunkTick))
 			break;
 
@@ -432,10 +420,8 @@ void CDemoPlayer::ScanFile()
 		{
 			if(ChunkType&CHUNKTICKFLAG_KEYFRAME)
 			{
-				CKeyFrameSearch *pKey;
-
 				// save the position
-				pKey = (CKeyFrameSearch *)Heap.Allocate(sizeof(CKeyFrameSearch));
+				CKeyFrameSearch *pKey = (CKeyFrameSearch *)Heap.Allocate(sizeof(CKeyFrameSearch));
 				pKey->m_Frame.m_Filepos = CurrentPos;
 				pKey->m_Frame.m_Tick = ChunkTick;
 				pKey->m_pNext = 0;
@@ -453,10 +439,10 @@ void CDemoPlayer::ScanFile()
 		}
 		else if(ChunkSize)
 			io_skip(m_File, ChunkSize);
-
 	}
 
 	// copy all the frames to an array instead for fast access
+	int i;
 	m_pKeyFrames = (CKeyFrame*)mem_alloc(m_Info.m_SeekablePoints*sizeof(CKeyFrame), 1);
 	for(pCurrentKey = pFirstKey, i = 0; pCurrentKey; pCurrentKey = pCurrentKey->m_pNext, i++)
 		m_pKeyFrames[i] = pCurrentKey->m_Frame;
@@ -467,22 +453,21 @@ void CDemoPlayer::ScanFile()
 
 void CDemoPlayer::DoTick()
 {
-	static char aCompresseddata[CSnapshot::MAX_SIZE];
+	static char aCompressedData[CSnapshot::MAX_SIZE];
 	static char aDecompressed[CSnapshot::MAX_SIZE];
 	static char aData[CSnapshot::MAX_SIZE];
-	static char aNewsnap[CSnapshot::MAX_SIZE];
-	int ChunkType, ChunkTick, ChunkSize;
-	int DataSize = 0;
-	int GotSnapshot = 0;
+	static char aNewSnap[CSnapshot::MAX_SIZE];
+	bool GotSnapshot = false;
 
 	// update ticks
 	m_Info.m_PreviousTick = m_Info.m_Info.m_CurrentTick;
 	m_Info.m_Info.m_CurrentTick = m_Info.m_NextTick;
-	ChunkTick = m_Info.m_Info.m_CurrentTick;
+	int ChunkTick = m_Info.m_Info.m_CurrentTick;
 
 	while(1)
 	{
-		DataSize = 0;
+		int DataSize = 0;
+		int ChunkType, ChunkSize;
 		if(ReadChunkHeader(&ChunkType, &ChunkSize, &ChunkTick))
 		{
 			// stop on error or eof
@@ -500,7 +485,7 @@ void CDemoPlayer::DoTick()
 		// read the chunk
 		if(ChunkSize)
 		{
-			if(io_read(m_File, aCompresseddata, ChunkSize) != (unsigned)ChunkSize)
+			if(io_read(m_File, aCompressedData, ChunkSize) != (unsigned)ChunkSize)
 			{
 				// stop on error or eof
 				m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "demo_player", "error reading chunk");
@@ -508,7 +493,7 @@ void CDemoPlayer::DoTick()
 				break;
 			}
 
-			DataSize = m_Huffman.Decompress(aCompresseddata, ChunkSize, aDecompressed, sizeof(aDecompressed));
+			DataSize = m_Huffman.Decompress(aCompressedData, ChunkSize, aDecompressed, sizeof(aDecompressed));
 			if(DataSize < 0)
 			{
 				// stop on error or eof
@@ -518,7 +503,6 @@ void CDemoPlayer::DoTick()
 			}
 
 			DataSize = CVariableInt::Decompress(aDecompressed, DataSize, aData, sizeof(aData));
-
 			if(DataSize < 0)
 			{
 				m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "demo_player", "error during intpack decompression");
@@ -530,25 +514,24 @@ void CDemoPlayer::DoTick()
 		if(ChunkType == CHUNKTYPE_DELTA)
 		{
 			// process delta snapshot
-			GotSnapshot = 1;
+			GotSnapshot = true;
 
 			// only unpack the delta if we have a valid snapshot
 			if(m_LastSnapshotDataSize == -1)
 				continue;
 
-			DataSize = m_pSnapshotDelta->UnpackDelta((CSnapshot*)m_aLastSnapshotData, (CSnapshot*)aNewsnap, aData, DataSize);
-
+			DataSize = m_pSnapshotDelta->UnpackDelta((CSnapshot*)m_aLastSnapshotData, (CSnapshot*)aNewSnap, aData, DataSize);
 			if(DataSize >= 0)
 			{
-				if(m_pListner)
-					m_pListner->OnDemoPlayerSnapshot(aNewsnap, DataSize);
+				if(m_pListener)
+					m_pListener->OnDemoPlayerSnapshot(aNewSnap, DataSize);
 
 				m_LastSnapshotDataSize = DataSize;
-				mem_copy(m_aLastSnapshotData, aNewsnap, DataSize);
+				mem_copy(m_aLastSnapshotData, aNewSnap, DataSize);
 			}
 			else
 			{
-				char aBuf[256];
+				char aBuf[64];
 				str_format(aBuf, sizeof(aBuf), "error during unpacking of delta, err=%d", DataSize);
 				m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "demo_player", aBuf);
 			}
@@ -557,23 +540,23 @@ void CDemoPlayer::DoTick()
 		{
 			// process full snapshot
 			CSnapshotBuilder Builder;
-			GotSnapshot = 1;
+			GotSnapshot = true;
 
 			if(Builder.UnserializeSnap(aData, DataSize))
-				DataSize = Builder.Finish(aNewsnap);
+				DataSize = Builder.Finish(aNewSnap);
 			else
 				DataSize = -1;
-			
+
 			if(DataSize >= 0)
 			{
 				m_LastSnapshotDataSize = DataSize;
-				mem_copy(m_aLastSnapshotData, aNewsnap, DataSize);
-				if(m_pListner)
-					m_pListner->OnDemoPlayerSnapshot(aNewsnap, DataSize);
+				mem_copy(m_aLastSnapshotData, aNewSnap, DataSize);
+				if(m_pListener)
+					m_pListener->OnDemoPlayerSnapshot(aNewSnap, DataSize);
 			}
 			else
 			{
-				char aBuf[256];
+				char aBuf[64];
 				str_format(aBuf, sizeof(aBuf), "error during unpacking of snapshot, err=%d", DataSize);
 				m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "demo_player", aBuf);
 			}
@@ -581,10 +564,10 @@ void CDemoPlayer::DoTick()
 		else
 		{
 			// if there were no snapshots in this tick, replay the last one
-			if(!GotSnapshot && m_pListner && m_LastSnapshotDataSize != -1)
+			if(!GotSnapshot && m_pListener && m_LastSnapshotDataSize != -1)
 			{
-				GotSnapshot = 1;
-				m_pListner->OnDemoPlayerSnapshot(m_aLastSnapshotData, m_LastSnapshotDataSize);
+				GotSnapshot = true;
+				m_pListener->OnDemoPlayerSnapshot(m_aLastSnapshotData, m_LastSnapshotDataSize);
 			}
 
 			// check the remaining types
@@ -595,8 +578,8 @@ void CDemoPlayer::DoTick()
 			}
 			else if(ChunkType == CHUNKTYPE_MESSAGE)
 			{
-				if(m_pListner)
-					m_pListner->OnDemoPlayerMessage(aData, DataSize);
+				if(m_pListener)
+					m_pListener->OnDemoPlayerMessage(aData, DataSize);
 			}
 		}
 	}
@@ -604,17 +587,12 @@ void CDemoPlayer::DoTick()
 
 void CDemoPlayer::Pause()
 {
-	m_Info.m_Info.m_Paused = 1;
+	m_Info.m_Info.m_Paused = true;
 }
 
 void CDemoPlayer::Unpause()
 {
-	if(m_Info.m_Info.m_Paused)
-	{
-		/*m_Info.start_tick = m_Info.current_tick;
-		m_Info.start_time = time_get();*/
-		m_Info.m_Info.m_Paused = 0;
-	}
+	m_Info.m_Info.m_Paused = false;
 }
 
 const char *CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, int StorageType, const char *pNetversion)
@@ -654,7 +632,7 @@ const char *CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole
 		return m_aErrorMsg;
 	}
 
-	if(m_Info.m_Header.m_Version < gs_ActVersion)
+	if(m_Info.m_Header.m_Version != gs_ActVersion)
 	{
 		str_format(m_aErrorMsg, sizeof(m_aErrorMsg), "demo version %d is not supported", m_Info.m_Header.m_Version);
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "demo_player", m_aErrorMsg);
@@ -681,11 +659,11 @@ const char *CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole
 		m_DemoType = DEMOTYPE_INVALID;
 
 	// read map
-	unsigned MapSize = (m_Info.m_Header.m_aMapSize[0]<<24) | (m_Info.m_Header.m_aMapSize[1]<<16) | (m_Info.m_Header.m_aMapSize[2]<<8) | (m_Info.m_Header.m_aMapSize[3]);
+	unsigned MapSize = DecodeUnsigned(m_Info.m_Header.m_aMapSize);
 
 	// check if we already have the map
 	// TODO: improve map checking (maps folder, check crc)
-	unsigned Crc = (m_Info.m_Header.m_aMapCrc[0]<<24) | (m_Info.m_Header.m_aMapCrc[1]<<16) | (m_Info.m_Header.m_aMapCrc[2]<<8) | (m_Info.m_Header.m_aMapCrc[3]);
+	unsigned Crc = DecodeUnsigned(m_Info.m_Header.m_aMapCrc);
 	char aMapFilename[128];
 	str_format(aMapFilename, sizeof(aMapFilename), "downloadedmaps/%s_%08x.map", m_Info.m_Header.m_aMapName, Crc);
 	IOHANDLE MapFile = pStorage->OpenFile(aMapFilename, IOFLAG_READ, IStorage::TYPE_ALL);
@@ -711,17 +689,13 @@ const char *CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole
 	}
 
 	// get timeline markers
-	int Num = ((m_Info.m_Header.m_aNumTimelineMarkers[0]<<24)&0xFF000000) | ((m_Info.m_Header.m_aNumTimelineMarkers[1]<<16)&0xFF0000) |
-				((m_Info.m_Header.m_aNumTimelineMarkers[2]<<8)&0xFF00) | (m_Info.m_Header.m_aNumTimelineMarkers[3]&0xFF);
-	m_Info.m_Info.m_NumTimelineMarkers = min(Num, int(MAX_TIMELINE_MARKERS));
+	m_Info.m_Info.m_NumTimelineMarkers = min(DecodeUnsigned(m_Info.m_Header.m_aNumTimelineMarkers), unsigned(MAX_TIMELINE_MARKERS));
 	for(int i = 0; i < m_Info.m_Info.m_NumTimelineMarkers; i++)
 	{
-		char *pTimelineMarker = m_Info.m_Header.m_aTimelineMarkers[i];
-		m_Info.m_Info.m_aTimelineMarkers[i] = ((pTimelineMarker[0]<<24)&0xFF000000) | ((pTimelineMarker[1]<<16)&0xFF0000) |
-												((pTimelineMarker[2]<<8)&0xFF00) | (pTimelineMarker[3]&0xFF);
+		m_Info.m_Info.m_aTimelineMarkers[i] = DecodeUnsigned(m_Info.m_Header.m_aTimelineMarkers[i]);
 	}
 
-	// scan the file for interessting points
+	// scan the file for interesting points
 	ScanFile();
 
 	// ready for playback
@@ -741,8 +715,6 @@ int CDemoPlayer::Play()
 		DoTick();
 
 	// set start info
-	/*m_Info.start_tick = m_Info.previous_tick;
-	m_Info.start_time = time_get();*/
 	m_Info.m_CurrentTime = m_Info.m_PreviousTick*time_freq()/SERVER_TICK_SPEED;
 	m_Info.m_LastUpdate = time_get();
 	return 0;
@@ -750,18 +722,13 @@ int CDemoPlayer::Play()
 
 int CDemoPlayer::SetPos(float Percent)
 {
-	int Keyframe;
-	int WantedTick;
 	if(!m_File)
 		return -1;
 
 	// -5 because we have to have a current tick and previous tick when we do the playback
-	WantedTick = m_Info.m_Info.m_FirstTick + (int)((m_Info.m_Info.m_LastTick-m_Info.m_Info.m_FirstTick)*Percent) - 5;
+	int WantedTick = m_Info.m_Info.m_FirstTick + (int)((m_Info.m_Info.m_LastTick-m_Info.m_Info.m_FirstTick)*Percent) - 5;
 
-	Keyframe = (int)(m_Info.m_SeekablePoints*Percent);
-
-	if(Keyframe < 0 || Keyframe >= m_Info.m_SeekablePoints)
-		return -1;
+	int Keyframe = clamp((int)(m_Info.m_SeekablePoints*Percent), 0, m_Info.m_SeekablePoints-1);
 
 	// get correct key frame
 	if(m_pKeyFrames[Keyframe].m_Tick < WantedTick)
@@ -774,7 +741,6 @@ int CDemoPlayer::SetPos(float Percent)
 	// seek to the correct keyframe
 	io_seek(m_File, m_pKeyFrames[Keyframe].m_Filepos, IOSEEK_START);
 
-	//m_Info.start_tick = -1;
 	m_Info.m_NextTick = -1;
 	m_Info.m_Info.m_CurrentTick = -1;
 	m_Info.m_PreviousTick = -1;
@@ -799,49 +765,42 @@ int CDemoPlayer::Update()
 	int64 Deltatime = Now-m_Info.m_LastUpdate;
 	m_Info.m_LastUpdate = Now;
 
-	if(!IsPlaying())
+	if(!IsPlaying() || m_Info.m_Info.m_Paused)
 		return 0;
 
-	if(m_Info.m_Info.m_Paused)
-	{
+	int64 Freq = time_freq();
+	m_Info.m_CurrentTime += (int64)(Deltatime*(double)m_Info.m_Info.m_Speed);
 
+	while(1)
+	{
+		int64 CurtickStart = (m_Info.m_Info.m_CurrentTick)*Freq/SERVER_TICK_SPEED;
+
+		// break if we are ready
+		if(CurtickStart > m_Info.m_CurrentTime)
+			break;
+
+		// do one more tick
+		DoTick();
+
+		if(m_Info.m_Info.m_Paused)
+			return 0;
 	}
-	else
+
+	// update intratick
 	{
-		int64 Freq = time_freq();
-		m_Info.m_CurrentTime += (int64)(Deltatime*(double)m_Info.m_Info.m_Speed);
+		int64 CurtickStart = (m_Info.m_Info.m_CurrentTick)*Freq/SERVER_TICK_SPEED;
+		int64 PrevtickStart = (m_Info.m_PreviousTick)*Freq/SERVER_TICK_SPEED;
+		m_Info.m_IntraTick = (m_Info.m_CurrentTime - PrevtickStart) / (float)(CurtickStart-PrevtickStart);
+		m_Info.m_TickTime = (m_Info.m_CurrentTime - PrevtickStart) / (float)Freq;
+	}
 
-		while(1)
-		{
-			int64 CurtickStart = (m_Info.m_Info.m_CurrentTick)*Freq/SERVER_TICK_SPEED;
-
-			// break if we are ready
-			if(CurtickStart > m_Info.m_CurrentTime)
-				break;
-
-			// do one more tick
-			DoTick();
-
-			if(m_Info.m_Info.m_Paused)
-				return 0;
-		}
-
-		// update intratick
-		{
-			int64 CurtickStart = (m_Info.m_Info.m_CurrentTick)*Freq/SERVER_TICK_SPEED;
-			int64 PrevtickStart = (m_Info.m_PreviousTick)*Freq/SERVER_TICK_SPEED;
-			m_Info.m_IntraTick = (m_Info.m_CurrentTime - PrevtickStart) / (float)(CurtickStart-PrevtickStart);
-			m_Info.m_TickTime = (m_Info.m_CurrentTime - PrevtickStart) / (float)Freq;
-		}
-
-		if(m_Info.m_Info.m_CurrentTick == m_Info.m_PreviousTick ||
-			m_Info.m_Info.m_CurrentTick == m_Info.m_NextTick)
-		{
-			char aBuf[256];
-			str_format(aBuf, sizeof(aBuf), "tick error prev=%d cur=%d next=%d",
-				m_Info.m_PreviousTick, m_Info.m_Info.m_CurrentTick, m_Info.m_NextTick);
-			m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "demo_player", aBuf);
-		}
+	if(m_Info.m_Info.m_CurrentTick == m_Info.m_PreviousTick ||
+		m_Info.m_Info.m_CurrentTick == m_Info.m_NextTick)
+	{
+		char aBuf[128];
+		str_format(aBuf, sizeof(aBuf), "tick error prev=%d cur=%d next=%d",
+			m_Info.m_PreviousTick, m_Info.m_Info.m_CurrentTick, m_Info.m_NextTick);
+		m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "demo_player", aBuf);
 	}
 
 	return 0;
@@ -857,7 +816,7 @@ int CDemoPlayer::Stop()
 	m_File = 0;
 	mem_free(m_pKeyFrames);
 	m_pKeyFrames = 0;
-	str_copy(m_aFilename, "", sizeof(m_aFilename));
+	m_aFilename[0] = '\0';
 	return 0;
 }
 
@@ -890,14 +849,9 @@ bool CDemoPlayer::GetDemoInfo(class IStorage *pStorage, const char *pFilename, i
 		return false;
 
 	io_read(File, pDemoHeader, sizeof(CDemoHeader));
-	if(mem_comp(pDemoHeader->m_aMarker, gs_aHeaderMarker, sizeof(gs_aHeaderMarker)) || pDemoHeader->m_Version < gs_ActVersion)
-	{
-		io_close(File);
-		return false;
-	}
-
+	bool Valid = mem_comp(pDemoHeader->m_aMarker, gs_aHeaderMarker, sizeof(gs_aHeaderMarker)) == 0 && pDemoHeader->m_Version == gs_ActVersion;
 	io_close(File);
-	return true;
+	return Valid;
 }
 
 int CDemoPlayer::GetDemoType() const

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -42,10 +42,10 @@ public:
 class CDemoPlayer : public IDemoPlayer
 {
 public:
-	class IListner
+	class IListener
 	{
 	public:
-		virtual ~IListner() {}
+		virtual ~IListener() {}
 		virtual void OnDemoPlayerSnapshot(void *pData, int Size) = 0;
 		virtual void OnDemoPlayerMessage(void *pData, int Size) = 0;
 	};
@@ -69,7 +69,7 @@ public:
 	};
 
 private:
-	IListner *m_pListner;
+	IListener *m_pListener;
 
 
 	// Playback
@@ -107,7 +107,7 @@ public:
 
 	CDemoPlayer(class CSnapshotDelta *m_pSnapshotDelta);
 
-	void SetListner(IListner *pListner);
+	void SetListener(IListener *pListner);
 
 	const char *Load(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, int StorageType, const char *pNetversion);
 	int Play();


### PR DESCRIPTION
- Seekbar scrolling was not taking into account the rounding correctly. Now it should be possible to scroll all the way to 0:00 and the max time.
- Pause playback while scrolling and holding on seekbar, restore previous pause state after release. 
- Fix clicking on same seekbar position multiple times not working.
- Extract integer serialization into EncodeUnsigned/DecodeUnsigned. Change the type to unsigned char for all encoded fields.
- Reorder some declarations and logic.
  - Changes the demo version logic to exclude every version not equal to gs_ActVersion, instead of only rejecting lower demo versions. Should be fine in my opinion, as a future demo version would most likely not be compatible with older clients anyway.
- Fix spelling.