### PR TITLE
make chat logs backwards compatible

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -192,15 +192,15 @@ void CGameContext::CreateSound(vec2 Pos, int Sound, int64 Mask)
 void CGameContext::SendChat(int ChatterClientID, int Mode, int To, const char *pText)
 {
 	char aBuf[256];
-	if(ChatterClientID >= 0 && ChatterClientID < MAX_CLIENTS)
+	if(0 <= ChatterClientID && ChatterClientID < MAX_CLIENTS)
 	{
 		if(Mode == CHAT_TEAM)
 		{
 			int TeamID = m_apPlayers[ChatterClientID]->GetTeam();
-			str_format(aBuf, sizeof(aBuf), "%d:%d:%d:%s: %s", Mode, TeamID, ChatterClientID, Server()->ClientName(ChatterClientID), pText);
+			str_format(aBuf, sizeof(aBuf), "%d:%d:%d:%s: %s", TeamID, ChatterClientID, Mode, Server()->ClientName(ChatterClientID), pText);
 		}
 		else
-			str_format(aBuf, sizeof(aBuf), "%d:%d:%s: %s", Mode, ChatterClientID, Server()->ClientName(ChatterClientID), pText);
+			str_format(aBuf, sizeof(aBuf), "%d:%d:%s: %s", ChatterClientID, Mode, Server()->ClientName(ChatterClientID), pText);
 	}
 	else
 		str_format(aBuf, sizeof(aBuf), "*** %s", pText);


### PR DESCRIPTION
keep the same order of integer values, just prefix the newly added `teamID`

This allows for old regular expressions to be easily adapted:

https://regex101.com/r/N8IyEf/1
 
Python/Golang regex: 
```
(([\d]+):)?([\d]+):([\d]+):(.{0,20}): (.*)$
```

```

// TeamID, ClientID, Mode, PlayerName, Text
//%d:%d:%d:%s: %s - team chat

0:63:1:Günther: hey popelz

// ClientID, Mode, PlayerName, Text
// %d:%d:%s: %s - global chat - previous & current format

63:1:Günther: hey popelz


// this parsing can be split in two regular expressons if needed.

// Group 1 can be ignored
// Group 2 contains the teamID (I guess it's None type when there is no teamID)
// Group 3: ClientID
// Group 4: Mode
// Group 5: Nickname
// Group 6: Text message
```

