### PR TITLE
Extend comment to include world deaths

### DIFF
--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -221,7 +221,7 @@ int IGameController::OnCharacterDeath(CCharacter *pVictim, CPlayer *pKiller, int
 	if(!pKiller || Weapon == WEAPON_GAME)
 		return 0;
 	if(pKiller == pVictim->GetPlayer())
-		pVictim->GetPlayer()->m_Score--; // suicide
+		pVictim->GetPlayer()->m_Score--; // suicide or world
 	else
 	{
 		if(IsTeamplay() && pVictim->GetPlayer()->GetTeam() == pKiller->GetTeam())


### PR DESCRIPTION
lmao just spend 30 minutes searching the code that decrements score on world death and this comment made me skip that line every time :rage: 