### PR TITLE
fixed system.c compile need option -std=c99/gnu99

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2325,7 +2325,8 @@ int mem_comp(const void *a, const void *b, int size)
 int mem_has_null(const void *block, unsigned size)
 {
 	const unsigned char *bytes = block;
-	for(unsigned i = 0; i < size; i++)
+	unsigned i;        
+	for(i = 0; i < size; i++)
 	{
 		if(bytes[i] == 0)
 		{


### PR DESCRIPTION
when I build teeworlds with gcc4.9.2 and cmake 3.0.2 get the following errors
`/home/loongson/Work/teeworlds/src/base/system.c:2328:2: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
  for(unsigned i = 0; i < size; i++)
  ^
/home/loongson/Work/teeworlds/src/base/system.c:2328:2: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
CMakeFiles/engine-shared.dir/build.make:884: recipe for target 'CMakeFiles/engine-shared.dir/src/base/system.c.o' failed
make[2]: *** [CMakeFiles/engine-shared.dir/src/base/system.c.o] Error 1
CMakeFiles/Makefile2:92: recipe for target 'CMakeFiles/engine-shared.dir/all' failed
make[1]: *** [CMakeFiles/engine-shared.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2`
I check the all the code，only this code written like this，so I fixed it and compiled successfully。