### PR TITLE
Add convenience methods to text renderer that accept the full color (vec4)

### DIFF
--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -52,6 +52,8 @@ public:
 	// old foolish interface
 	virtual void TextColor(float r, float g, float b, float a) = 0;
 	virtual void TextOutlineColor(float r, float g, float b, float a) = 0;
+	inline void TextColor(const vec4 *pColor) { TextColor(pColor->r, pColor->g, pColor->b, pColor->a); }
+	inline void TextOutlineColor(const vec4 *pColor) { TextOutlineColor(pColor->r, pColor->g, pColor->b, pColor->a); }
 	virtual void Text(void *pFontSetV, float x, float y, float Size, const char *pText, float LineWidth, bool MultiLine=true) = 0;
 	virtual float TextWidth(void *pFontSetV, float Size, const char *pText, int StrLength, float LineWidth) = 0;
 	virtual int TextLineCount(void *pFontSetV, float Size, const char *pText, float LineWidth) = 0;

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -52,8 +52,8 @@ public:
 	// old foolish interface
 	virtual void TextColor(float r, float g, float b, float a) = 0;
 	virtual void TextOutlineColor(float r, float g, float b, float a) = 0;
-	inline void TextColor(const vec4 *pColor) { TextColor(pColor->r, pColor->g, pColor->b, pColor->a); }
-	inline void TextOutlineColor(const vec4 *pColor) { TextOutlineColor(pColor->r, pColor->g, pColor->b, pColor->a); }
+	inline void TextColor(const vec4 &Color) { TextColor(Color.r, Color.g, Color.b, Color.a); }
+	inline void TextOutlineColor(const vec4 &Color) { TextOutlineColor(Color.r, Color.g, Color.b, Color.a); }
 	virtual void Text(void *pFontSetV, float x, float y, float Size, const char *pText, float LineWidth, bool MultiLine=true) = 0;
 	virtual float TextWidth(void *pFontSetV, float Size, const char *pText, int StrLength, float LineWidth) = 0;
 	virtual int TextLineCount(void *pFontSetV, float Size, const char *pText, float LineWidth) = 0;

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1298,8 +1298,8 @@ void CChat::OnRender()
 
 		if(pLine->m_Highlighted)
 		{
-			TextRender()->TextColor(&TextColor);
-			TextRender()->TextOutlineColor(&ColorHighlightOutline);
+			TextRender()->TextColor(TextColor);
+			TextRender()->TextOutlineColor(ColorHighlightOutline);
 			TextRender()->TextEx(&Cursor, pLine->m_aText, -1);
 		}
 		else

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1298,13 +1298,8 @@ void CChat::OnRender()
 
 		if(pLine->m_Highlighted)
 		{
-			TextRender()->TextColor(TextColor.r, TextColor.g, TextColor.b, TextColor.a);
-
-			TextRender()->TextOutlineColor(ColorHighlightOutline.r,
-										   ColorHighlightOutline.g,
-										   ColorHighlightOutline.b,
-										   ColorHighlightOutline.a);
-
+			TextRender()->TextColor(&TextColor);
+			TextRender()->TextOutlineColor(&ColorHighlightOutline);
 			TextRender()->TextEx(&Cursor, pLine->m_aText, -1);
 		}
 		else


### PR DESCRIPTION
Makes it much more convenient to use in the case where you would have to pass all 4 parameters of an already existing vec4 variable.

Refactors usage in chat.cpp for demonstration. The menus would have more of it, but now that it's there, usage can be adapted incrementally IMO.
