### PR TITLE
Show small warmup if motd/scoreboard/stats active

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -17,6 +17,9 @@
 #include "hud.h"
 #include "voting.h"
 #include "binds.h"
+#include "motd.h"
+#include "scoreboard.h"
+#include "stats.h"
 
 CHud::CHud()
 {
@@ -31,6 +34,14 @@ void CHud::OnReset()
 {
 	m_WarmupHideTick = 0;
 	m_CheckpointTime = 0;
+}
+
+bool CHud::IsLargeWarmupTimerShown()
+{
+	return !m_pClient->m_pMotd->IsActive()
+		&& !m_pClient->m_pScoreboard->IsActive()
+		&& !m_pClient->m_pStats->IsActive()
+		&& (m_WarmupHideTick == 0 || (time_get() - m_WarmupHideTick) / time_freq() < 10); // inactivity based
 }
 
 void CHud::RenderGameTimer()
@@ -347,22 +358,22 @@ void CHud::RenderWarmupTimer()
 	if(m_pClient->m_Snap.m_pGameData->m_GameStateFlags&GAMESTATEFLAG_WARMUP)
 	{
 		char aBuf[256];
-		float FontSize = 20.0f;
-		float w = 0.0f;
 		const char *pText = Localize("Warmup");
+		const bool LargeTimer = IsLargeWarmupTimerShown();
+		const float FontSizeTitle = LargeTimer ? 20.0f : 8.0f;
+		const float FontSizeMessage = LargeTimer ? 16.0f : 6.0f;
 
-		if(m_WarmupHideTick == 0 || (time_get() - m_WarmupHideTick) / time_freq() < 10)
+		if(LargeTimer)
 		{
-			w = TextRender()->TextWidth(0, FontSize, pText, -1, -1.0f);
-			TextRender()->Text(0, 150*Graphics()->ScreenAspect() - w/2, 50, FontSize, pText, -1.0f);
+			float TextWidth = TextRender()->TextWidth(0, FontSizeTitle, pText, -1, -1.0f);
+			TextRender()->Text(0, 150*Graphics()->ScreenAspect() - TextWidth/2, 50, FontSizeTitle, pText, -1.0f);
 		}
 		else
 		{
 			TextRender()->TextColor(1, 1, 0.5f, 1);
-			TextRender()->Text(0x0, 10, 45, 8, pText, -1.0f);
+			TextRender()->Text(0, 10, 45, FontSizeTitle, pText, -1.0f);
 		}
 
-		FontSize = 16.0f;
 		if(m_pClient->m_Snap.m_pGameData->m_GameStateEndTick == 0)
 		{
 			if(m_pClient->m_Snap.m_NotReadyCount == 1)
@@ -391,14 +402,14 @@ void CHud::RenderWarmupTimer()
 				str_format(aBuf, sizeof(aBuf), "%d", round_to_int(Seconds));
 		}
 
-		if(m_WarmupHideTick == 0 || (time_get() - m_WarmupHideTick) / time_freq() < 10)
+		if(LargeTimer)
 		{
-			w = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);
-			TextRender()->Text(0, 150*Graphics()->ScreenAspect() - w/2, 75, FontSize, aBuf, -1.0f);
+			float TextWidth = TextRender()->TextWidth(0, FontSizeMessage, aBuf, -1, -1.0f);
+			TextRender()->Text(0, 150*Graphics()->ScreenAspect() - TextWidth/2, 75, FontSizeMessage, aBuf, -1.0f);
 		}
 		else
 		{
-			TextRender()->Text(0x0, 10, 54, 6, aBuf, -1.0f);
+			TextRender()->Text(0, 10, 54, FontSizeMessage, aBuf, -1.0f);
 			TextRender()->TextColor(1, 1, 1, 1);
 		}
 	}
@@ -441,7 +452,7 @@ void CHud::RenderTeambalanceWarning()
 			TextRender()->TextColor(1,1,0.5f,1);
 		else
 			TextRender()->TextColor(0.7f,0.7f,0.2f,1.0f);
-		TextRender()->Text(0x0, 5, 50, 6, pText, -1.0f);
+		TextRender()->Text(0, 5, 50, 6, pText, -1.0f);
 		TextRender()->TextColor(1,1,1,1);
 	}
 }

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -8,7 +8,10 @@ class CHud : public CComponent
 {
 	float m_Width, m_Height;
 	float m_AverageFPS;
+
+
 	int64 m_WarmupHideTick;
+	bool IsLargeWarmupTimerShown();
 
 	int m_CheckpointDiff;
 	int64 m_CheckpointTime;


### PR DESCRIPTION
![screenshot_2020-04-14_12-37-13](https://user-images.githubusercontent.com/23437060/79216040-cc64e500-7e4c-11ea-8e7b-eada7da69036.png)

Analogous for scoreboard and stats.

Closes #2541.