### PR TITLE
Always end match properly

### DIFF
--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -922,15 +922,8 @@ void IGameController::ChangeMap(const char *pToMap)
 	str_copy(m_aMapWish, pToMap, sizeof(m_aMapWish));
 
 	m_MatchCount = m_GameInfo.m_MatchNum-1;
-	if(m_GameState == IGS_WARMUP_GAME || m_GameState == IGS_WARMUP_USER)
-		SetGameState(IGS_GAME_RUNNING);
+	SetGameState(IGS_GAME_RUNNING);
 	EndMatch();
-
-	if(m_GameState != IGS_END_MATCH)
-	{
-		// game could not been ended, force cycle
-		CycleMap();
-	}
 }
 
 void IGameController::CycleMap()


### PR DESCRIPTION
Previously changing map during a pause or while the warmup timer was running would cause an abrupt map change.

An even better solution would be to allow `IGS_END_MATCH` state to be reached from any state like `IGS_GAME_RUNNING` however I wasn't completely sure if that has any undesired effects.