### PR TITLE
Fix macOS SDL2 issues

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -88,10 +88,10 @@ public:
 	virtual void AutoStatScreenshot_Start() = 0;
 	virtual void AutoScreenshot_Start() = 0;
 	virtual void ServerBrowserUpdate() = 0;
-	
+
 	// gfx
 	virtual void SwitchWindowScreen(int Index) = 0;
-	virtual void ToggleFullscreen() = 0;
+	virtual bool ToggleFullscreen() = 0;
 	virtual void ToggleWindowBordered() = 0;
 	virtual void ToggleWindowVSync() = 0;
 
@@ -130,7 +130,7 @@ public:
 	virtual const void *SnapFindItem(int SnapID, int Type, int ID) const = 0;
 	virtual const void *SnapGetItem(int SnapID, int Index, CSnapItem *pItem) const = 0;
 	virtual void SnapInvalidateItem(int SnapID, int Index) = 0;
-	
+
 	virtual void *SnapNewItem(int Type, int ID, int Size) = 0;
 
 	virtual void SnapSetStaticsize(int ItemType, int Size) = 0;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -740,7 +740,6 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *pScreen, int *pWin
 	}
 
 	SDL_GetWindowSize(m_pWindow, pWindowWidth, pWindowHeight);
-	SDL_GL_GetDrawableSize(m_pWindow, pScreenWidth, pScreenHeight); // drawable size may differ in high dpi mode
 
 	// create gl context
 	m_GLContext = SDL_GL_CreateContext(m_pWindow);
@@ -749,6 +748,8 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *pScreen, int *pWin
 		dbg_msg("gfx", "unable to create OpenGL context: %s", SDL_GetError());
 		return -1;
 	}
+
+	SDL_GL_GetDrawableSize(m_pWindow, pScreenWidth, pScreenHeight); // drawable size may differ in high dpi mode
 
 	#if defined(CONF_FAMILY_WINDOWS)
 		glTexImage3DInternal = (PFNGLTEXIMAGE3DPROC) wglGetProcAddress("glTexImage3D");

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -699,9 +699,11 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *pScreen, int *pWin
 		SdlFlags |= SDL_WINDOW_BORDERLESS;
 	if(Flags&IGraphicsBackend::INITFLAG_FULLSCREEN)
 #if defined(CONF_PLATFORM_MACOSX)	// Todo SDL: remove this when fixed (game freezes when losing focus in fullscreen)
+	{
 		SdlFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;	// always use "fake" fullscreen
-	*pWindowWidth = *pDesktopWidth;
-	*pWindowHeight = *pDesktopHeight;
+		*pWindowWidth = *pDesktopWidth;
+		*pWindowHeight = *pDesktopHeight;
+	}
 #else
 		SdlFlags |= SDL_WINDOW_FULLSCREEN;
 #endif

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2439,10 +2439,16 @@ void CClient::ConchainWindowScreen(IConsole::IResult *pResult, void *pUserData, 
 		pfnCallback(pResult, pCallbackUserData);
 }
 
-void CClient::ToggleFullscreen()
+bool CClient::ToggleFullscreen()
 {
+#ifndef CONF_PLATFORM_MACOSX
 	if(Graphics()->Fullscreen(Config()->m_GfxFullscreen^1))
 		Config()->m_GfxFullscreen ^= 1;
+	return true;
+#else
+	Config()->m_GfxFullscreen ^= 1;
+	return false;
+#endif
 }
 
 void CClient::ConchainFullscreen(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -326,7 +326,7 @@ public:
 
 	// gfx
 	void SwitchWindowScreen(int Index);
-	void ToggleFullscreen();
+	bool ToggleFullscreen();
 	void ToggleWindowBordered();
 	void ToggleWindowVSync();
 };

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1643,6 +1643,10 @@ bool CMenus::DoResolutionList(CUIRect* pRect, CListBox* pListBox,
 void CMenus::RenderSettingsGraphics(CUIRect MainView)
 {
 	bool CheckSettings = false;
+	bool CheckFullscreen = false;
+	#ifdef CONF_PLATFORM_MACOSX
+	CheckFullscreen = true;
+	#endif
 
 	static int s_GfxFullscreen = Config()->m_GfxFullscreen;
 	static int s_GfxScreenWidth = Config()->m_GfxScreenWidth;
@@ -1904,10 +1908,8 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 			s_GfxScreenHeight == Config()->m_GfxScreenHeight &&
 			s_GfxFsaaSamples == Config()->m_GfxFsaaSamples &&
 			s_GfxTextureQuality == Config()->m_GfxTextureQuality &&
-			s_GfxTextureCompression == Config()->m_GfxTextureCompression
-			#ifdef CONF_PLATFORM_MACOSX
-				&& s_GfxFullscreen == Config()->m_GfxFullscreen
-			#endif
+			s_GfxTextureCompression == Config()->m_GfxTextureCompression &&
+			(!CheckFullscreen || s_GfxFullscreen == Config()->m_GfxFullscreen)
 			)
 			m_NeedRestartGraphics = false;
 		else

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1001,7 +1001,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	if(DoButton_CheckBox(&s_EnableColoredBroadcasts, Localize("Enable colored server broadcasts"),
 						 Config()->m_ClColoredBroadcast, &Button))
 		Config()->m_ClColoredBroadcast ^= 1;
-	
+
 	GameRight.HSplitTop(Spacing, 0, &GameRight);
 	GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
 	static int s_DisableWhisperFeature = 0;
@@ -1644,6 +1644,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 {
 	bool CheckSettings = false;
 
+	static int s_GfxFullscreen = Config()->m_GfxFullscreen;
 	static int s_GfxScreenWidth = Config()->m_GfxScreenWidth;
 	static int s_GfxScreenHeight = Config()->m_GfxScreenHeight;
 	static int s_GfxFsaaSamples = Config()->m_GfxFsaaSamples;
@@ -1692,7 +1693,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	ScreenLeft.HSplitTop(ButtonHeight, &Button, &ScreenLeft);
 	static int s_ButtonGfxFullscreen = 0;
 	if(DoButton_CheckBox(&s_ButtonGfxFullscreen, Localize("Fullscreen"), Config()->m_GfxFullscreen, &Button))
-		Client()->ToggleFullscreen();
+		CheckSettings |= !Client()->ToggleFullscreen();
 
 	if(!Config()->m_GfxFullscreen)
 	{
@@ -1903,7 +1904,11 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 			s_GfxScreenHeight == Config()->m_GfxScreenHeight &&
 			s_GfxFsaaSamples == Config()->m_GfxFsaaSamples &&
 			s_GfxTextureQuality == Config()->m_GfxTextureQuality &&
-			s_GfxTextureCompression == Config()->m_GfxTextureCompression)
+			s_GfxTextureCompression == Config()->m_GfxTextureCompression
+			#ifdef CONF_PLATFORM_MACOSX
+				&& s_GfxFullscreen == Config()->m_GfxFullscreen
+			#endif
+			)
 			m_NeedRestartGraphics = false;
 		else
 			m_NeedRestartGraphics = true;


### PR DESCRIPTION
I couldn't test the usage of ToggleFullscreen in changing screens (I don't have an extra screen)

This fixes a bug on macOS 10.13 where the NSView won't realise the window is supposed to not be high-dpi until we create a context. It also allows people to start the game in windowed mode at any resolution.

With SDL 2.0.13 we'll be able to get rid of the forced restart when toggling.