### PR TITLE
Make the race record message change backward compatible

### DIFF
--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -285,8 +285,9 @@ class NetMessage(NetObject):
 
 
 class NetVariable:
-	def __init__(self, name):
+	def __init__(self, name, default=None):
 		self.name = name
+		self.default = None if default is None else str(default)
 	def emit_declaration(self):
 		return []
 	def emit_validate(self):
@@ -318,13 +319,16 @@ class NetIntAny(NetVariable):
 	def emit_declaration(self):
 		return ["int %s;"%self.name]
 	def emit_unpack(self):
-		return ["pMsg->%s = pUnpacker->GetInt();" % self.name]
+		if self.default is None:
+			return ["pMsg->%s = pUnpacker->GetInt();" % self.name]
+		else:
+			return ["pMsg->%s = pUnpacker->GetIntOrDefault(%s);" % (self.name, self.default)]
 	def emit_pack(self):
 		return ["pPacker->AddInt(%s);" % self.name]
 
 class NetIntRange(NetIntAny):
-	def __init__(self, name, min, max):
-		NetIntAny.__init__(self,name)
+	def __init__(self, name, min, max, default=None):
+		NetIntAny.__init__(self,name,default=default)
 		self.min = str(min)
 		self.max = str(max)
 	def emit_validate(self):
@@ -351,8 +355,9 @@ class NetFlag(NetIntAny):
 		return ["if(!CheckFlag(\"%s\", pMsg->%s, %s)) break;"%(self.name, self.name, self.mask)]
 
 class NetBool(NetIntRange):
-	def __init__(self, name):
-		NetIntRange.__init__(self,name,0,1)
+	def __init__(self, name, default=None):
+		default = None if default is None else int(default)
+		NetIntRange.__init__(self,name,0,1,default=default)
 
 class NetTick(NetIntRange):
 	def __init__(self, name):

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -5,7 +5,6 @@ Emotes = Enum("EMOTE", ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
 Emoticons = Enum("EMOTICON", ["OOP", "EXCLAMATION", "HEARTS", "DROP", "DOTDOT", "MUSIC", "SORRY", "GHOST", "SUSHI", "SPLATTEE", "DEVILTEE", "ZOMG", "ZZZ", "WTF", "EYES", "QUESTION"])
 Votes = Enum("VOTE", ["UNKNOWN", "START_OP", "START_KICK", "START_SPEC", "END_ABORT", "END_PASS", "END_FAIL"]) # todo 0.8: add RUN_OP, RUN_KICK, RUN_SPEC; rem UNKNOWN
 ChatModes = Enum("CHAT", ["NONE", "ALL", "TEAM", "WHISPER"])
-RaceRecordTypes = Enum("RECORDTYPE", ["NONE", "PLAYER", "MAP"])
 
 PlayerFlags = Flags("PLAYERFLAG", ["ADMIN", "CHATTING", "SCOREBOARD", "READY", "DEAD", "WATCHING", "BOT"])
 GameFlags = Flags("GAMEFLAG", ["TEAMS", "FLAGS", "SURVIVAL", "RACE"])
@@ -69,7 +68,6 @@ Enums = [
 	Emoticons,
 	Votes,
 	ChatModes,
-	RaceRecordTypes,
 	GameMsgIDs,
 ]
 
@@ -454,7 +452,8 @@ Messages = [
 		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
 		NetIntRange("m_Time", -1, 'max_int'),
 		NetIntAny("m_Diff"),
-		NetEnum("m_RecordType", RaceRecordTypes)
+		NetBool("m_RecordPersonal"),
+		NetBool("m_RecordServer", default=False),
 	]),
 
 	NetMessage("Sv_Checkpoint", [

--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -114,6 +114,19 @@ int CUnpacker::GetInt()
 	return i;
 }
 
+int CUnpacker::GetIntOrDefault(int Default)
+{
+	if(m_Error)
+	{
+		return 0;
+	}
+	if(m_pCurrent == m_pEnd)
+	{
+		return Default;
+	}
+	return GetInt();
+}
+
 const char *CUnpacker::GetString(int SanitizeType)
 {
 	if(m_Error || m_pCurrent >= m_pEnd)

--- a/src/engine/shared/packer.h
+++ b/src/engine/shared/packer.h
@@ -43,6 +43,7 @@ public:
 
 	void Reset(const void *pData, int Size);
 	int GetInt();
+	int GetIntOrDefault(int Default);
 	const char *GetString(int SanitizeType = SANITIZE);
 	const unsigned char *GetRaw(int Size);
 	bool Error() const { return m_Error; }

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -97,11 +97,11 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 		str_format(aBuf, sizeof(aBuf), "%2d: %s: finished in %s", pMsg->m_ClientID, m_pClient->m_aClients[pMsg->m_ClientID].m_aName, aTime);
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "race", aBuf);
 
-		if(pMsg->m_RecordType != RECORDTYPE_NONE)
+		if(pMsg->m_RecordPersonal || pMsg->m_RecordServer)
 		{
-			if(pMsg->m_RecordType == RECORDTYPE_MAP)
+			if(pMsg->m_RecordServer)
 				str_format(aBuf, sizeof(aBuf), Localize("'%s' has set a new map record: %s"), aLabel, aTime);
-			else // RECORDTYPE_PLAYER
+			else // m_RecordPersonal
 				str_format(aBuf, sizeof(aBuf), Localize("'%s' has set a new personal record: %s"), aLabel, aTime);
 			
 			if(pMsg->m_Diff < 0)
@@ -117,7 +117,7 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 
 		if(m_pClient->m_Snap.m_pGameDataRace && m_pClient->m_Snap.m_pGameDataRace->m_RaceFlags&RACEFLAG_FINISHMSG_AS_CHAT)
 		{
-			if(pMsg->m_RecordType == RECORDTYPE_NONE) // don't print the time twice
+			if(!pMsg->m_RecordPersonal && !pMsg->m_RecordServer) // don't print the time twice
 			{
 				str_format(aBuf, sizeof(aBuf), Localize("'%s' finished in: %s"), aLabel, aTime);
 				m_pClient->m_pChat->AddLine(aBuf);
@@ -132,7 +132,8 @@ void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 
 			Finish.m_Time = pMsg->m_Time;
 			Finish.m_Diff = pMsg->m_Diff;
-			Finish.m_RecordType = pMsg->m_RecordType;
+			Finish.m_RecordPersonal = pMsg->m_RecordPersonal;
+			Finish.m_RecordServer = pMsg->m_RecordServer;
 
 			AddInfoMsg(INFOMSG_FINISH, Finish);
 		}
@@ -289,10 +290,10 @@ void CInfoMessages::RenderFinishMsg(const CInfoMsg *pInfoMsg, float x, float y) 
 	float TimeW = TextRender()->TextWidth(0, FontSize, aTime, -1, -1.0f);
 
 	x -= TimeW;
-	if(pInfoMsg->m_RecordType == RECORDTYPE_PLAYER)
-		TextRender()->TextColor(0.2f, 0.6f, 1.0f, 1.0f);
-	else if(pInfoMsg->m_RecordType == RECORDTYPE_MAP)
+	if(pInfoMsg->m_RecordServer)
 		TextRender()->TextColor(1.0f, 0.5f, 0.0f, 1.0f);
+	else if(pInfoMsg->m_RecordPersonal)
+		TextRender()->TextColor(0.2f, 0.6f, 1.0f, 1.0f);
 	TextRender()->Text(0, x, y, FontSize, aTime, -1);
 
 	x -= 52.0f + 10.0f;
@@ -318,6 +319,6 @@ void CInfoMessages::RenderFinishMsg(const CInfoMsg *pInfoMsg, float x, float y) 
 	x -= 28.0f;
 
 	// render player tee
-	int Emote = pInfoMsg->m_RecordType != RECORDTYPE_NONE ? EMOTE_HAPPY : EMOTE_NORMAL;
+	int Emote = (pInfoMsg->m_RecordPersonal || pInfoMsg->m_RecordServer) ? EMOTE_HAPPY : EMOTE_NORMAL;
 	RenderTools()->RenderTee(CAnimState::GetIdle(), &pInfoMsg->m_Player1RenderInfo, Emote, vec2(-1,0), vec2(x, y+28));
 }

--- a/src/game/client/components/infomessages.h
+++ b/src/game/client/components/infomessages.h
@@ -30,7 +30,8 @@ class CInfoMessages : public CComponent
 		// finish msg
 		int m_Time;
 		int m_Diff;
-		int m_RecordType;
+		int m_RecordPersonal;
+		int m_RecordServer;
 	};
 
 	enum


### PR DESCRIPTION
Also add defaults for ints later introduced in the protocol.

This allows introducing new fields in the network protocol without
breaking backward compatibility (new client -- old server scenario).