### PR TITLE
Improve client loading and progress reporting, refactoring, fix menus music (closes #2460)

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -152,8 +152,6 @@ public:
 	virtual bool ConnectionProblems() const = 0;
 
 	virtual bool SoundInitFailed() const = 0;
-
-	virtual IGraphics::CTextureHandle GetDebugFont() const = 0; // TODO: remove this function
 };
 
 class IGameClient : public IInterface

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -646,7 +646,7 @@ void CCommandProcessor_SDL_OpenGL::RunBuffer(CCommandBuffer *pBuffer)
 
 // ------------ CGraphicsBackend_SDL_OpenGL
 
-int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *Screen, int *pWindowWidth, int *pWindowHeight, int* pScreenWidth, int* pScreenHeight, int FsaaSamples, int Flags, int *pDesktopWidth, int *pDesktopHeight)
+int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *pScreen, int *pWindowWidth, int *pWindowHeight, int* pScreenWidth, int* pScreenHeight, int FsaaSamples, int Flags, int *pDesktopWidth, int *pDesktopHeight)
 {
 	if(!SDL_WasInit(SDL_INIT_VIDEO))
 	{
@@ -662,13 +662,12 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *Screen, int *pWind
 	m_NumScreens = SDL_GetNumVideoDisplays();
 	if(m_NumScreens > 0)
 	{
-		*Screen = clamp(*Screen, 0, m_NumScreens-1);
-		if(SDL_GetDisplayBounds(*Screen, &ScreenPos) != 0)
+		*pScreen = clamp(*pScreen, 0, m_NumScreens-1);
+		if(SDL_GetDisplayBounds(*pScreen, &ScreenPos) != 0)
 		{
 			dbg_msg("gfx", "unable to retrieve screen information: %s", SDL_GetError());
 			return -1;
 		}
-
 	}
 	else
 	{
@@ -677,7 +676,7 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *Screen, int *pWind
 	}
 
 	// store desktop resolution for settings reset button
-	if(!GetDesktopResolution(*Screen, pDesktopWidth, pDesktopHeight))
+	if(!GetDesktopResolution(*pScreen, pDesktopWidth, pDesktopHeight))
 	{
 		dbg_msg("gfx", "unable to get desktop resolution: %s", SDL_GetError());
 		return -1;

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -198,7 +198,7 @@ class CGraphicsBackend_SDL_OpenGL : public CGraphicsBackend_Threaded
 	int m_NumScreens;
 	int m_TextureArraySize;
 public:
-	virtual int Init(const char *pName, int *Screen, int *pWindowWidth, int *pWindowHeight, int *pScreenWidth, int *pScreenHeight, int FsaaSamples, int Flags, int *pDesktopWidth, int *pDesktopHeight);
+	virtual int Init(const char *pName, int *pScreen, int *pWindowWidth, int *pWindowHeight, int *pScreenWidth, int *pScreenHeight, int FsaaSamples, int Flags, int *pDesktopWidth, int *pDesktopHeight);
 	virtual int Shutdown();
 
 	virtual int MemoryUsage() const;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -61,31 +61,22 @@ void CGraph::Init(float Min, float Max)
 	m_Index = 0;
 }
 
-void CGraph::ScaleMax()
+void CGraph::Scale()
 {
-	int i = 0;
+	m_Min = m_MinRange;
 	m_Max = m_MaxRange;
-	for(i = 0; i < MAX_VALUES; i++)
+	for(int i = 0; i < MAX_VALUES; i++)
 	{
 		if(m_aValues[i] > m_Max)
 			m_Max = m_aValues[i];
-	}
-}
-
-void CGraph::ScaleMin()
-{
-	int i = 0;
-	m_Min = m_MinRange;
-	for(i = 0; i < MAX_VALUES; i++)
-	{
-		if(m_aValues[i] < m_Min)
+		else if(m_aValues[i] < m_Min)
 			m_Min = m_aValues[i];
 	}
 }
 
 void CGraph::Add(float v, float r, float g, float b)
 {
-	m_Index = (m_Index+1)&(MAX_VALUES-1);
+	m_Index = (m_Index+1)%MAX_VALUES;
 	m_aValues[m_Index] = v;
 	m_aColors[m_Index][0] = r;
 	m_aColors[m_Index][1] = g;
@@ -95,7 +86,6 @@ void CGraph::Add(float v, float r, float g, float b)
 void CGraph::Render(IGraphics *pGraphics, IGraphics::CTextureHandle FontTexture, float x, float y, float w, float h, const char *pDescription)
 {
 	//m_pGraphics->BlendNormal();
-
 
 	pGraphics->TextureClear();
 
@@ -110,24 +100,24 @@ void CGraph::Render(IGraphics *pGraphics, IGraphics::CTextureHandle FontTexture,
 	IGraphics::CLineItem LineItem(x, y+h/2, x+w, y+h/2);
 	pGraphics->LinesDraw(&LineItem, 1);
 	pGraphics->SetColor(0.5f, 0.5f, 0.5f, 0.75f);
-	IGraphics::CLineItem Array[2] = {
+	IGraphics::CLineItem aLineItems[2] = {
 		IGraphics::CLineItem(x, y+(h*3)/4, x+w, y+(h*3)/4),
 		IGraphics::CLineItem(x, y+h/4, x+w, y+h/4)};
-	pGraphics->LinesDraw(Array, 2);
+	pGraphics->LinesDraw(aLineItems, 2);
 	for(int i = 1; i < MAX_VALUES; i++)
 	{
 		float a0 = (i-1)/(float)MAX_VALUES;
 		float a1 = i/(float)MAX_VALUES;
-		int i0 = (m_Index+i-1)&(MAX_VALUES-1);
-		int i1 = (m_Index+i)&(MAX_VALUES-1);
+		int i0 = (m_Index+i-1)%MAX_VALUES;
+		int i1 = (m_Index+i)%MAX_VALUES;
 
 		float v0 = (m_aValues[i0]-m_Min) / (m_Max-m_Min);
 		float v1 = (m_aValues[i1]-m_Min) / (m_Max-m_Min);
 
-		IGraphics::CColorVertex Array[2] = {
+		IGraphics::CColorVertex aColorVertices[2] = {
 			IGraphics::CColorVertex(0, m_aColors[i0][0], m_aColors[i0][1], m_aColors[i0][2], 0.75f),
 			IGraphics::CColorVertex(1, m_aColors[i1][0], m_aColors[i1][1], m_aColors[i1][2], 0.75f)};
-		pGraphics->SetColorVertex(Array, 2);
+		pGraphics->SetColorVertex(aColorVertices, 2);
 		IGraphics::CLineItem LineItem(x+a0*w, y+h-v0*h, x+a1*w, y+h-v1*h);
 		pGraphics->LinesDraw(&LineItem, 1);
 
@@ -752,20 +742,16 @@ void CClient::DebugRender()
 	// render graphs
 	if(Config()->m_DbgGraphs)
 	{
-		//Graphics()->MapScreen(0,0,400.0f,300.0f);
 		float w = Graphics()->ScreenWidth()/4.0f;
 		float h = Graphics()->ScreenHeight()/6.0f;
 		float sp = Graphics()->ScreenWidth()/100.0f;
 		float x = Graphics()->ScreenWidth()-w-sp;
 
-		m_FpsGraph.ScaleMax();
-		m_FpsGraph.ScaleMin();
+		m_FpsGraph.Scale();
 		m_FpsGraph.Render(Graphics(), s_Font, x, sp*5, w, h, "FPS");
-		m_InputtimeMarginGraph.ScaleMin();
-		m_InputtimeMarginGraph.ScaleMax();
+		m_InputtimeMarginGraph.Scale();
 		m_InputtimeMarginGraph.Render(Graphics(), s_Font, x, sp*5+h+sp, w, h, "Prediction Margin");
-		m_GametimeMarginGraph.ScaleMin();
-		m_GametimeMarginGraph.ScaleMax();
+		m_GametimeMarginGraph.Scale();
 		m_GametimeMarginGraph.Render(Graphics(), s_Font, x, sp*5+h+sp+h+sp, w, h, "Gametime Margin");
 	}
 }

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -683,12 +683,12 @@ void CClient::DebugRender()
 	static NETSTATS Prev, Current;
 	static int64 LastSnap = 0;
 	static float FrameTimeAvg = 0;
-	static IGraphics::CTextureHandle Font = Graphics()->LoadTexture("ui/debug_font.png", IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, IGraphics::TEXLOAD_NORESAMPLE);
+	static IGraphics::CTextureHandle s_Font = Graphics()->LoadTexture("ui/debug_font.png", IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, IGraphics::TEXLOAD_NORESAMPLE);
 	char aBuffer[256];
 	int64 Now = time_get();
 
 	//m_pGraphics->BlendNormal();
-	Graphics()->TextureSet(Font);
+	Graphics()->TextureSet(s_Font);
 	Graphics()->MapScreen(0,0,Graphics()->ScreenWidth(),Graphics()->ScreenHeight());
 	Graphics()->QuadsBegin();
 
@@ -760,13 +760,13 @@ void CClient::DebugRender()
 
 		m_FpsGraph.ScaleMax();
 		m_FpsGraph.ScaleMin();
-		m_FpsGraph.Render(Graphics(), Font, x, sp*5, w, h, "FPS");
+		m_FpsGraph.Render(Graphics(), s_Font, x, sp*5, w, h, "FPS");
 		m_InputtimeMarginGraph.ScaleMin();
 		m_InputtimeMarginGraph.ScaleMax();
-		m_InputtimeMarginGraph.Render(Graphics(), Font, x, sp*5+h+sp, w, h, "Prediction Margin");
+		m_InputtimeMarginGraph.Render(Graphics(), s_Font, x, sp*5+h+sp, w, h, "Prediction Margin");
 		m_GametimeMarginGraph.ScaleMin();
 		m_GametimeMarginGraph.ScaleMax();
-		m_GametimeMarginGraph.Render(Graphics(), Font, x, sp*5+h+sp+h+sp, w, h, "Gametime Margin");
+		m_GametimeMarginGraph.Render(Graphics(), s_Font, x, sp*5+h+sp+h+sp, w, h, "Gametime Margin");
 	}
 }
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -614,12 +614,6 @@ void CClient::GetServerInfo(CServerInfo *pServerInfo)
 	m_ServerBrowser.UpdateFavoriteState(pServerInfo);
 }
 
-int CClient::LoadData()
-{
-	m_DebugFont = Graphics()->LoadTexture("ui/debug_font.png", IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, IGraphics::TEXLOAD_NORESAMPLE);
-	return 1;
-}
-
 // ---
 
 const void *CClient::SnapGetItem(int SnapID, int Index, CSnapItem *pItem) const
@@ -683,17 +677,18 @@ void CClient::SnapSetStaticsize(int ItemType, int Size)
 
 void CClient::DebugRender()
 {
-	static NETSTATS Prev, Current;
-	static int64 LastSnap = 0;
-	static float FrameTimeAvg = 0;
-	int64 Now = time_get();
-	char aBuffer[512];
-
 	if(!Config()->m_Debug)
 		return;
 
+	static NETSTATS Prev, Current;
+	static int64 LastSnap = 0;
+	static float FrameTimeAvg = 0;
+	static IGraphics::CTextureHandle Font = Graphics()->LoadTexture("ui/debug_font.png", IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, IGraphics::TEXLOAD_NORESAMPLE);
+	char aBuffer[256];
+	int64 Now = time_get();
+
 	//m_pGraphics->BlendNormal();
-	Graphics()->TextureSet(m_DebugFont);
+	Graphics()->TextureSet(Font);
 	Graphics()->MapScreen(0,0,Graphics()->ScreenWidth(),Graphics()->ScreenHeight());
 	Graphics()->QuadsBegin();
 
@@ -737,8 +732,7 @@ void CClient::DebugRender()
 	// render rates
 	{
 		int y = 0;
-		int i;
-		for(i = 0; i < 256; i++)
+		for(int i = 0; i < 256; i++)
 		{
 			if(m_SnapshotDelta.GetDataRate(i))
 			{
@@ -766,13 +760,13 @@ void CClient::DebugRender()
 
 		m_FpsGraph.ScaleMax();
 		m_FpsGraph.ScaleMin();
-		m_FpsGraph.Render(Graphics(), m_DebugFont, x, sp*5, w, h, "FPS");
+		m_FpsGraph.Render(Graphics(), Font, x, sp*5, w, h, "FPS");
 		m_InputtimeMarginGraph.ScaleMin();
 		m_InputtimeMarginGraph.ScaleMax();
-		m_InputtimeMarginGraph.Render(Graphics(), m_DebugFont, x, sp*5+h+sp, w, h, "Prediction Margin");
+		m_InputtimeMarginGraph.Render(Graphics(), Font, x, sp*5+h+sp, w, h, "Prediction Margin");
 		m_GametimeMarginGraph.ScaleMin();
 		m_GametimeMarginGraph.ScaleMax();
-		m_GametimeMarginGraph.Render(Graphics(), m_DebugFont, x, sp*5+h+sp+h+sp, w, h, "Gametime Margin");
+		m_GametimeMarginGraph.Render(Graphics(), Font, x, sp*5+h+sp+h+sp, w, h, "Gametime Margin");
 	}
 }
 
@@ -1974,11 +1968,6 @@ void CClient::Run()
 
 	// init the editor
 	m_pEditor->Init();
-
-
-	// load data
-	if(!LoadData())
-		return;
 
 	GameClient()->OnInit();
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -782,10 +782,16 @@ const char *CClient::ErrorString() const
 
 void CClient::Render()
 {
-	if(Config()->m_GfxClear)
-		Graphics()->Clear(1,1,0);
-
-	GameClient()->OnRender();
+	if(m_EditorActive)
+	{
+		m_pEditor->UpdateAndRender();
+	}
+	else
+	{
+		if(Config()->m_GfxClear)
+			Graphics()->Clear(1,1,0);
+		GameClient()->OnRender();
+	}
 	DebugRender();
 }
 
@@ -1966,9 +1972,6 @@ void CClient::Run()
 	// start refreshing addresses while we load
 	MasterServer()->RefreshAddresses(m_ContactClient.NetType());
 
-	// init the editor
-	m_pEditor->Init();
-
 	GameClient()->OnInit();
 
 	char aBuf[256];
@@ -2099,13 +2102,7 @@ void CClient::Run()
 				// when we are stress testing only render every 10th frame
 				if(!Config()->m_DbgStress || (m_RenderFrames%10) == 0 )
 				{
-					if(!m_EditorActive)
-						Render();
-					else
-					{
-						m_pEditor->UpdateAndRender();
-						DebugRender();
-					}
+					Render();
 					m_pGraphics->Swap();
 				}
 			}

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -7,7 +7,6 @@
 
 class CGraph
 {
-public:
 	enum
 	{
 		// restrictions: Must be power of two
@@ -20,11 +19,10 @@ public:
 	float m_aColors[MAX_VALUES][3];
 	int m_Index;
 
+public:
 	void Init(float Min, float Max);
 
-	void ScaleMax();
-	void ScaleMin();
-
+	void Scale();
 	void Add(float v, float r, float g, float b);
 	void Render(IGraphics *pGraphics, IGraphics::CTextureHandle FontTexture, float x, float y, float w, float h, const char *pDescription);
 };

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -9,7 +9,6 @@ class CGraph
 {
 	enum
 	{
-		// restrictions: Must be power of two
 		MAX_VALUES=128,
 	};
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -89,8 +89,6 @@ class CClient : public IClient, public CDemoPlayer::IListner
 	unsigned m_SnapshotParts;
 	int64 m_LocalStartTime;
 
-	IGraphics::CTextureHandle m_DebugFont;
-
 	int64 m_LastRenderTime;
 	int64 m_LastCpuTime;
 	float m_LastAvgCpuFrameTime;
@@ -223,8 +221,6 @@ public:
 
 	virtual bool SoundInitFailed() const { return m_SoundInitFailed; }
 
-	virtual IGraphics::CTextureHandle GetDebugFont() const { return m_DebugFont; }
-
 	void SendInput();
 
 	// TODO: OPT: do this alot smarter!
@@ -247,8 +243,6 @@ public:
 
 
 	virtual void GetServerInfo(CServerInfo *pServerInfo);
-
-	int LoadData();
 
 	// ---
 

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -171,7 +171,7 @@ class CTextRender : public IEngineTextRender
 		pSizeData->m_TextureHeight = Height;
 		pSizeData->m_CurrentCharacter = 0;
 
-		dbg_msg("", "pFont memory usage: %d", FontMemoryUsage);
+		dbg_msg("pFont", "memory usage: %d", FontMemoryUsage);
 
 		mem_free(pMem);
 	}

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -35,6 +35,7 @@ public:
 
 	virtual void OnStateChange(int NewState, int OldState) {};
 	virtual void OnConsoleInit() {};
+	virtual int GetInitAmount() const { return 0; }; // Amount of progress reported by this component during OnInit
 	virtual void OnInit() {};
 	virtual void OnShutdown() {};
 	virtual void OnReset() {};

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -10,6 +10,7 @@
 #include <engine/external/json-parser/json.h>
 #include <engine/shared/config.h>
 
+#include "menus.h"
 #include "countryflags.h"
 
 
@@ -129,11 +130,17 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 		m_CodeIndexLUT[max(0, (m_aCountryFlags[i].m_CountryCode-CODE_LB)%CODE_RANGE)] = i;
 }
 
+int CCountryFlags::GetInitAmount() const
+{
+	return 15;
+}
+
 void CCountryFlags::OnInit()
 {
 	// load country flags
 	m_aCountryFlags.clear();
 	LoadCountryflagsIndexfile();
+	m_pClient->m_pMenus->RenderLoading(5);
 	if(!m_aCountryFlags.size())
 	{
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "countryflags", "failed to load country flags. folder='countryflags/'");
@@ -143,6 +150,7 @@ void CCountryFlags::OnInit()
 		mem_zero(DummyEntry.m_aCountryCodeString, sizeof(DummyEntry.m_aCountryCodeString));
 		m_aCountryFlags.add(DummyEntry);
 	}
+	m_pClient->m_pMenus->RenderLoading(10);
 }
 
 int CCountryFlags::Num() const

--- a/src/game/client/components/countryflags.h
+++ b/src/game/client/components/countryflags.h
@@ -19,6 +19,7 @@ public:
 		bool operator<(const CCountryFlag &Other) const { return str_comp(m_aCountryCodeString, Other.m_aCountryCodeString) < 0; }
 	};
 
+	int GetInitAmount() const;
 	void OnInit();
 
 	int Num() const;

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -14,10 +14,9 @@
 #include <game/client/component.h>
 #include <game/client/render.h>
 
-#include <game/client/components/camera.h>
-#include <game/client/components/mapimages.h>
-
-
+#include "camera.h"
+#include "mapimages.h"
+#include "menus.h"
 #include "maplayers.h"
 
 CMapLayers::CMapLayers(int t)
@@ -71,14 +70,22 @@ void CMapLayers::LoadBackgroundMap()
 	LoadEnvPoints(m_pMenuLayers, m_lEnvPointsMenu);
 }
 
+int CMapLayers::GetInitAmount() const
+{
+	if(m_Type == TYPE_BACKGROUND)
+		return 15;
+	return 0;
+}
+
 void CMapLayers::OnInit()
 {
 	if(m_Type == TYPE_BACKGROUND)
 	{
 		m_pMenuLayers = new CLayers;
 		m_pMenuMap = CreateEngineMap();
-
+		m_pClient->m_pMenus->RenderLoading(1);
 		LoadBackgroundMap();
+		m_pClient->m_pMenus->RenderLoading(14);
 	}
 
 	m_pEggTiles = 0;

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -37,6 +37,7 @@ public:
 
 	CMapLayers(int Type);
 	virtual void OnStateChange(int NewState, int OldState);
+	virtual int GetInitAmount() const;
 	virtual void OnInit();
 	virtual void OnShutdown();
 	virtual void OnRender();

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2502,7 +2502,8 @@ void CMenus::RenderBackground()
 	Graphics()->TextureClear();
 	Graphics()->QuadsBegin();
 		float Size = 15.0f;
-		float OffsetTime = fmod(Client()->LocalTime()*0.15f, 2.0f);
+		static int64 s_MenuBackgroundStart = time_get();
+		float OffsetTime = fmod((time_get()-s_MenuBackgroundStart)*0.15f/time_freq(), 2.0f);
 		for(int y = -2; y < (int)(sw/Size); y++)
 			for(int x = -2; x < (int)(sh/Size); x++)
 			{

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2502,8 +2502,8 @@ void CMenus::RenderBackground()
 	Graphics()->QuadsEnd();
 
 	// render border fade
-	static IGraphics::CTextureHandle m_TextureBlob = Graphics()->LoadTexture("ui/blob.png", IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, 0);
-	Graphics()->TextureSet(m_TextureBlob);
+	static IGraphics::CTextureHandle s_TextureBlob = Graphics()->LoadTexture("ui/blob.png", IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, 0);
+	Graphics()->TextureSet(s_TextureBlob);
 	Graphics()->QuadsBegin();
 		Graphics()->SetColor(0,0,0,0.5f);
 		IGraphics::CQuadItem QuadItem = IGraphics::CQuadItem(-100, -100, sw+200, sh+200);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1264,6 +1264,7 @@ void CMenus::RenderLoading(int WorkedAmount)
 	RenderTools()->DrawRoundRect(&Rect, vec4(0.0f, 0.0f, 0.0f, 0.5f), 40.0f);
 
 	Rect.y += 20;
+	TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.3f);
 	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 	UI()->DoLabel(&Rect, "Teeworlds", 48.0f, CUI::ALIGN_CENTER);
 
@@ -1271,15 +1272,16 @@ void CMenus::RenderLoading(int WorkedAmount)
 	float Spacing = 40.0f;
 	float Rounding = 5.0f;
 	CUIRect FullBar = {x+Spacing, y+h-75.0f, w-2*Spacing, 25.0f};
-	RenderTools()->DrawRoundRect(&FullBar, vec4(1.0f, 1.0f, 1.0f, 0.10f), Rounding);
+	RenderTools()->DrawRoundRect(&FullBar, vec4(1.0f, 1.0f, 1.0f, 0.1f), Rounding);
 	CUIRect FillingBar = FullBar;
 	FillingBar.w = (FullBar.w-2*Rounding)*Percent+2*Rounding;
 	RenderTools()->DrawRoundRect(&FillingBar, vec4(1.0f, 1.0f, 1.0f, 0.75f), Rounding);
 
-	if(Percent > 0.5)
+	if(Percent > 0.5f)
+	{
+		TextRender()->TextOutlineColor(1.0f, 1.0f, 1.0f, 0.7f);
 		TextRender()->TextColor(0.2f, 0.2f, 0.2f, 1.0f);
-	else
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+	}
 	char aBuf[8];
 	str_format(aBuf, sizeof(aBuf), "%d%%", (int)(100*Percent));
 	UI()->DoLabel(&FullBar, aBuf, 20.0f, CUI::ALIGN_CENTER);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1249,11 +1249,9 @@ void CMenus::RenderLoading(int WorkedAmount)
 
 	s_LastLoadRender = time_get();
 
-	CUIRect Screen = *UI()->Screen();
-	Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
-
 	RenderBackground();
 
+	CUIRect Screen = *UI()->Screen();
 	float w = 700;
 	float h = 200;
 	float x = Screen.w/2-w/2;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1265,7 +1265,7 @@ void CMenus::RenderLoading(int WorkedAmount)
 
 	Rect.y += 20;
 	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
-	UI()->DoLabel(&Rect, Localize("Loading"), 48.0f, CUI::ALIGN_CENTER);
+	UI()->DoLabel(&Rect, "Teeworlds", 48.0f, CUI::ALIGN_CENTER);
 
 	float Percent = m_LoadCurrent/(float)m_LoadTotal;
 	float Spacing = 40.0f;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1263,20 +1263,16 @@ void CMenus::RenderLoading(int WorkedAmount)
 	Graphics()->BlendNormal();
 	RenderTools()->DrawRoundRect(&Rect, vec4(0.0f, 0.0f, 0.0f, 0.5f), 40.0f);
 
-	Rect.x = x;
-	Rect.y = y+20;
-	Rect.w = w;
-	Rect.h = h;
+	Rect.y += 20;
 	UI()->DoLabel(&Rect, Localize("Loading"), 48.0f, CUI::ALIGN_CENTER);
 
 	float Percent = m_LoadCurrent/(float)m_LoadTotal;
 	float Spacing = 40.0f;
 	float Rounding = 5.0f;
-	Rect.x = x+Spacing;
-	Rect.y = y+h-75.0f;
-	Rect.w = (w-2*Spacing-2*Rounding)*Percent+2*Rounding;
-	Rect.h = 25.0f;
-	RenderTools()->DrawRoundRect(&Rect, vec4(1.0f, 1.0f, 1.0f, 0.75f), Rounding);
+	CUIRect Bar = {x+Spacing, y+h-75.0f, w-2*Spacing, 25.0f};
+	RenderTools()->DrawRoundRect(&Bar, vec4(1.0f, 1.0f, 1.0f, 0.10f), Rounding);
+	Bar.w = (Bar.w-2*Rounding)*Percent+2*Rounding;
+	RenderTools()->DrawRoundRect(&Bar, vec4(1.0f, 1.0f, 1.0f, 0.75f), Rounding);
 
 	Graphics()->Swap();
 }

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1264,15 +1264,25 @@ void CMenus::RenderLoading(int WorkedAmount)
 	RenderTools()->DrawRoundRect(&Rect, vec4(0.0f, 0.0f, 0.0f, 0.5f), 40.0f);
 
 	Rect.y += 20;
+	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 	UI()->DoLabel(&Rect, Localize("Loading"), 48.0f, CUI::ALIGN_CENTER);
 
 	float Percent = m_LoadCurrent/(float)m_LoadTotal;
 	float Spacing = 40.0f;
 	float Rounding = 5.0f;
-	CUIRect Bar = {x+Spacing, y+h-75.0f, w-2*Spacing, 25.0f};
-	RenderTools()->DrawRoundRect(&Bar, vec4(1.0f, 1.0f, 1.0f, 0.10f), Rounding);
-	Bar.w = (Bar.w-2*Rounding)*Percent+2*Rounding;
-	RenderTools()->DrawRoundRect(&Bar, vec4(1.0f, 1.0f, 1.0f, 0.75f), Rounding);
+	CUIRect FullBar = {x+Spacing, y+h-75.0f, w-2*Spacing, 25.0f};
+	RenderTools()->DrawRoundRect(&FullBar, vec4(1.0f, 1.0f, 1.0f, 0.10f), Rounding);
+	CUIRect FillingBar = FullBar;
+	FillingBar.w = (FullBar.w-2*Rounding)*Percent+2*Rounding;
+	RenderTools()->DrawRoundRect(&FillingBar, vec4(1.0f, 1.0f, 1.0f, 0.75f), Rounding);
+
+	if(Percent > 0.5)
+		TextRender()->TextColor(0.2f, 0.2f, 0.2f, 1.0f);
+	else
+		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+	char aBuf[8];
+	str_format(aBuf, sizeof(aBuf), "%d%%", (int)(100*Percent));
+	UI()->DoLabel(&FullBar, aBuf, 20.0f, CUI::ALIGN_CENTER);
 
 	Graphics()->Swap();
 }

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -682,6 +682,8 @@ private:
 	void RenderBackButton(CUIRect MainView);
 	inline float GetListHeaderHeight() const { return ms_ListheaderHeight + (Config()->m_UiWideview ? 3.0f : 0.0f); }
 	inline float GetListHeaderHeightFactor() const { return 1.0f + (Config()->m_UiWideview ? (3.0f/ms_ListheaderHeight) : 0.0f); }
+	static void ConchainUpdateMusicState(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	void UpdateMusicState();
 
 	// found in menus_demo.cpp
 	void RenderDemoPlayer(CUIRect MainView);
@@ -719,7 +721,6 @@ private:
 	static void ConchainFriendlistUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainServerbrowserUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainServerbrowserSortingUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
-	static void ConchainToggleMusic(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	void DoFriendListEntry(CUIRect *pView, CFriendItem *pFriend, const void *pID, const CContactInfo *pFriendInfo, const CServerInfo *pServerInfo, bool Checked, bool Clan = false);
 	void SetOverlay(int Type, float x, float y, const void *pData);
 	void UpdateFriendCounter(const CServerInfo *pEntry);
@@ -766,8 +767,6 @@ private:
 	// loading
 	int m_LoadCurrent;
 	int m_LoadTotal;
-
-	void ToggleMusic();
 
 	void SetMenuPage(int NewPage);
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -400,10 +400,6 @@ private:
 
 	int64 m_LastInput;
 
-	// loading
-	int m_LoadCurrent;
-	int m_LoadTotal;
-
 	//
 	char m_aMessageTopic[512];
 	char m_aMessageBody[512];
@@ -577,6 +573,7 @@ private:
 	void SaveFilters();
 	void RemoveFilter(int FilterIndex);
 	void Move(bool Up, int Filter);
+	void InitDefaultFilters();
 
 	class CInfoOverlay
 	{
@@ -666,22 +663,15 @@ private:
 	{
 		MAX_RESOLUTIONS=256,
 	};
-
 	CVideoMode m_aModes[MAX_RESOLUTIONS];
 	int m_NumModes;
-
 	struct CVideoFormat
 	{
 		int m_WidthValue;
 		int m_HeightValue;
 	};
-
-	CVideoFormat m_aVideoFormats[MAX_RESOLUTIONS];
 	sorted_array<CVideoMode> m_lRecommendedVideoModes;
 	sorted_array<CVideoMode> m_lOtherVideoModes;
-	int m_NumVideoFormats;
-	int m_CurrentVideoFormat;
-	void UpdateVideoFormats();
 	void UpdatedFilteredVideoModes();
 	void UpdateVideoModeSettings();
 
@@ -773,7 +763,9 @@ private:
 	void InvokePopupMenu(void *pID, int Flags, float X, float Y, float W, float H, int (*pfnFunc)(CMenus *pMenu, CUIRect Rect), void *pExtra=0);
 	void DoPopupMenu();
 
-	IGraphics::CTextureHandle m_TextureBlob;
+	// loading
+	int m_LoadCurrent;
+	int m_LoadTotal;
 
 	void ToggleMusic();
 
@@ -784,6 +776,9 @@ private:
 	void RenderBackground();
 	void RenderBackgroundShadow(const CUIRect *pRect, bool TopToBottom);
 public:
+	void InitLoading(int TotalWorkAmount);
+	void RenderLoading(int WorkedAmount = 0);
+
 	struct CSwitchTeamInfo
 	{
 		char m_aNotification[128];
@@ -798,10 +793,9 @@ public:
 
 	CMenus();
 
-	void RenderLoading();
-
 	bool IsActive() const { return m_MenuActive; }
 
+	virtual int GetInitAmount() const;
 	virtual void OnInit();
 
 	virtual void OnConsoleInit();

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -772,7 +772,7 @@ private:
 
 	bool CheckHotKey(int Key) const;
 
-	void RenderBackground();
+	void RenderBackground(float Time);
 	void RenderBackgroundShadow(const CUIRect *pRect, bool TopToBottom);
 public:
 	void InitLoading(int TotalWorkAmount);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1954,7 +1954,7 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 		if(DoButton_CheckBox(&s_ButtonSndMusic, Localize("Play background music"), Config()->m_SndMusic, &Button))
 		{
 			Config()->m_SndMusic ^= 1;
-			ToggleMusic();
+			UpdateMusicState();
 		}
 
 		Sound.HSplitTop(Spacing, 0, &Sound);
@@ -2032,11 +2032,8 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 		if(Config()->m_SndEnable)
 		{
 			Config()->m_SndInit = 1;
-			if(Config()->m_SndMusic)
-				m_pClient->m_pSounds->Play(CSounds::CHN_MUSIC, SOUND_MENU, 1.0f);
 		}
-		else
-			m_pClient->m_pSounds->Stop(SOUND_MENU);
+		UpdateMusicState();
 	}
 
 	// reset button
@@ -2055,14 +2052,11 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 	{
 		Config()->m_SndEnable = 1;
 		Config()->m_SndInit = 1;
-		if(!Config()->m_SndMusic)
-		{
-			Config()->m_SndMusic = 1;
-			m_pClient->m_pSounds->Play(CSounds::CHN_MUSIC, SOUND_MENU, 1.0f);
-		}
+		Config()->m_SndMusic = 1;
 		Config()->m_SndNonactiveMute = 0;
 		Config()->m_SndRate = 48000;
 		Config()->m_SndVolume = 100;
+		UpdateMusicState();
 	}
 }
 

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -12,6 +12,7 @@
 #include <engine/shared/config.h>
 #include <engine/shared/jsonwriter.h>
 
+#include "menus.h"
 #include "skins.h"
 
 
@@ -209,6 +210,10 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 	return 0;
 }
 
+int CSkins::GetInitAmount() const
+{
+	return NUM_SKINPARTS*2 + 8;
+}
 
 void CSkins::OnInit()
 {
@@ -260,6 +265,7 @@ void CSkins::OnInit()
 			DummySkinPart.m_BloodColor = vec3(1.0f, 1.0f, 1.0f);
 			m_aaSkinParts[p].add(DummySkinPart);
 		}
+		m_pClient->m_pMenus->RenderLoading(2);
 	}
 
 	// create dummy skin
@@ -278,10 +284,12 @@ void CSkins::OnInit()
 		m_DummySkin.m_aPartColors[p] = p==SKINPART_MARKING ? (255<<24)+65408 : 65408;
 		m_DummySkin.m_aUseCustomColors[p] = 0;
 	}
+	m_pClient->m_pMenus->RenderLoading(1);
 
 	// load skins
 	m_aSkins.clear();
 	Storage()->ListDirectory(IStorage::TYPE_ALL, "skins", SkinScan, this);
+	m_pClient->m_pMenus->RenderLoading(5);
 
 	// add dummy skin
 	if(!m_aSkins.size())
@@ -305,6 +313,7 @@ void CSkins::OnInit()
 			m_XmasHatTexture = Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
 		}
 	}
+	m_pClient->m_pMenus->RenderLoading(1);
 
 	{
 		// add bot decoration
@@ -324,6 +333,7 @@ void CSkins::OnInit()
 			m_BotTexture = Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
 		}
 	}
+	m_pClient->m_pMenus->RenderLoading(1);
 }
 
 void CSkins::AddSkin(const char *pSkinName)

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -55,7 +55,7 @@ public:
 	IGraphics::CTextureHandle m_XmasHatTexture;
 	IGraphics::CTextureHandle m_BotTexture;
 
-	//
+	int GetInitAmount() const;
 	void OnInit();
 
 	void AddSkin(const char *pSkinName);

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -29,7 +29,7 @@ static int LoadSoundsThread(void *pUser)
 		}
 
 		if(pData->m_Render)
-			pData->m_pGameClient->m_pMenus->RenderLoading();
+			pData->m_pGameClient->m_pMenus->RenderLoading(1);
 	}
 
 	return 0;
@@ -56,6 +56,13 @@ ISound::CSampleHandle CSounds::GetSampleId(int SetId)
 	while(Id == pSet->m_Last);
 	pSet->m_Last = Id;
 	return pSet->m_aSounds[Id].m_Id;
+}
+
+int CSounds::GetInitAmount()
+{
+	if(Config()->m_SndAsyncLoading)
+		return 0;
+	return g_pData->m_NumSounds;
 }
 
 void CSounds::OnInit()

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -58,7 +58,7 @@ ISound::CSampleHandle CSounds::GetSampleId(int SetId)
 	return pSet->m_aSounds[Id].m_Id;
 }
 
-int CSounds::GetInitAmount()
+int CSounds::GetInitAmount() const
 {
 	if(Config()->m_SndAsyncLoading)
 		return 0;

--- a/src/game/client/components/sounds.h
+++ b/src/game/client/components/sounds.h
@@ -35,7 +35,7 @@ public:
 		CHN_GLOBAL,
 	};
 
-	virtual int GetInitAmount();
+	virtual int GetInitAmount() const;
 	virtual void OnInit();
 	virtual void OnReset();
 	virtual void OnStateChange(int NewState, int OldState);

--- a/src/game/client/components/sounds.h
+++ b/src/game/client/components/sounds.h
@@ -35,6 +35,7 @@ public:
 		CHN_GLOBAL,
 	};
 
+	virtual int GetInitAmount();
 	virtual void OnInit();
 	virtual void OnReset();
 	virtual void OnStateChange(int NewState, int OldState);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -371,16 +371,27 @@ void CGameClient::OnInit()
 		}
 	}
 
+	// determine total work for loading all components
+	int TotalWorkAmount = g_pData->m_NumImages + 2; // +2=editor
+	for(int i = m_All.m_Num-1; i >= 0; --i)
+		TotalWorkAmount += m_All.m_paComponents[i]->GetInitAmount();
+
+	m_pMenus->InitLoading(TotalWorkAmount);
+	m_pMenus->RenderLoading(); // render initial loading screen
 	// init all components
 	for(int i = m_All.m_Num-1; i >= 0; --i)
 		m_All.m_paComponents[i]->OnInit();
 
-	// setup load amount// load textures
+	// load textures
 	for(int i = 0; i < g_pData->m_NumImages; i++)
 	{
 		g_pData->m_aImages[i].m_Id = Graphics()->LoadTexture(g_pData->m_aImages[i].m_pFilename, IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, g_pData->m_aImages[i].m_Flag ? IGraphics::TEXLOAD_LINEARMIPMAPS : 0);
-		m_pMenus->RenderLoading();
+		m_pMenus->RenderLoading(1);
 	}
+
+	// init the editor
+	m_pEditor->Init();
+	m_pMenus->RenderLoading(2);
 
 	OnReset();
 
@@ -393,6 +404,7 @@ void CGameClient::OnInit()
 
 	m_IsXmasDay = time_isxmasday();
 	m_IsEasterDay = time_iseasterday();
+	m_pMenus->RenderLoading();
 }
 
 void CGameClient::OnUpdate()

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -470,8 +470,6 @@ void CLayerTiles::ShowInfo()
 {
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
-	Graphics()->TextureSet(m_pEditor->Client()->GetDebugFont());
-	Graphics()->QuadsBegin();
 
 	int StartY = max(0, (int)(ScreenY0/32.0f)-1);
 	int StartX = max(0, (int)(ScreenX0/32.0f)-1);
@@ -484,20 +482,19 @@ void CLayerTiles::ShowInfo()
 			int c = x + y*m_Width;
 			if(m_pTiles[c].m_Index)
 			{
-				char aBuf[64];
+				char aBuf[32];
 				str_format(aBuf, sizeof(aBuf), "%i", m_pTiles[c].m_Index);
-				m_pEditor->Graphics()->QuadsText(x*32, y*32, 16.0f, aBuf);
+				TextRender()->Text(0, x*32+4, y*32+4, 10.0f, aBuf, 32.0f);
 
 				char aFlags[4] = {	m_pTiles[c].m_Flags&TILEFLAG_VFLIP ? 'V' : ' ',
 									m_pTiles[c].m_Flags&TILEFLAG_HFLIP ? 'H' : ' ',
 									m_pTiles[c].m_Flags&TILEFLAG_ROTATE? 'R' : ' ',
 									0};
-				m_pEditor->Graphics()->QuadsText(x*32, y*32+16, 16.0f, aFlags);
+				TextRender()->Text(0, x*32+4, y*32+18, 10.0f, aFlags, 32.0f);
 			}
 			x += m_pTiles[c].m_Skip;
 		}
 
-	Graphics()->QuadsEnd();
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -7,6 +7,7 @@
 #include <engine/console.h>
 #include <engine/graphics.h>
 #include <engine/textrender.h>
+#include <engine/storage.h>
 
 #include <generated/client_data.h>
 #include <game/client/localization.h>
@@ -470,6 +471,9 @@ void CLayerTiles::ShowInfo()
 {
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	static IGraphics::CTextureHandle s_Font = Graphics()->LoadTexture("ui/debug_font.png", IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, IGraphics::TEXLOAD_NORESAMPLE);
+	Graphics()->TextureSet(s_Font);
+	Graphics()->QuadsBegin();
 
 	int StartY = max(0, (int)(ScreenY0/32.0f)-1);
 	int StartX = max(0, (int)(ScreenX0/32.0f)-1);
@@ -484,17 +488,26 @@ void CLayerTiles::ShowInfo()
 			{
 				char aBuf[32];
 				str_format(aBuf, sizeof(aBuf), "%i", m_pTiles[c].m_Index);
-				TextRender()->Text(0, x*32+4, y*32+4, 10.0f, aBuf, 32.0f);
+				m_pEditor->Graphics()->QuadsText(x*32, y*32, 16.0f, aBuf);
 
 				char aFlags[4] = {	m_pTiles[c].m_Flags&TILEFLAG_VFLIP ? 'V' : ' ',
 									m_pTiles[c].m_Flags&TILEFLAG_HFLIP ? 'H' : ' ',
 									m_pTiles[c].m_Flags&TILEFLAG_ROTATE? 'R' : ' ',
 									0};
-				TextRender()->Text(0, x*32+4, y*32+18, 10.0f, aFlags, 32.0f);
+				m_pEditor->Graphics()->QuadsText(x*32, y*32+16, 16.0f, aFlags);
+
+				// TODO: Use text render instead, once it's optimized enough for this much text at once, and remove usage of debug font here
+				/*str_format(aBuf, sizeof(aBuf),
+					"%i\n%c%c%c", m_pTiles[c].m_Index,
+						m_pTiles[c].m_Flags&TILEFLAG_VFLIP ? 'V' : ' ',
+						m_pTiles[c].m_Flags&TILEFLAG_HFLIP ? 'H' : ' ',
+						m_pTiles[c].m_Flags&TILEFLAG_ROTATE? 'R' : ' ');
+				TextRender()->Text(0, x*32+4, y*32+4, 10.0f, aBuf, 32.0f);*/
 			}
 			x += m_pTiles[c].m_Skip;
 		}
 
+	Graphics()->QuadsEnd();
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 


### PR DESCRIPTION
- Remove `IClient::GetDebugFont` ~~and use the default font to render the editor tile debug info~~
  - Debug font is loaded lazily because it's most often not used.
  - Performance in editor with default font and lots of tiles with debug info is fine on my machine; not for others, so I reverted to using the debug font, but without depending on the engine client. 
- Add `CComponent::GetInitAmount()` which returns the number of progress ticks, that that particular component will report in its `OnInit` method using `RenderLoading`.
  - Used in existing implementations of OnInit to provide smoother progress report (country flags, menus, skins, background maps)
  - Fixed number of ticks are used for long running methods (especially menus init) to provide some feedback during loading. Values tweaked based on relative execution times on my machine.
  - Game type icons and browser filters are also loaded during loading screen.
- Remove unused `CMenus::m_CurrentVideoFormat` and `UpdateVideoFormats`. Used bubble sort most inefficiently without even being used.
- Initialize editor after client components instead of before, to get the loading screen up sooner.
- Fix some naming, minor restructuring.
- UI: Show full progress bar faintly behind the filling one:
![grafik](https://user-images.githubusercontent.com/23437060/73982785-3d5fbc00-4935-11ea-8859-e48c07234ac0.png)
- Total startup time hasn't really changed, but the time where the screen is just white should be much shorter now.

This should address the technical items of #2403.

Also fixes incorrect menu music states and duplicated music playback when ingame (closes #2460).