### PR TITLE
Fix high LAN latency (maybe also server list loading poorly) on first startup

### DIFF
--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -422,6 +422,9 @@ void CBroadcast::OnMessage(int MsgType, void* pRawMsg)
 
 void CBroadcast::OnRender()
 {
+	if(Client()->State() < IClient::STATE_ONLINE)
+		return;
+
 	// server broadcast
 	RenderServerBroadcast();
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -737,7 +737,7 @@ const char* CChat::GetCommandName(int Mode) const
 
 void CChat::OnRender()
 {
-	if(Client()->State() <= Client()->STATE_LOADING)
+	if(Client()->State() < IClient::STATE_ONLINE)
 		return;
 
 	// send pending chat messages

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -93,6 +93,13 @@ void CEmoticon::DrawCircle(float x, float y, float r, int Segments)
 
 void CEmoticon::OnRender()
 {
+	if(Client()->State() < IClient::STATE_ONLINE)
+	{
+		m_Active = false;
+		m_WasActive = false;
+		return;
+	}
+
 	if(!m_Active)
 	{
 		if(m_WasActive && m_SelectedEmote != -1)

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -141,7 +141,7 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 
 void CInfoMessages::OnRender()
 {
-	if(!Config()->m_ClShowhud)
+	if(!Config()->m_ClShowhud || Client()->State() < IClient::STATE_ONLINE)
 		return;
 
 	float Width = 400*3.0f*Graphics()->ScreenAspect();

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2391,8 +2391,6 @@ void CMenus::OnStateChange(int NewState, int OldState)
 	}
 }
 
-extern "C" void font_debug_render();
-
 void CMenus::OnRender()
 {
 	UI()->StartCheck();

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1513,16 +1513,23 @@ int CMenus::Render()
 	CUIRect Screen = *UI()->Screen();
 	Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
 
-	static bool s_First = true;
-	if(s_First)
+	static int s_InitTick = 5;
+	if(s_InitTick > 0)
 	{
-		// refresh server browser before we are in browser menu to save time
-		m_pClient->m_pCamera->ChangePosition(CCamera::POS_START);
-		ServerBrowser()->Refresh(IServerBrowser::REFRESHFLAG_INTERNET|IServerBrowser::REFRESHFLAG_LAN);
-		ServerBrowser()->SetType(Config()->m_UiBrowserPage == PAGE_LAN ? IServerBrowser::TYPE_LAN : IServerBrowser::TYPE_INTERNET);
-
-		UpdateMusicState();
-		s_First = false;
+		s_InitTick--;
+		if(s_InitTick == 4)
+		{
+			m_pClient->m_pCamera->ChangePosition(CCamera::POS_START);
+			UpdateMusicState();
+		}
+		else if(s_InitTick == 0)
+		{
+			// Wait a few frames before refreshing server browser,
+			// else the increased rendering time at startup prevents
+			// the network from being pumped effectively.
+			ServerBrowser()->Refresh(IServerBrowser::REFRESHFLAG_INTERNET|IServerBrowser::REFRESHFLAG_LAN);
+			ServerBrowser()->SetType(Config()->m_UiBrowserPage == PAGE_LAN ? IServerBrowser::TYPE_LAN : IServerBrowser::TYPE_INTERNET);
+		}
 	}
 
 	// render background only if needed

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -71,7 +71,7 @@ void CNamePlates::RenderNameplate(
 
 void CNamePlates::OnRender()
 {
-	if (!Config()->m_ClNameplates)
+	if (!Config()->m_ClNameplates || Client()->State() < IClient::STATE_ONLINE)
 		return;
 
 	for(int i = 0; i < MAX_CLIENTS; i++)

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -137,22 +137,22 @@ void CParticles::OnRender()
 	if(Client()->State() < IClient::STATE_ONLINE)
 		return;
 
-	static int64 LastTime = 0;
-	int64 t = time_get();
+	static int64 s_LastTime = 0;
+	int64 Now = time_get();
 
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
 		const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
 		if(!pInfo->m_Paused)
-			Update((float)((t-LastTime)/(double)time_freq())*pInfo->m_Speed);
+			Update((float)((Now-s_LastTime)/(double)time_freq())*pInfo->m_Speed);
 	}
 	else
 	{
 		if(m_pClient->m_Snap.m_pGameData && !(m_pClient->m_Snap.m_pGameData->m_GameStateFlags&GAMESTATEFLAG_PAUSED))
-			Update((float)((t-LastTime)/(double)time_freq()));
+			Update((float)((Now-s_LastTime)/(double)time_freq()));
 	}
 
-	LastTime = t;
+	s_LastTime = Now;
 }
 
 void CParticles::RenderGroup(int Group)

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -483,6 +483,9 @@ void CPlayers::RenderPlayer(
 
 void CPlayers::OnRender()
 {
+	if(Client()->State() < IClient::STATE_ONLINE)
+		return;
+
 	// update RenderInfo for ninja
 	bool IsTeamplay = (m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS) != 0;
 	for(int i = 0; i < MAX_CLIENTS; ++i)


### PR DESCRIPTION
I can't test whether this fixes #2285 in general, as I never had any problems with the server list loading poorly on startup, even when setting br_max_request to 100.
However this definitely fixes LAN servers having a much higher latency (~200-300) on first startup, by delaying the first serverbrowser refresh for a few frames, as the first frames contain a lot of initialization that delays pumping the network.