### PR TITLE
Add forward/backward skipping to demo player, refactoring

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -97,8 +97,6 @@ private:
 
 	float ButtonFade(CButtonContainer *pBC, float Seconds, int Checked=0);
 
-
-	int DoButton_DemoPlayer(CButtonContainer *pBC, const char *pText, const CUIRect *pRect);
 	int DoButton_SpriteID(CButtonContainer *pBC, int ImageID, int SpriteID, bool Checked, const CUIRect *pRect, int Corners=CUI::CORNER_ALL, float r=5.0f, bool Fade=true);
 	int DoButton_SpriteClean(int ImageID, int SpriteID, const CUIRect *pRect);
 	int DoButton_SpriteCleanID(const void *pID, int ImageID, int SpriteID, const CUIRect *pRect, bool Blend=true);
@@ -471,6 +469,16 @@ private:
 		bool m_InfosLoaded;
 		bool m_Valid;
 		CDemoHeader m_Info;
+
+		int GetMarkerCount() const
+		{
+			if(!m_Valid || !m_InfosLoaded)
+				return -1;
+			return ((m_Info.m_aNumTimelineMarkers[0]<<24)&0xFF000000) |
+				((m_Info.m_aNumTimelineMarkers[1]<<16)&0xFF0000) |
+				((m_Info.m_aNumTimelineMarkers[2]<<8)&0xFF00) |
+				(m_Info.m_aNumTimelineMarkers[3]&0xFF);
+		}
 
 		bool operator<(const CDemoItem &Other) const
 		{


### PR DESCRIPTION
- Add skipping forwards and backwards in the demo player:
  - Left/Right arrow keys go backwards/forwards 5 seconds. Holding down Shift changes this duration to 30 seconds.
    - IMO this is a good compromise for both short and long demos.
  - Ctrl+Left/Right skips to the previous/next demo marker (or the beginning/end of the demo if no more markers).
  - Using Ctrl to toggle the seekbar still works as before (had to be slightly changed to work thou). Skipping in general also makes the seekbar visible for 5 seconds.
  - There is no UI for skipping. Other video players (YouTube, VLC) also have no UI. Even if, I don't think anyone would want click a button 10 times instead of holding down an arrow key.
- Replace the single usage of `DoButton_DemoPlayer` for the "Close" button by `DoButton_Menu`.
  - Reduces the number of special button functions needed.
  - Button color is now consistent with the other demo player buttons (was light grey before):
![screenshot_2020-04-27_12-27-59](https://user-images.githubusercontent.com/23437060/80591170-821f5e80-8a1d-11ea-9ae4-7b3fb162e8e2.png)
- Move `DemoGetMarkerCount` to `CDemoItem::GetMarkerCount`.
- Remove unnecessary `s_SeekBarID`.