### PR TITLE
Add a fallback for broken servers

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -525,7 +525,12 @@ void CChat::SendServerCommand(const char *pCommand, const char *pArgs)
 {
 	CNetMsg_Cl_Command Msg;
 	Msg.m_Name = pCommand;
-	Msg.m_Arguments = pArgs;
+
+	//TODO 0.8: don't send pCommand twice
+	char aBuf[128];
+	str_format(aBuf, sizeof(aBuf), "/%s%s%s", pCommand, pArgs[0] ? " " : "", pArgs);
+	Msg.m_Arguments = aBuf;
+
 	Client()->SendPackMsg(&Msg, MSGFLAG_VITAL);
 }
 

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -97,6 +97,7 @@ class CChat : public CComponent
 	void HandleCommands(float x, float y, float w);
 	bool ExecuteCommand();
 	bool CompleteCommand();
+	void SendServerCommand(const char *pCommand, const char *pArgs);
 
 	static void Com_All(IConsole::IResult *pResult, void *pContext);
 	static void Com_Team(IConsole::IResult *pResult, void *pContext);


### PR DESCRIPTION
This was supposed to fix #2573, but turns out the server doesn't even handle command messages at all. I don't think a fallback to a chat message is desirable here, but it's up to you.

This should still be merged to fix the UI getting stuck on said broken server.