### PR TITLE
Delete incomplete map file when download is aborted (closes #2126)

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -278,8 +278,9 @@ CClient::CClient() : m_DemoPlayer(&m_SnapshotDelta), m_DemoRecorder(&m_SnapshotD
 
 	// map download
 	m_aMapdownloadFilename[0] = 0;
+	m_aMapdownloadFilenameTemp[0] = 0;
 	m_aMapdownloadName[0] = 0;
-	m_MapdownloadFile = 0;
+	m_MapdownloadFileTemp = 0;
 	m_MapdownloadChunk = 0;
 	m_MapdownloadSha256 = SHA256_ZEROED;
 	m_MapdownloadSha256Present = false;
@@ -571,12 +572,12 @@ void CClient::DisconnectWithReason(const char *pReason)
 
 	// disable all downloads
 	m_MapdownloadChunk = 0;
-	if(m_MapdownloadFile)
+	if(m_MapdownloadFileTemp)
 	{
-		io_close(m_MapdownloadFile);
-		Storage()->RemoveFile(m_aMapdownloadFilename, IStorage::TYPE_SAVE);
+		io_close(m_MapdownloadFileTemp);
+		Storage()->RemoveFile(m_aMapdownloadFilenameTemp, IStorage::TYPE_SAVE);
 	}
-	m_MapdownloadFile = 0;
+	m_MapdownloadFileTemp = 0;
 	m_MapdownloadSha256 = SHA256_ZEROED;
 	m_MapdownloadSha256Present = false;
 	m_MapdownloadCrc = 0;
@@ -834,17 +835,27 @@ const char *CClient::LoadMap(const char *pName, const char *pFilename, const SHA
 }
 
 
-static void FormatMapDownloadFilename(const char *pName, const SHA256_DIGEST *pSha256, int Crc, char *pBuffer, int BufferSize)
+static void FormatMapDownloadFilename(const char *pName, const SHA256_DIGEST *pSha256, int Crc, bool Temp, char *pBuffer, int BufferSize)
 {
+	char aSuffix[32];
+	if(Temp)
+	{
+		str_format(aSuffix, sizeof(aSuffix), ".%d.tmp", pid());
+	}
+	else
+	{
+		str_copy(aSuffix, ".map", sizeof(aSuffix));
+	}
+
 	if(pSha256)
 	{
 		char aSha256[SHA256_MAXSTRSIZE];
 		sha256_str(*pSha256, aSha256, sizeof(aSha256));
-		str_format(pBuffer, BufferSize, "downloadedmaps/%s_%s.map", pName, aSha256);
+		str_format(pBuffer, BufferSize, "downloadedmaps/%s_%s%s", pName, aSha256, aSuffix);
 	}
 	else
 	{
-		str_format(pBuffer, BufferSize, "downloadedmaps/%s_%08x.map", pName, Crc);
+		str_format(pBuffer, BufferSize, "downloadedmaps/%s_%08x%s", pName, Crc, aSuffix);
 	}
 }
 
@@ -872,7 +883,7 @@ const char *CClient::LoadMapSearch(const char *pMapName, const SHA256_DIGEST *pW
 		return pError;
 
 	// try the downloaded maps
-	FormatMapDownloadFilename(pMapName, pWantedSha256, WantedCrc, aBuf, sizeof(aBuf));
+	FormatMapDownloadFilename(pMapName, pWantedSha256, WantedCrc, false, aBuf, sizeof(aBuf));
 	pError = LoadMap(pMapName, aBuf, pWantedSha256, WantedCrc);
 	if(!pError)
 		return pError;
@@ -880,7 +891,7 @@ const char *CClient::LoadMapSearch(const char *pMapName, const SHA256_DIGEST *pW
 	// backward compatibility with old names
 	if(pWantedSha256)
 	{
-		FormatMapDownloadFilename(pMapName, 0, WantedCrc, aBuf, sizeof(aBuf));
+		FormatMapDownloadFilename(pMapName, 0, WantedCrc, false, aBuf, sizeof(aBuf));
 		pError = LoadMap(pMapName, aBuf, 0, WantedCrc);
 		if(!pError)
 			return pError;
@@ -1161,21 +1172,22 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 				}
 				else
 				{
-					if(m_MapdownloadFile)
+					if(m_MapdownloadFileTemp)
 					{
-						io_close(m_MapdownloadFile);
-						Storage()->RemoveFile(m_aMapdownloadFilename, IStorage::TYPE_SAVE);
+						io_close(m_MapdownloadFileTemp);
+						Storage()->RemoveFile(m_aMapdownloadFilenameTemp, IStorage::TYPE_SAVE);
 					}
 
 					// start map download
-					FormatMapDownloadFilename(pMap, pMapSha256, MapCrc, m_aMapdownloadFilename, sizeof(m_aMapdownloadFilename));
+					FormatMapDownloadFilename(pMap, pMapSha256, MapCrc, false, m_aMapdownloadFilename, sizeof(m_aMapdownloadFilename));
+					FormatMapDownloadFilename(pMap, pMapSha256, MapCrc, true, m_aMapdownloadFilenameTemp, sizeof(m_aMapdownloadFilenameTemp));
 
 					char aBuf[256];
-					str_format(aBuf, sizeof(aBuf), "starting to download map to '%s'", m_aMapdownloadFilename);
+					str_format(aBuf, sizeof(aBuf), "starting to download map to '%s'", m_aMapdownloadFilenameTemp);
 					m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client/network", aBuf);
 
 					str_copy(m_aMapdownloadName, pMap, sizeof(m_aMapdownloadName));
-					m_MapdownloadFile = Storage()->OpenFile(m_aMapdownloadFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+					m_MapdownloadFileTemp = Storage()->OpenFile(m_aMapdownloadFilenameTemp, IOFLAG_WRITE, IStorage::TYPE_SAVE);
 					m_MapdownloadChunk = 0;
 					m_MapdownloadChunkNum = MapChunkNum;
 					m_MapDownloadChunkSize = MapChunkSize;
@@ -1196,7 +1208,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 		}
 		else if((pPacket->m_Flags&NET_CHUNKFLAG_VITAL) != 0 && Msg == NETMSG_MAP_DATA)
 		{
-			if(!m_MapdownloadFile)
+			if(!m_MapdownloadFileTemp)
 				return;
 
 			int Size = min(m_MapDownloadChunkSize, m_MapdownloadTotalsize-m_MapdownloadAmount);
@@ -1204,7 +1216,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 			if(Unpacker.Error())
 				return;
 
-			io_write(m_MapdownloadFile, pData, Size);
+			io_write(m_MapdownloadFileTemp, pData, Size);
 			++m_MapdownloadChunk;
 			m_MapdownloadAmount += Size;
 
@@ -1213,11 +1225,13 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 				// map download complete
 				m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client/network", "download complete, loading map");
 
-				if(m_MapdownloadFile)
-					io_close(m_MapdownloadFile);
-				m_MapdownloadFile = 0;
+				if(m_MapdownloadFileTemp)
+					io_close(m_MapdownloadFileTemp);
+				m_MapdownloadFileTemp = 0;
 				m_MapdownloadAmount = 0;
 				m_MapdownloadTotalsize = -1;
+
+				Storage()->RenameFile(m_aMapdownloadFilenameTemp, m_aMapdownloadFilename, IStorage::TYPE_SAVE);
 
 				// load map
 				const char *pError = LoadMap(m_aMapdownloadName, m_aMapdownloadFilename, m_MapdownloadSha256Present ? &m_MapdownloadSha256 : 0, m_MapdownloadCrc);

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -572,7 +572,10 @@ void CClient::DisconnectWithReason(const char *pReason)
 	// disable all downloads
 	m_MapdownloadChunk = 0;
 	if(m_MapdownloadFile)
+	{
 		io_close(m_MapdownloadFile);
+		Storage()->RemoveFile(m_aMapdownloadFilename, IStorage::TYPE_SAVE);
+	}
 	m_MapdownloadFile = 0;
 	m_MapdownloadSha256 = SHA256_ZEROED;
 	m_MapdownloadSha256Present = false;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1161,6 +1161,12 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 				}
 				else
 				{
+					if(m_MapdownloadFile)
+					{
+						io_close(m_MapdownloadFile);
+						Storage()->RemoveFile(m_aMapdownloadFilename, IStorage::TYPE_SAVE);
+					}
+
 					// start map download
 					FormatMapDownloadFilename(pMap, pMapSha256, MapCrc, m_aMapdownloadFilename, sizeof(m_aMapdownloadFilename));
 
@@ -1169,8 +1175,6 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 					m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client/network", aBuf);
 
 					str_copy(m_aMapdownloadName, pMap, sizeof(m_aMapdownloadName));
-					if(m_MapdownloadFile)
-						io_close(m_MapdownloadFile);
 					m_MapdownloadFile = Storage()->OpenFile(m_aMapdownloadFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
 					m_MapdownloadChunk = 0;
 					m_MapdownloadChunkNum = MapChunkNum;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -125,8 +125,9 @@ class CClient : public IClient, public CDemoPlayer::IListener
 
 	// map download
 	char m_aMapdownloadFilename[IO_MAX_PATH_LENGTH];
+	char m_aMapdownloadFilenameTemp[IO_MAX_PATH_LENGTH];
 	char m_aMapdownloadName[IO_MAX_PATH_LENGTH];
-	IOHANDLE m_MapdownloadFile;
+	IOHANDLE m_MapdownloadFileTemp;
 	int m_MapdownloadChunk;
 	int m_MapdownloadChunkNum;
 	int m_MapDownloadChunkSize;


### PR DESCRIPTION
Since continuing a map download isn't possible, there is no point in keeping a partially downloaded map around.

This avoids a crash when a map download from a 0.7.2 server is aborted due to being banned for stressing. Connecting after the ban has been lifted will crash the client as it tries to load the incomplete map instead of restarting. Closes #2126.