### PR TITLE
Add a privacy notice to the whisper helper

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -979,7 +979,7 @@ void CChat::OnRender()
 				TextRender()->SetCursor(&InfoCursor, 2.0f, y+12.0f, CategoryFontSize*0.75, TEXTFLAG_RENDER);
 
 				char aInfoText[128];
-				str_format(aInfoText, sizeof(aInfoText), Localize("Press Tab to cycle chat recipients"));
+				str_format(aInfoText, sizeof(aInfoText), Localize("Press Tab to cycle chat recipients. Whispers aren't encrypted and might be logged by the server."));
 				TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.5f);
 				TextRender()->TextEx(&InfoCursor, aInfoText, -1);
 			}


### PR DESCRIPTION
Closes https://github.com/teeworlds/teeworlds/issues/2496

```
<Dune> #2496: we already have a note under whispers to explain how to change chat recipient
<Dune> I guess we could add something short there. Press Tab to cycle between chat recipients. [...]
<Dune> Whispers may be logged by the server?
<Dune> Server admins may log whispers?
<Dune> Whisper privacy may be compromised by server modifications?
<Oy> Whispers aren't private and might be logged by the server?
<Dune> aren't secured*?
<Oy> yeah
<Dune> or secure
<Dune> or encrypted
<Oy> encrypted +1
```

This messes the translations a bit, could have made that two different strings, but not sure if that's worth it. 