### PR TITLE
Fix #2476

### DIFF
--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -34,6 +34,13 @@ void CNetRecvUnpacker::Start(const NETADDR *pAddr, CNetConnection *pConnection, 
 // TODO: rename this function
 int CNetRecvUnpacker::FetchChunk(CNetChunk *pChunk)
 {
+	// Don't bother with connections that already went offline
+	if(m_pConnection && m_pConnection->State() != NET_CONNSTATE_ONLINE)
+	{
+		Clear();
+		return 0;
+	}
+
 	CNetChunkHeader Header;
 	unsigned char *pEnd = m_Data.m_aChunkData + m_Data.m_DataSize;
 
@@ -300,7 +307,7 @@ int CNetBase::UnpackPacket(NETADDR *pAddr, unsigned char *pBuffer, CNetPacketCon
 		pPacket->m_Token = (pBuffer[3] << 24) | (pBuffer[4] << 16) | (pBuffer[5] << 8) | pBuffer[6];
 			// TTTTTTTT TTTTTTTT TTTTTTTT TTTTTTTT
 		pPacket->m_ResponseToken = NET_TOKEN_NONE;
-		
+
 		if(pPacket->m_Flags&NET_PACKETFLAG_COMPRESSION)
 			pPacket->m_DataSize = m_Huffman.Decompress(&pBuffer[NET_PACKETHEADERSIZE], pPacket->m_DataSize, pPacket->m_aChunkData, sizeof(pPacket->m_aChunkData));
 		else


### PR DESCRIPTION
Not completely sure if this is the best place to handle it, maybe `CNetServer::Drop` should be clearing `m_RecvUnpacker` either way, IMHO this is a better fix then the one mentioned in #2476.