### PR TITLE
Implement connection limits. Fix #1631

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -275,6 +275,7 @@ CClient::CClient() : m_DemoPlayer(&m_SnapshotDelta), m_DemoRecorder(&m_SnapshotD
 
 	//
 	m_aCmdConnect[0] = 0;
+	m_pErrorOverride = 0;
 
 	// map download
 	m_aMapdownloadFilename[0] = 0;
@@ -511,6 +512,24 @@ void CClient::Connect(const char *pAddress)
 {
 	char aBuf[512];
 	int Port = 8303;
+	NETADDR Addr;
+
+	if(net_addr_from_str(&Addr, pAddress) != 0 && net_host_lookup(pAddress, &Addr, m_NetClient.NetType()) != 0)
+	{
+		char aBufMsg[256];
+		str_format(aBufMsg, sizeof(aBufMsg), "could not find the address of %s, connecting to localhost", aBuf);
+		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aBufMsg);
+		net_host_lookup("localhost", &Addr, m_NetClient.NetType());
+	}
+
+	if(m_NetClient.Connlimit(Addr, 1, 1))
+	{
+		m_pErrorOverride = "Too fast";
+		SetState(IClient::STATE_CONNECTING);
+		DisconnectWithReason(m_pErrorOverride);
+		m_pErrorOverride = 0;
+		return;
+	}
 
 	Disconnect();
 
@@ -521,13 +540,7 @@ void CClient::Connect(const char *pAddress)
 
 	mem_zero(&m_CurrentServerInfo, sizeof(m_CurrentServerInfo));
 
-	if(net_addr_from_str(&m_ServerAddress, m_aServerAddressStr) != 0 && net_host_lookup(m_aServerAddressStr, &m_ServerAddress, m_NetClient.NetType()) != 0)
-	{
-		char aBufMsg[256];
-		str_format(aBufMsg, sizeof(aBufMsg), "could not find the address of %s, connecting to localhost", aBuf);
-		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aBufMsg);
-		net_host_lookup("localhost", &m_ServerAddress, m_NetClient.NetType());
-	}
+	m_ServerAddress = Addr;
 
 	m_RconAuthed = 0;
 	m_UseTempRconCommands = 0;
@@ -763,7 +776,7 @@ void CClient::Quit()
 
 const char *CClient::ErrorString() const
 {
-	return m_NetClient.ErrorString();
+	return m_pErrorOverride ? m_pErrorOverride : m_NetClient.ErrorString();
 }
 
 void CClient::Render()

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -122,6 +122,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 
 	//
 	char m_aCmdConnect[256];
+	const char *m_pErrorOverride;
 
 	// map download
 	char m_aMapdownloadFilename[256];

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -94,6 +94,8 @@ MACRO_CONFIG_INT(SvRconMaxTries, sv_rcon_max_tries, 3, 0, 100, CFGFLAG_SAVE|CFGF
 MACRO_CONFIG_INT(SvRconBantime, sv_rcon_bantime, 5, 0, 1440, CFGFLAG_SAVE|CFGFLAG_SERVER, "The time a client gets banned if remote console authentication fails. 0 makes it just use kick")
 MACRO_CONFIG_INT(SvAutoDemoRecord, sv_auto_demo_record, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_SERVER, "Automatically record demos")
 MACRO_CONFIG_INT(SvAutoDemoMax, sv_auto_demo_max, 10, 0, 1000, CFGFLAG_SAVE|CFGFLAG_SERVER, "Maximum number of automatically recorded demos (0 = no limit)")
+MACRO_CONFIG_INT(SvConnlimit, sv_connlimit, 4, 0, 100, CFGFLAG_SERVER, "Connlimit: Number of connections an IP is allowed to do in a timespan")
+MACRO_CONFIG_INT(SvConnlimitTime, sv_connlimit_time, 20, 0, 1000, CFGFLAG_SERVER, "Connlimit: Time in which IP's connections are counted")
 
 MACRO_CONFIG_STR(EcBindaddr, ec_bindaddr, 128, "localhost", CFGFLAG_SAVE|CFGFLAG_ECON, "Address to bind the external console to. Anything but 'localhost' is dangerous")
 MACRO_CONFIG_INT(EcPort, ec_port, 0, 0, 0, CFGFLAG_SAVE|CFGFLAG_ECON, "Port to use for the external console")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -95,7 +95,7 @@ MACRO_CONFIG_INT(SvRconBantime, sv_rcon_bantime, 5, 0, 1440, CFGFLAG_SAVE|CFGFLA
 MACRO_CONFIG_INT(SvAutoDemoRecord, sv_auto_demo_record, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_SERVER, "Automatically record demos")
 MACRO_CONFIG_INT(SvAutoDemoMax, sv_auto_demo_max, 10, 0, 1000, CFGFLAG_SAVE|CFGFLAG_SERVER, "Maximum number of automatically recorded demos (0 = no limit)")
 MACRO_CONFIG_INT(SvConnlimit, sv_connlimit, 4, 0, 100, CFGFLAG_SERVER, "Connlimit: Number of connections an IP is allowed to do in a timespan")
-MACRO_CONFIG_INT(SvConnlimitTime, sv_connlimit_time, 20, 0, 1000, CFGFLAG_SERVER, "Connlimit: Time in which IP's connections are counted")
+MACRO_CONFIG_INT(SvConnlimitWindow, sv_connlimit_window, 20, 0, 1000, CFGFLAG_SERVER, "Connlimit: Time in which IP's connections are counted")
 
 MACRO_CONFIG_STR(EcBindaddr, ec_bindaddr, 128, "localhost", CFGFLAG_SAVE|CFGFLAG_ECON, "Address to bind the external console to. Anything but 'localhost' is dangerous")
 MACRO_CONFIG_INT(EcPort, ec_port, 0, 0, 0, CFGFLAG_SAVE|CFGFLAG_ECON, "Port to use for the external console")

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -209,6 +209,14 @@ class CNetBase
 	CHuffman m_Huffman;
 	unsigned char m_aRequestTokenBuf[NET_TOKENREQUEST_DATASIZE];
 
+	struct SConnection
+	{
+		NETADDR m_Addr;
+		int64 m_Time;
+		int m_Conns;
+	};
+	SConnection m_aConnLog[NET_CONNLIMIT_IPS];
+
 public:
 	CNetBase();
 	~CNetBase();
@@ -226,6 +234,8 @@ public:
 	void SendPacketConnless(const NETADDR *pAddr, TOKEN Token, TOKEN ResponseToken, const void *pData, int DataSize);
 	void SendPacket(const NETADDR *pAddr, CNetPacketConstruct *pPacket);
 	int UnpackPacket(NETADDR *pAddr, unsigned char *pBuffer, CNetPacketConstruct *pPacket);
+
+	bool Connlimit(const NETADDR &Addr, int Window, int Limit);
 };
 
 class CNetTokenManager
@@ -467,14 +477,6 @@ class CNetServer : public CNetBase
 	CNetTokenManager m_TokenManager;
 	CNetTokenCache m_TokenCache;
 
-	struct SConnection
-	{
-		NETADDR m_Addr;
-		int64 m_Time;
-		int m_Conns;
-	};
-	SConnection m_aConnLog[NET_CONNLIMIT_IPS];
-
 public:
 	//
 	bool Open(NETADDR BindAddr, class CConfig *pConfig, class IConsole *pConsole, class IEngine *pEngine, class CNetBan *pNetBan,
@@ -497,8 +499,6 @@ public:
 	//
 	void SetMaxClients(int MaxClients);
 	void SetMaxClientsPerIP(int MaxClientsPerIP);
-
-	bool Connlimit(const NETADDR &Addr);
 };
 
 class CNetConsole

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -67,7 +67,7 @@ enum
 enum
 {
 	NET_MAX_CHUNKHEADERSIZE = 3,
-	
+
 	// packets
 	NET_PACKETHEADERSIZE = 7,
 	NET_PACKETHEADERSIZE_CONNLESS = NET_PACKETHEADERSIZE + 2,
@@ -108,7 +108,7 @@ enum
 	//
 	NET_MAX_CLIENTS = 64,
 	NET_MAX_CONSOLE_CLIENTS = 4,
-	
+
 	NET_MAX_SEQUENCE = 1<<10,
 	NET_SEQUENCE_MASK = NET_MAX_SEQUENCE-1,
 
@@ -130,6 +130,7 @@ enum
 	NET_CTRLMSG_TOKEN=5,
 
 	NET_CONN_BUFFERSIZE=1024*32,
+	NET_CONNLIMIT_IPS=16,
 
 	NET_ENUM_TERMINATOR
 };
@@ -214,7 +215,7 @@ public:
 	CConfig *Config() { return m_pConfig; }
 	class IEngine *Engine() { return m_pEngine; }
 	int NetType() { return m_Socket.type; }
-	
+
 	void Init(NETSOCKET Socket, class CConfig *pConfig, class IConsole *pConsole, class IEngine *pEngine);
 	void Shutdown();
 	void UpdateLogHandles();
@@ -466,6 +467,14 @@ class CNetServer : public CNetBase
 	CNetTokenManager m_TokenManager;
 	CNetTokenCache m_TokenCache;
 
+	struct SConnection
+	{
+		NETADDR m_Addr;
+		int64 m_Time;
+		int m_Conns;
+	};
+	SConnection m_aConnLog[NET_CONNLIMIT_IPS];
+
 public:
 	//
 	bool Open(NETADDR BindAddr, class CConfig *pConfig, class IConsole *pConsole, class IEngine *pEngine, class CNetBan *pNetBan,
@@ -488,6 +497,8 @@ public:
 	//
 	void SetMaxClients(int MaxClients);
 	void SetMaxClientsPerIP(int MaxClientsPerIP);
+
+	bool Connlimit(const NETADDR &Addr);
 };
 
 class CNetConsole

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -50,6 +50,8 @@ CMenus::CMenus()
 	m_ActivePage = PAGE_INTERNET;
 	m_GamePage = PAGE_GAME;
 
+	m_aError[0] = 0;
+
 	m_SidebarTab = 0;
 	m_SidebarActive = true;
 	m_ShowServerDetails = true;
@@ -653,13 +655,13 @@ void CMenus::DoScrollbarOptionLabeled(void *pID, int *pOption, const CUIRect *pR
 	str_format(aBuf, sizeof(aBuf), "%s: %s", pStr, aLabels[Value]);
 
 	float FontSize = pRect->h*ms_FontmodHeight*0.8f;
-	
+
 	RenderTools()->DrawUIRect(pRect, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
 	CUIRect Label, ScrollBar;
 	pRect->VSplitLeft(5.0f, 0, &Label);
 	Label.VSplitRight(60.0f, &Label, &ScrollBar);
-	
+
 	Label.y += 2.0f;
 	UI()->DoLabel(&Label, aBuf, FontSize, CUI::ALIGN_LEFT);
 
@@ -1722,7 +1724,7 @@ int CMenus::Render()
 		else if(m_Popup == POPUP_DISCONNECTED)
 		{
 			pTitle = Localize("Disconnected");
-			pExtraText = Client()->ErrorString();
+			pExtraText = m_aError;
 			pButtonText = Localize("Ok");
 			ExtraAlign = CUI::ALIGN_LEFT;
 		}
@@ -2397,6 +2399,7 @@ void CMenus::OnStateChange(int NewState, int OldState)
 		m_Popup = POPUP_NONE;
 		if(Client()->ErrorString() && Client()->ErrorString()[0] != 0)
 		{
+			str_copy(m_aError, Client()->ErrorString(), sizeof(m_aError));
 			if(str_find(Client()->ErrorString(), "password"))
 			{
 				m_Popup = POPUP_PASSWORD;
@@ -2520,7 +2523,7 @@ void CMenus::OnRender()
 
 bool CMenus::CheckHotKey(int Key) const
 {
-	return !m_KeyReaderIsActive && !m_KeyReaderWasActive && !m_PrevCursorActive && !m_PopupActive && 
+	return !m_KeyReaderIsActive && !m_KeyReaderWasActive && !m_PrevCursorActive && !m_PopupActive &&
 		!Input()->KeyIsPressed(KEY_LSHIFT) && !Input()->KeyIsPressed(KEY_RSHIFT) && !Input()->KeyIsPressed(KEY_LCTRL) && !Input()->KeyIsPressed(KEY_RCTRL) && !Input()->KeyIsPressed(KEY_LALT) && // no modifier
 		Input()->KeyIsPressed(Key) && !m_pClient->m_pGameConsole->IsConsoleActive();
 }

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -333,6 +333,7 @@ private:
 
 	int m_GamePage;
 	int m_Popup;
+	char m_aError[256];
 	int m_ActivePage;
 	int m_MenuPage;
 	int m_MenuPageOld;


### PR DESCRIPTION
Instead of checking people who error out, this limits the amount of connections in a given timeframe. It also adds two config variables to adjust sensitivity, which you could change to match the current vanilla behaviour if you prefer.

It also fixes what @heinrich5991 mentioned in #1631.

Originally made for DDNet by @def- 

Closes #1631