### PR TITLE
[bind] remove unneeded space at the end of string

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -437,7 +437,7 @@ void CBinds::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
 		if(pSelf->m_aaaKeyBindings[Key][Modifier][0] == 0)
 		{
 			// explicitly unbind keys that were unbound by the user
-			str_format(aBuffer, sizeof(aBuffer), "unbind %s%s ", GetModifierName(Modifier), pSelf->Input()->KeyName(Key));
+			str_format(aBuffer, sizeof(aBuffer), "unbind %s%s", GetModifierName(Modifier), pSelf->Input()->KeyName(Key));
 			pConfigManager->WriteLine(aBuffer);
 		}
 	}

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -411,7 +411,7 @@ void CBinds::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
 			if(pSelf->m_aaaKeyBindings[i][m][0] == 0)
 				continue;
 
-			str_format(aBuffer, sizeof(aBuffer), "bind %s%s ", GetModifierName(m), pSelf->Input()->KeyName(i));
+			str_format(aBuffer, sizeof(aBuffer), "bind %s%s", GetModifierName(m), pSelf->Input()->KeyName(i));
 
 			// process the string. we need to escape some characters
 			const char *pSrc = pSelf->m_aaaKeyBindings[i][m];


### PR DESCRIPTION
Hello. This PR fixes some cosmetic issue I had with my config. There is whitespace at the end every unbind line!

There seems to be something similar here
https://github.com/teeworlds/teeworlds/blob/master/src/game/client/components/binds.cpp#L414
and here
https://github.com/teeworlds/teeworlds/blob/0.6/src/game/client/components/binds.cpp#L225
but I don't see any whitespace on other lines so I left it as it is.