### PR TITLE
Handle adding assets

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1837,6 +1837,12 @@ int fs_file_time(const char *name, time_t *created, time_t *modified)
 	return 0;
 }
 
+char *fs_basename(char *path)
+{
+    char *base = strrchr(path, '/');
+    return base ? base+1 : path;
+}
+
 void swap_endian(void *data, unsigned elem_size, unsigned num)
 {
 	char *src = (char*) data;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1508,6 +1508,21 @@ char *fs_read_str(const char *name);
 int fs_file_time(const char *name, time_t *created, time_t *modified);
 
 /*
+	Function: fs_basename
+		Gets the basename(filename) for given path.
+
+	Parameters:
+		path - The path.
+
+	Returns:
+		Pointer inside the path to the start of the basename.
+
+	Remarks:
+		- Path is never modified
+*/
+char *fs_basename(char *path);
+
+/*
 	Group: Undocumented
 */
 

--- a/src/game/editor/ed2_map.h
+++ b/src/game/editor/ed2_map.h
@@ -201,7 +201,7 @@ struct CEditorMap2
 	void AssetsClearAndSetImages(CImageName* aName, CImageInfo* aInfo, u32* aImageEmbeddedCrc, int ImageCount);
 	u32 AssetsAddEmbeddedData(void* pData, u64 DataSize);
 	void AssetsClearEmbeddedFiles();
-	bool AssetsAddAndLoadImage(const char* pFilename); // also loads automap rules if there are any
+	bool AssetsAddAndLoadImage(const char* pFilePath); // also loads automap rules if there are any
 	void AssetsDeleteImage(int ImgID);
 	void AssetsLoadAutomapFileForImage(int ImgID);
 	void AssetsLoadMissingAutomapFiles();

--- a/src/game/editor/editor2.cpp
+++ b/src/game/editor/editor2.cpp
@@ -2801,7 +2801,7 @@ void CEditor2::CUIFileSelect::GenerateListBoxEntries()
 	}
 }
 
-bool CEditor2::DoFileSelect(CUIRect MainRect, CUIFileSelect *pState)
+bool CEditor2::DoFileSelect(CUIRect MainRect, CUIFileSelect *pState, CUIRect *pPreviewRect)
 {
 	const float Padding = 20.0f;
 	const float FontSize = 7.0f;
@@ -2867,6 +2867,8 @@ bool CEditor2::DoFileSelect(CUIRect MainRect, CUIFileSelect *pState)
 	Preview.VSplitLeft(Padding/2, 0, &Preview);
 
 	Preview.h = Preview.w;
+	if(pPreviewRect)
+		*pPreviewRect = Preview;
 
 	{
 		CUIRect Label;

--- a/src/game/editor/editor2.h
+++ b/src/game/editor/editor2.h
@@ -155,7 +155,7 @@ class CEditor2: public IEditor, public CEditor2Ui
 
 	CUIFileSelect m_UiFileSelectState;
 
-	bool DoFileSelect(CUIRect MainRect, CUIFileSelect *pState);
+	bool DoFileSelect(CUIRect MainRect, CUIFileSelect *pState, CUIRect *pPreviewRect = 0);
 
 	bool m_UiDetailPanelIsOpen;
 

--- a/src/game/editor/editor2.h
+++ b/src/game/editor/editor2.h
@@ -129,6 +129,7 @@ class CEditor2: public IEditor, public CEditor2Ui
 		int m_Selected;
 		char m_aPath[512];
 		char m_aCompletePath[512];
+		int m_StorageType;
 
 		void *m_pContext;
 
@@ -149,7 +150,7 @@ class CEditor2: public IEditor, public CEditor2Ui
 		}
 
 		static int EditorListdirCallback(const CFsFileInfo* info, int IsDir, int StorageType, void *pUser);
-		void PopulateFileList(IStorage *pStorage, int StorageType);
+		void PopulateFileList(IStorage *pStorage);
 		void GenerateListBoxEntries();
 	};
 
@@ -305,6 +306,7 @@ class CEditor2: public IEditor, public CEditor2Ui
 	void RenderPopupMapSaveAs(void* pPopupData);
 	void RenderPopupYesNo(void *pPopupData);
 	void RenderPopupMapNew(void *pPopupData);
+	void RenderPopupAddImage(void *pPopupData);
 
 	struct CUIPopupYesNo
 	{


### PR DESCRIPTION
If you prefer we could revert the change to ed2_map and instead strip mapres from the beginning before calling `EditAddImage`.

The background checkers for the preview are also scaled for assets that aren't square, we could fix that if you want.

Closes #2550 