### PR TITLE
Remove whispers from server logs

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -197,15 +197,18 @@ void CGameContext::SendChat(int ChatterClientID, int Mode, int To, const char *p
 	else
 		str_format(aBuf, sizeof(aBuf), "*** %s", pText);
 
-	char aBufMode[32];
+	const char *pModeStr;
 	if(Mode == CHAT_WHISPER)
-		str_copy(aBufMode, "whisper", sizeof(aBufMode));
+		pModeStr = 0;
 	else if(Mode == CHAT_TEAM)
-		str_copy(aBufMode, "teamchat", sizeof(aBufMode));
+		pModeStr = "teamchat";
 	else
-		str_copy(aBufMode, "chat", sizeof(aBufMode));
+		pModeStr = "chat";
 
-	Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, aBufMode, aBuf);
+	if(pModeStr)
+	{
+		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, pModeStr, aBuf);
+	}
 
 
 	CNetMsg_Sv_Chat Msg;


### PR DESCRIPTION
This stops admins from accidentally looking at whispers. Fixes #2482.