### PR TITLE
Fix more issues with commands

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -82,8 +82,8 @@ void CChat::OnReset()
 	m_CommandManager.AddCommand("mute", "Mute a player", "s[name]", &Com_Mute, this);
 	m_CommandManager.AddCommand("r", "Reply to a whisper", "?r[message]", &Com_Reply, this);
 	m_CommandManager.AddCommand("team", "Switch to team chat", "?r[message]", &Com_Team, this);
-	m_CommandManager.AddCommand("w", "Whisper another player", "s[name] ?r[message]", &Com_Whisper, this);
-	m_CommandManager.AddCommand("whisper", "Whisper another player", "s[name] ?r[message]", &Com_Whisper, this);
+	m_CommandManager.AddCommand("w", "Whisper another player", "s[name]", &Com_Whisper, this);
+	m_CommandManager.AddCommand("whisper", "Whisper another player", "s[name]", &Com_Whisper, this);
 }
 
 void CChat::OnMapLoad()
@@ -1605,13 +1605,7 @@ void CChat::Com_Whisper(IConsole::IResult *pResult, void *pContext)
 	if(TargetID != -1)
 	{
 		pChatData->m_WhisperTarget = TargetID;
-		pChatData->m_ChatCmdBuffer[0] = 0;
-		if(pResult->NumArguments() > 1)
-		{
-			// save the parameter in a buffer before EnableMode clears it
-			str_copy(pChatData->m_ChatCmdBuffer, pResult->GetString(1), sizeof(pChatData->m_ChatCmdBuffer));
-		}
-		pChatData->EnableMode(CHAT_WHISPER, pChatData->m_ChatCmdBuffer);
+		pChatData->EnableMode(CHAT_WHISPER);
 	}
 }
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1331,7 +1331,7 @@ void CChat::Say(int Mode, const char *pLine)
 
 bool CChat::IsTypingCommand() const
 {
-	return m_Input.GetString()[0] == '/' && !m_IgnoreCommand;
+	return m_Input.GetString()[0] == '/' && !m_IgnoreCommand && m_CommandManager.CommandCount() - m_FilteredCount;
 }
 
 // chat commands handlers
@@ -1666,7 +1666,10 @@ int CChat::FilterChatCommands(const char *pLine)
 {
 	m_aFilter.set_size(m_CommandManager.CommandCount());
 
-	m_FilteredCount = m_CommandManager.Filter(m_aFilter, pLine + 1);
+	char aCommand[16];
+	str_format(aCommand, sizeof(aCommand), "%.*s", str_span(pLine + 1, " "), pLine + 1);
+	m_FilteredCount = m_CommandManager.Filter(m_aFilter, aCommand, str_find(pLine, " ") ? true : false);
+
 	return m_FilteredCount;
 }
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -258,9 +258,10 @@ bool CChat::OnInput(IInput::CEvent Event)
 	else if(Event.m_Flags&IInput::FLAG_PRESS && (Event.m_Key == KEY_RETURN || Event.m_Key == KEY_KP_ENTER))
 	{
 		bool AddEntry = false;
-		if(IsTypingCommand() && ExecuteCommand())
+		if(IsTypingCommand())
 		{
-			AddEntry = true;
+			if(ExecuteCommand())
+				AddEntry = true;
 		}
 		else
 		{

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1523,7 +1523,7 @@ bool CChat::CompleteCommand()
 		return false;
 
 	const CCommandManager::CCommand *pCommand = m_CommandManager.GetCommand(m_SelectedCommand);
-	if(!pCommand)
+	if(!pCommand || str_find(m_Input.GetString(), " "))
 		return false;
 
 	// autocomplete command

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1371,11 +1371,12 @@ void CChat::HandleCommands(float x, float y, float w)
 				for(int i = End - m_CommandManager.CommandCount(); i >= 0; i--)
 					PreviousActiveCommand(&m_CommandStart);
 
-			if(m_SelectedCommand < m_CommandStart)
+			while(m_SelectedCommand < m_CommandStart)
 			{
 				PreviousActiveCommand(&m_CommandStart);
 			}
-			else if(m_SelectedCommand > End)
+
+			while(m_SelectedCommand > End)
 			{
 				NextActiveCommand(&m_CommandStart);
 				NextActiveCommand(&End);

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -258,7 +258,7 @@ bool CChat::OnInput(IInput::CEvent Event)
 	else if(Event.m_Flags&IInput::FLAG_PRESS && (Event.m_Key == KEY_RETURN || Event.m_Key == KEY_KP_ENTER))
 	{
 		bool AddEntry = false;
-		if(IsTypingCommand())
+		if(IsTypingCommand() && m_CommandManager.CommandCount() - m_FilteredCount)
 		{
 			if(ExecuteCommand())
 				AddEntry = true;
@@ -1331,7 +1331,7 @@ void CChat::Say(int Mode, const char *pLine)
 
 bool CChat::IsTypingCommand() const
 {
-	return m_Input.GetString()[0] == '/' && !m_IgnoreCommand && m_CommandManager.CommandCount() - m_FilteredCount;
+	return m_Input.GetString()[0] == '/' && !m_IgnoreCommand;
 }
 
 // chat commands handlers

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -245,7 +245,7 @@ bool CChat::OnInput(IInput::CEvent Event)
 
 	if(Event.m_Flags&IInput::FLAG_PRESS && (Event.m_Key == KEY_ESCAPE || Event.m_Key == KEY_MOUSE_1 || Event.m_Key == KEY_MOUSE_2))
 	{
-		if(IsTypingCommand())
+		if(IsTypingCommand() && m_CommandManager.CommandCount() - m_FilteredCount)
 		{
 			m_IgnoreCommand = true;
 		}

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -95,7 +95,8 @@ class CChat : public CComponent
 	CCommandManager m_CommandManager;
 	bool IsTypingCommand() const;
 	void HandleCommands(float x, float y, float w);
-	bool ExecuteCommand(bool Execute);
+	bool ExecuteCommand();
+	bool CompleteCommand();
 
 	static void Com_All(IConsole::IResult *pResult, void *pContext);
 	static void Com_Team(IConsole::IResult *pResult, void *pContext);

--- a/src/game/commands.h
+++ b/src/game/commands.h
@@ -116,7 +116,7 @@ public:
         m_aCommands.clear();
     }
 
-    int CommandCount()
+    int CommandCount() const
     {
         return m_aCommands.size();
     }
@@ -140,7 +140,7 @@ public:
         return m_pConsole->ParseCommandArgs(pArgs, pCom->m_aArgsFormat, pCom->m_pfnCallback, &Context);
     }
 
-    int Filter(array<bool> &aFilter, const char *pStr)
+    int Filter(array<bool> &aFilter, const char *pStr, bool Exact)
     {
         dbg_assert(aFilter.size() == m_aCommands.size(), "filter size must match command count");
         if(!*pStr)
@@ -151,9 +151,15 @@ public:
         }
 
         int Filtered = 0;
-        for(int i = 0; i < m_aCommands.size(); i++)
+        if(Exact)
         {
-            Filtered += (aFilter[i] = str_find_nocase(m_aCommands[i].m_aName, pStr) != m_aCommands[i].m_aName);
+            for(int i = 0; i < m_aCommands.size(); i++)
+                Filtered += (aFilter[i] = str_comp(m_aCommands[i].m_aName, pStr));
+        }
+        else
+        {
+            for(int i = 0; i < m_aCommands.size(); i++)
+                Filtered += (aFilter[i] = str_find_nocase(m_aCommands[i].m_aName, pStr) != m_aCommands[i].m_aName);
         }
 
         return Filtered;


### PR DESCRIPTION
Relying on the UI `m_SelectedCommand` for executing commands was a bad idea to start with, if you typed `/wh` then backspace + space to get to `/w ` whisper would still be executed instead of w. In other words executing commands that are a superstring of other commands was tough to use.

I also reverted the instant whisper as per #2525 and fixed a small UI oddity.

Sorry this feature turned out such a mess, missed a little too much