### PR TITLE
Chat history improvements. Fix #2588

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -251,6 +251,7 @@ bool CChat::OnInput(IInput::CEvent Event)
 		}
 		else
 		{
+			m_pHistoryEntry = 0x0;
 			m_Mode = CHAT_NONE;
 			m_pClient->OnRelease();
 		}
@@ -427,7 +428,7 @@ bool CChat::OnInput(IInput::CEvent Event)
 
 	if(Event.m_Flags&IInput::FLAG_PRESS && Event.m_Key == KEY_UP)
 	{
-		if(IsTypingCommand())
+		if(IsTypingCommand() && !m_pHistoryEntry)
 		{
 			PreviousActiveCommand(&m_SelectedCommand);
 			if(m_SelectedCommand < 0)
@@ -451,7 +452,7 @@ bool CChat::OnInput(IInput::CEvent Event)
 	}
 	else if (Event.m_Flags&IInput::FLAG_PRESS && Event.m_Key == KEY_DOWN)
 	{
-		if(IsTypingCommand())
+		if(IsTypingCommand() && !m_pHistoryEntry)
 		{
 			NextActiveCommand(&m_SelectedCommand);
 			if(m_SelectedCommand >= m_CommandManager.CommandCount())
@@ -530,6 +531,7 @@ void CChat::ServerCommandCallback(IConsole::IResult *pResult, void *pContext)
 	Msg.m_Arguments = pComContext->m_pArgs;
 	pChatData->Client()->SendPackMsg(&Msg, MSGFLAG_VITAL);
 
+	pChatData->m_pHistoryEntry = 0x0;
 	pChatData->m_Mode = CHAT_NONE;
 	pChatData->m_pClient->OnRelease();
 }


### PR DESCRIPTION
This has been a problem since 0.7.4 however it went unnoticed because it was fairly uncommon to send messages that start with a /.

This also fixes #2588, it's not that the history entry wasn't added but that when closing the chat I forgot to clear the current history entry. (closing the chat maybe should be refactored into a function)

I'm not sure if we should actually fix it like this though, maybe it should be fixed as part of #2568? Could implement different types of history entries so we can also separate whispers from normal messages as part of a larger refactor.