### PR TITLE
Editor: arbitrary drag&drop of layers and groups

### DIFF
--- a/src/game/editor/ed2_actions.cpp
+++ b/src/game/editor/ed2_actions.cpp
@@ -1,18 +1,5 @@
 #include "editor2.h"
 
-static char s_aEdMsg[256];
-#define ed_log(...)\
-	str_format(s_aEdMsg, sizeof(s_aEdMsg), __VA_ARGS__);\
-	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "editor", s_aEdMsg)
-
-#ifdef CONF_DEBUG
-	#define ed_dbg(...)\
-		str_format(s_aEdMsg, sizeof(s_aEdMsg), __VA_ARGS__);\
-		Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "editor", s_aEdMsg)
-#else
-	#define ed_dbg(...)
-#endif
-
 void CEditor2::EditDeleteLayer(int LyID, int ParentGroupID)
 {
 	dbg_assert(m_Map.m_aLayers.IsValid(LyID), "LyID out of bounds");

--- a/src/game/editor/editor2.cpp
+++ b/src/game/editor/editor2.cpp
@@ -1537,7 +1537,7 @@ void CEditor2::RenderMapEditorUiLayerGroups(CUIRect NavRect)
 
 	bool DisplayDragMoveOverlay = s_DragMove.m_IsDragging && (DragMoveGroupListIndex >= 0 || DragMoveLayerListIndex >= 0);
 	CUIRect DragMoveOverlayRect;
-	int DragMoveDir = 0;
+	int DragMoveOffset = 0;
 	// -----------------------
 
 	const int GroupCount = m_Map.m_GroupIDListCount;
@@ -1565,7 +1565,7 @@ void CEditor2::RenderMapEditorUiLayerGroups(CUIRect NavRect)
 		if(DragMoveGroupListIndex == gi)
 		{
 			DragMoveOverlayRect = ButtonRect;
-			DragMoveDir = (int)sign(m_UiMousePos.y - ButtonRect.y);
+			DragMoveOffset = (int)(m_UiMousePos.y - ButtonRect.y - ButtonHeight/2.0f)/(Spacing+ButtonHeight);
 		}
 
 		CUIRect ExpandBut, ShowButton;
@@ -1659,7 +1659,7 @@ void CEditor2::RenderMapEditorUiLayerGroups(CUIRect NavRect)
 				if(DragMoveLayerListIndex == li && DragMoveParentGroupListIndex == gi)
 				{
 					DragMoveOverlayRect = ButtonRect;
-					DragMoveDir = (int)sign(m_UiMousePos.y - ButtonRect.y);
+					DragMoveOffset = (int)(m_UiMousePos.y - ButtonRect.y - ButtonHeight/2.0f)/(Spacing+ButtonHeight);
 				}
 
 				// show button
@@ -1811,27 +1811,44 @@ void CEditor2::RenderMapEditorUiLayerGroups(CUIRect NavRect)
 		EditDeleteGroup(ToDeleteID);
 	}
 
-	// drag overlay (arrows for now)
-	if(DisplayDragMoveOverlay && !UI()->MouseInside(&DragMoveOverlayRect))
+	// sanitize DragMoveOffset
+	if(DragMoveOffset != 0)
 	{
-		const vec4 Color = StyleColorInputSelected;
-		const float MarginX = 10.0f;
-		const float x = DragMoveOverlayRect.x + MarginX;
-		const float y = DragMoveOverlayRect.y + (DragMoveDir == 1 ? DragMoveOverlayRect.h : 0);
-		const float w = DragMoveOverlayRect.w - (MarginX * 2);
+		if(DragMoveLayerListIndex != -1)
+			DragMoveOffset = EditLayerClampMove(DragMoveParentGroupListIndex, DragMoveLayerListIndex, DragMoveOffset);
+		else if(DragMoveGroupListIndex != -1)
+		{
+			const int MinNewPos = 0;
+			const int MaxNewPos = m_Map.m_GroupIDListCount-1;
+			DragMoveOffset = clamp(DragMoveOffset, MinNewPos-DragMoveGroupListIndex, MaxNewPos-DragMoveGroupListIndex);
+		}
+	}
+
+	// drag overlay (arrows for now)
+	if(DisplayDragMoveOverlay && !UI()->MouseInside(&DragMoveOverlayRect) && DragMoveOffset != 0)
+	{
+		const float x = DragMoveOverlayRect.x;
+		const float y = DragMoveOverlayRect.y 
+			+ (sign(DragMoveOffset) == 1 ? DragMoveOverlayRect.h : 0) 
+			+ (ButtonHeight+Spacing) * DragMoveOffset;
+		const float w = DragMoveOverlayRect.w;
+
+		char aBuf[64];
+		str_format(aBuf, sizeof(aBuf), "Drag=%d", DragMoveOffset);
+		DrawText(DragMoveOverlayRect, aBuf, FontSize*2);
 
 		Graphics()->TextureClear();
 		Graphics()->QuadsBegin();
-		IGraphics::CFreeformItem Triangle(
+		IGraphics::CFreeformItem RowIndicator(
+			x, y + Spacing * sign(DragMoveOffset),
+			x + w, y + Spacing * sign(DragMoveOffset),
 			x, y,
-			x + w, y,
-			x + w * 0.5f, y - 25 * -DragMoveDir,
 			x + w, y
-		);
+		); 
 
-		Graphics()->SetColor(Color.r*Color.a, Color.g*Color.a, Color.b*Color.a, Color.a);
+		Graphics()->SetColor(1, 0, 0, 1);
 
-		Graphics()->QuadsDrawFreeform(&Triangle, 1);
+		Graphics()->QuadsDrawFreeform(&RowIndicator, 1);
 		Graphics()->QuadsEnd();
 	}
 
@@ -1843,7 +1860,7 @@ void CEditor2::RenderMapEditorUiLayerGroups(CUIRect NavRect)
 		{
 			if(DragMoveGroupListIndex != -1)
 			{
-				int NewGroupListIndex = EditGroupOrderMove(DragMoveGroupListIndex,  DragMoveDir < 0 ? -1 : 1);
+				int NewGroupListIndex = EditGroupOrderMove(DragMoveGroupListIndex,  DragMoveOffset < 0 ? -1 : 1);
 				m_UiGroupState[m_Map.m_aGroupIDList[NewGroupListIndex]].m_IsOpen = true;
 
 				if((int)m_Map.m_aGroupIDList[DragMoveGroupListIndex] == m_UiSelectedGroupID && NewGroupListIndex != DragMoveGroupListIndex)
@@ -1854,7 +1871,7 @@ void CEditor2::RenderMapEditorUiLayerGroups(CUIRect NavRect)
 			}
 			else if(DragMoveLayerListIndex != -1)
 			{
-				int NewGroupListIndex = EditLayerOrderMove(DragMoveParentGroupListIndex, DragMoveLayerListIndex, DragMoveDir < 0 ? -1 : 1);
+				int NewGroupListIndex = EditLayerOrderMove(DragMoveParentGroupListIndex, DragMoveLayerListIndex, DragMoveOffset);
 				m_UiGroupState[m_Map.m_aGroupIDList[NewGroupListIndex]].m_IsOpen = true;
 			}
 		}

--- a/src/game/editor/editor2.h
+++ b/src/game/editor/editor2.h
@@ -286,8 +286,10 @@ class CEditor2: public IEditor, public CEditor2Ui
 	void EditLayerChangeImage(int LayerID, int NewImageID);
 	void EditLayerHighDetail(int LayerID, bool NewHighDetail);
 	void EditGroupUseClipping(int GroupID, bool NewUseClipping);
+	int EditLayerClampMove(int ParentGroupListIndex, int LayerListIndex, int RelativePos);
 	int EditGroupOrderMove(int GroupListIndex, int RelativePos);
 	int EditLayerOrderMove(int ParentGroupListIndex, int LayerListIndex, int RelativePos);
+	void EditLayerOrderMoveByOne(int& ParentGroupListIndex, int& LayerListIndex, int RelativePos);
 	void EditTileSelectionFlipX(int LayerID);
 	void EditTileSelectionFlipY(int LayerID);
 	void EditBrushPaintLayer(int PaintTX, int PaintTY, int LayerID);

--- a/src/game/editor/editor2.h
+++ b/src/game/editor/editor2.h
@@ -286,8 +286,9 @@ class CEditor2: public IEditor, public CEditor2Ui
 	void EditLayerChangeImage(int LayerID, int NewImageID);
 	void EditLayerHighDetail(int LayerID, bool NewHighDetail);
 	void EditGroupUseClipping(int GroupID, bool NewUseClipping);
-	int EditLayerClampMove(int ParentGroupListIndex, int LayerListIndex, int RelativePos);
+	int EditGroupClampMove(int ParentGroupListIndex, int* pRelativePos);
 	int EditGroupOrderMove(int GroupListIndex, int RelativePos);
+	int EditLayerClampMove(int ParentGroupListIndex, int LayerListIndex, int RelativePos);
 	int EditLayerOrderMove(int ParentGroupListIndex, int LayerListIndex, int RelativePos);
 	void EditLayerOrderMoveByOne(int& ParentGroupListIndex, int& LayerListIndex, int RelativePos);
 	void EditTileSelectionFlipX(int LayerID);

--- a/src/game/editor/editor2.h
+++ b/src/game/editor/editor2.h
@@ -290,7 +290,6 @@ class CEditor2: public IEditor, public CEditor2Ui
 	int EditGroupOrderMove(int GroupListIndex, int RelativePos);
 	int EditLayerClampMove(int ParentGroupListIndex, int LayerListIndex, int RelativePos);
 	int EditLayerOrderMove(int ParentGroupListIndex, int LayerListIndex, int RelativePos);
-	void EditLayerOrderMoveByOne(int& ParentGroupListIndex, int& LayerListIndex, int RelativePos);
 	void EditTileSelectionFlipX(int LayerID);
 	void EditTileSelectionFlipY(int LayerID);
 	void EditBrushPaintLayer(int PaintTX, int PaintTY, int LayerID);


### PR DESCRIPTION
### Overview
- A red row indicator will show up when moving a layer or a group, only to legit positions
  - Design decision: Moving a layer or group to its current position does not show an indicator; it is not a legit position
- Hidden groups: moving a layer into a hidden group will expand it, and put it on the top if coming from the top, and on the bottom if coming from the bottom. 
- Groups and layers can be moved at once to arbitrary positions, but will create several history entries
- Moving the game layer away from the group layer is still not possible
- Bug fix: drag and dropping no longer acts as a click on the group/layer

### Screenshots
![image](https://user-images.githubusercontent.com/355114/77249413-32d95780-6c41-11ea-86ae-1b20de68989a.png)

![image](https://user-images.githubusercontent.com/355114/77249404-28b75900-6c41-11ea-953c-9c109b616a01.png)
