### PR TITLE
Implement vote subheaders

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -257,8 +257,12 @@ void CConsole::Print(int Level, const char *pFrom, const char *pStr, bool Highli
 
 bool CConsole::LineIsValid(const char *pStr)
 {
-	if(!pStr || *pStr == 0)
+	if(!pStr)
 		return false;
+
+	// Comments and empty lines are valid commands
+	if(*pStr == '#' || *pStr == '\0')
+		return true;
 
 	do
 	{

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -241,6 +241,7 @@ private:
 	{
 		bool m_Visible;
 		bool m_Selected;
+		bool m_Disabled;
 		CUIRect m_Rect;
 	};
 
@@ -278,6 +279,7 @@ private:
 		void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int SelectedIndex,
 					const CUIRect *pRect = 0, bool Background = true, bool *pActive = 0);
 		CListboxItem DoNextItem(const void *pID, bool Selected = false, bool *pActive = 0);
+		CListboxItem DoSubheader();
 		int DoEnd();
 		bool FilterMatches(const char *pNeedle) const;
 		bool WasItemActivated() const { return m_ListBoxItemActivated; };

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -59,7 +59,7 @@ void CMenus::RenderGame(CUIRect MainView)
 
 	float Spacing = 3.0f;
 	float ButtonWidth = (MainView.w/6.0f)-(Spacing*5.0)/6.0f;
-	
+
 	// cut view
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	float NoteHeight = !Info.m_aNotification[0] ? 0.0f : 45.0f;
@@ -372,7 +372,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	UI()->DoLabel(&Label, Localize("Server info"), ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 	RenderTools()->DrawUIRect(&ServerInfo, vec4(0.0, 0.0, 0.0, 0.25f), CUI::CORNER_ALL, 5.0f);
 	ServerInfo.Margin(5.0f, &ServerInfo);
-	
+
 	ServerInfo.HSplitTop(2*ButtonHeight, &Label, &ServerInfo);
 	Label.y += 2.0f;
 	UI()->DoLabel(&Label, CurrentServerInfo.m_aName, ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT, Label.w);
@@ -381,7 +381,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	Label.y += 2.0f;
 	str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Address"), CurrentServerInfo.m_aHostname);
 	UI()->DoLabel(&Label, aBuf, ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
-	
+
 	ServerInfo.HSplitTop(ButtonHeight, &Label, &ServerInfo);
 	Label.y += 2.0f;
 	str_format(aBuf, sizeof(aBuf), "%s: %d", Localize("Ping"), m_pClient->m_Snap.m_pLocalInfo->m_Latency);
@@ -396,7 +396,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	Label.y += 2.0f;
 	str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Password"), CurrentServerInfo.m_Flags&IServerBrowser::FLAG_PASSWORD ? Localize("Yes", "With") : Localize("No", "Without/None"));
 	UI()->DoLabel(&Label, aBuf, ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
-	
+
 	const bool IsFavorite = CurrentServerInfo.m_Favorite;
 	ServerInfo.HSplitBottom(ButtonHeight, &ServerInfo, &Label);
 	static int s_AddFavButton = 0;
@@ -508,15 +508,21 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 
 	for(CVoteOptionClient *pOption = m_pClient->m_pVoting->m_pFirst; pOption; pOption = pOption->m_pNext)
 	{
-		if(m_aFilterString[0] && !str_find_nocase(pOption->m_aDescription, m_aFilterString))
+		if(m_aFilterString[0] && !pOption->m_IsSubheader && !str_find_nocase(pOption->m_aDescription, m_aFilterString))
 			continue; // no match found
 
-		CListboxItem Item = s_ListBox.DoNextItem(pOption);
+		if(!pOption->m_aDescription[0])
+			continue; // depth resets
+
+		CListboxItem Item = pOption->m_IsSubheader ? s_ListBox.DoSubheader() : s_ListBox.DoNextItem(pOption);
 
 		if(Item.m_Visible)
-		{			
+		{
 			Item.m_Rect.VMargin(5.0f, &Item.m_Rect);
 			Item.m_Rect.y += 2.0f;
+			for(int i = pOption->m_IsSubheader ? 1 : 0; i < pOption->m_Depth; i++)
+				Item.m_Rect.VSplitLeft(10.0f, 0, &Item.m_Rect);
+
 			UI()->DoLabel(&Item.m_Rect, pOption->m_aDescription, Item.m_Rect.h*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 		}
 	}
@@ -606,8 +612,11 @@ void CMenus::HandleCallvote(int Page, bool Force)
 		int RealIndex = 0, FilteredIndex = 0;
 		for(CVoteOptionClient *pOption = m_pClient->m_pVoting->m_pFirst; pOption; pOption = pOption->m_pNext, RealIndex++)
 		{
-			if(m_aFilterString[0] && !str_find_nocase(pOption->m_aDescription, m_aFilterString))
+			if(m_aFilterString[0] && !pOption->m_IsSubheader && !str_find_nocase(pOption->m_aDescription, m_aFilterString))
 				continue; // no match found
+
+			if(!pOption->m_aDescription[0])
+				continue; // depth reset
 
 			if(FilteredIndex == m_CallvoteSelectedOption)
 				break;
@@ -723,12 +732,12 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	// render background
 	MainView.HSplitBottom(90.0f+2*20.0f, &MainView, &Extended);
 	RenderTools()->DrawUIRect(&Extended, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
-	
+
 	bool doCallVote = false;
 	// render page
 	if(s_ControlPage == 0)
 		// double click triggers vote if not spectating
-		doCallVote = RenderServerControlServer(MainView) && m_pClient->m_aClients[m_pClient->m_LocalClientID].m_Team != TEAM_SPECTATORS; 
+		doCallVote = RenderServerControlServer(MainView) && m_pClient->m_aClients[m_pClient->m_LocalClientID].m_Team != TEAM_SPECTATORS;
 	else if(s_ControlPage == 1)
 		RenderServerControlKick(MainView, false);
 	else if(s_ControlPage == 2)
@@ -785,7 +794,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 					m_aCallvoteReason[0] = 0;
 			}
 		}
- 
+
 		if(pNotification == 0)
 		{
 			// call vote
@@ -861,4 +870,3 @@ void CMenus::RenderServerControl(CUIRect MainView)
 		}
 	}
 }
-

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -198,6 +198,14 @@ CMenus::CListboxItem CMenus::CListBox::DoNextItem(const void *pId, bool Selected
 	return Item;
 }
 
+CMenus::CListboxItem CMenus::CListBox::DoSubheader()
+{
+	CListboxItem Item = DoNextRow();
+	CUIRect r = Item.m_Rect;
+	m_pRenderTools->DrawUIRect(&r, vec4(1, 1, 1, 0.2f), 0, 0.0f);
+	return Item;
+}
+
 int CMenus::CListBox::DoEnd()
 {
 	m_ScrollRegion.End();

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -120,7 +120,19 @@ void CVoting::AddOption(const char *pDescription)
 	if(!m_pFirst)
 		m_pFirst = pOption;
 
+	int Depth = 0;
+	for(;*pDescription == '#'; pDescription++, Depth++);
+	pOption->m_Depth = Depth ? Depth : pOption->m_pPrev ? pOption->m_pPrev->m_Depth : 0;
+
+	if(Depth)
+		pOption->m_IsSubheader = true;
+
+	if(!*pDescription)
+		pOption->m_Depth = 0;
+
 	str_copy(pOption->m_aDescription, pDescription, sizeof(pOption->m_aDescription));
+
+	dbg_msg("Debug", "Added option '%s' with depth='%d'", pDescription, pOption->m_Depth);
 	++m_NumVoteOptions;
 }
 

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -132,7 +132,9 @@ void CVoting::AddOption(const char *pDescription)
 
 	str_copy(pOption->m_aDescription, pDescription, sizeof(pOption->m_aDescription));
 
-	dbg_msg("Debug", "Added option '%s' with depth='%d'", pDescription, pOption->m_Depth);
+	if(Config()->m_Debug)
+		dbg_msg("voting", "added option '%s' with depth='%d'", pDescription, pOption->m_Depth);
+
 	++m_NumVoteOptions;
 }
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1323,7 +1323,7 @@ void CGameContext::ConAddVote(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	// check for valid option
-	if((pCommand[0] != '#' && !pSelf->Console()->LineIsValid(pCommand)) || str_length(pCommand) >= VOTE_CMD_LENGTH)
+	if(!pSelf->Console()->LineIsValid(pCommand) || str_length(pCommand) >= VOTE_CMD_LENGTH)
 	{
 		char aBuf[256];
 		str_format(aBuf, sizeof(aBuf), "skipped invalid command '%s'", pCommand);

--- a/src/game/voting.h
+++ b/src/game/voting.h
@@ -21,6 +21,9 @@ struct CVoteOptionClient
 	CVoteOptionClient *m_pNext;
 	CVoteOptionClient *m_pPrev;
 	char m_aDescription[VOTE_DESC_LENGTH];
+
+	int m_Depth;
+	bool m_IsSubheader;
 };
 
 struct CVoteOptionServer


### PR DESCRIPTION
This patch introduces subheaders with varying depth, it doesn't really look the best on older clients though. We could remove the depth component and make it only depth 1.

This could also be extended to allow subheaders that are collapsible with something like `#-`

![image](https://user-images.githubusercontent.com/490500/77687477-820be900-6faf-11ea-8140-e6e635ec3d88.png)
This is how it looks with a modern client ^^

![image](https://user-images.githubusercontent.com/490500/77687520-9223c880-6faf-11ea-8dd4-dd5cb0d25eaa.png)
This is how it looks with an old client ^^