### PR TITLE
Don't add commands with malformed arglists. Fix #2573

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -83,6 +83,7 @@ public:
 	virtual void Chain(const char *pName, FChainCommandCallback pfnChainFunc, void *pUser) = 0;
 	virtual void StoreCommands(bool Store) = 0;
 
+	virtual bool ArgStringIsValid(const char *pFormat) = 0;
 	virtual bool LineIsValid(const char *pStr) = 0;
 	virtual void ExecuteLine(const char *pStr) = 0;
 	virtual void ExecuteLineFlag(const char *pStr, int FlagMask) = 0;

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -86,6 +86,41 @@ int CConsole::ParseStart(CResult *pResult, const char *pString, int Length)
 	return 0;
 }
 
+bool CConsole::ArgStringIsValid(const char *pFormat)
+{
+	char Command = *pFormat;
+	bool Valid = true;
+	bool Last = false;
+
+	while(Valid)
+	{
+		if(!Command)
+			break;
+
+		if(Last && *pFormat)
+			return false;
+
+		if(Command == '?')
+		{
+			if(!pFormat[1])
+				return false;
+		}
+		else
+		{
+			if(Command == 'i' || Command == 'f' || Command == 's')
+				;
+			else if(Command == 'r')
+				Last = true;
+			else
+				return false;
+		}
+
+		Valid = !NextParam(&Command, pFormat);
+	}
+
+	return Valid;
+}
+
 int CConsole::ParseArgs(CResult *pResult, const char *pFormat)
 {
 	char Command = *pFormat;
@@ -95,7 +130,7 @@ int CConsole::ParseArgs(CResult *pResult, const char *pFormat)
 
 	pStr = pResult->m_pArgsStart;
 
-	while(1)
+	while(!Error)
 	{
 		if(!Command)
 			break;
@@ -173,13 +208,13 @@ int CConsole::ParseArgs(CResult *pResult, const char *pFormat)
 		}
 
 		// fetch next command
-		Command = NextParam(pFormat);
+		Error = NextParam(&Command, pFormat);
 	}
 
 	return Error;
 }
 
-char CConsole::NextParam(const char *&pFormat)
+bool CConsole::NextParam(char *pNext, const char *&pFormat)
 {
 	if(*pFormat)
 	{
@@ -188,21 +223,19 @@ char CConsole::NextParam(const char *&pFormat)
 		if(*pFormat == '[')
 		{
 			// skip bracket contents
-			for(; *pFormat != ']'; pFormat++)
-			{
-				if (!*pFormat)
-					return *pFormat;
-			}
+			pFormat += str_span(pFormat, "]");
+			if(!*pFormat)
+				return true;
 
 			// skip ']'
 			pFormat++;
-
-			// skip space if there is one
-			if (*pFormat == ' ')
-				pFormat++;
 		}
+
+		// skip space if there is one
+		pFormat = str_skip_whitespaces_const(pFormat);
 	}
-	return *pFormat;
+	*pNext = *pFormat;
+	return false;
 }
 
 int CConsole::ParseCommandArgs(const char *pArgs, const char *pFormat, FCommandCallback pfnCallback, void *pContext)

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -125,12 +125,12 @@ class CConsole : public IConsole
 
 	/*
 	This function will set pFormat to the next parameter (i,s,r,v,?) it contains and
-	return the parameter.
+	pNext to the command.
 	Descriptions in brackets like [file] will be skipped.
-	Returns '\0' if there is no next parameter.
+	Returns true on failure.
 	Expects pFormat to point at a parameter.
 	*/
-	char NextParam(const char *&pFormat);
+	bool NextParam(char *pNext, const char *&pFormat);
 
 	class CExecutionQueue
 	{
@@ -196,6 +196,7 @@ public:
 	virtual void Chain(const char *pName, FChainCommandCallback pfnChainFunc, void *pUser);
 	virtual void StoreCommands(bool Store);
 
+	virtual bool ArgStringIsValid(const char *pFormat);
 	virtual bool LineIsValid(const char *pStr);
 	virtual void ExecuteLine(const char *pStr);
 	virtual void ExecuteLineFlag(const char *pStr, int FlagMask);

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -548,6 +548,9 @@ void CChat::OnMessage(int MsgType, void *pRawMsg)
 		CNetMsg_Sv_CommandInfo *pMsg = (CNetMsg_Sv_CommandInfo *)pRawMsg;
 		if(!m_CommandManager.AddCommand(pMsg->m_Name, pMsg->m_HelpText, pMsg->m_ArgsFormat, ServerCommandCallback, this))
 			dbg_msg("chat_commands", "adding server chat command: name='%s' args='%s' help='%s'", pMsg->m_Name, pMsg->m_ArgsFormat, pMsg->m_HelpText);
+		else
+			dbg_msg("chat-commands", "failed to add command '%s'", pMsg->m_Name);
+
 	}
 	else if(MsgType == NETMSGTYPE_SV_COMMANDINFOREMOVE)
 	{

--- a/src/game/commands.h
+++ b/src/game/commands.h
@@ -87,6 +87,9 @@ public:
         if(pCom)
             return 1;
 
+        if(!m_pConsole->ArgStringIsValid(pArgsFormat))
+            return 1;
+
         int Index = m_aCommands.add(CCommand(pCommand, pHelpText, pArgsFormat, pfnCallback, pContext));
         if(m_pfnNewCommandHook)
             m_pfnNewCommandHook(&m_aCommands[Index], m_pHookContext);


### PR DESCRIPTION
I tested this for about an hour, it correctly discards the malformed commands on fng2.
It passes the testcases I could think of + the ones we already have in the code.