### PR TITLE
Quote names in chat commands (closed #2525)

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -387,7 +387,7 @@ bool CChat::OnInput(IInput::CEvent Event)
 
 				// quote the name
 				char aQuoted[MAX_NAME_LENGTH+2];
-				if(IsTypingCommand() && *str_skip_to_whitespace_const(pCompletionString) != '\0')
+				if(IsTypingCommand() && str_find(pCompletionString, " "))
 				{
 					str_format(aQuoted, sizeof(aQuoted), "\"%s\"", pCompletionString);
 					pCompletionString = aQuoted;

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -385,6 +385,14 @@ bool CChat::OnInput(IInput::CEvent Event)
 				// add part before the name
 				str_truncate(aBuf, sizeof(aBuf), m_Input.GetString(), m_PlaceholderOffset);
 
+				// quote the name
+				char aQuoted[MAX_NAME_LENGTH+2];
+				if(IsTypingCommand() && *str_skip_to_whitespace_const(pCompletionString) != '\0')
+				{
+					str_format(aQuoted, sizeof(aQuoted), "\"%s\"", pCompletionString);
+					pCompletionString = aQuoted;
+				}
+
 				// add the name
 				str_append(aBuf, pCompletionString, sizeof(aBuf));
 


### PR DESCRIPTION
Fixes broken whisper for me. Also is nice for custom commands that use names. Since the old name system without duplicates is enforced already on some servers they would benefit from proper quoting if needed.

It only quotes in command mode and only names that need it:
![image](https://user-images.githubusercontent.com/20344300/79732614-3ae5ef00-82f4-11ea-9fc1-e2d47b027871.png)

![image](https://user-images.githubusercontent.com/20344300/79732647-4507ed80-82f4-11ea-8ded-faee6ad96694.png)

![image](https://user-images.githubusercontent.com/20344300/79732669-4c2efb80-82f4-11ea-89d4-6f22373a3175.png)
