### PR TITLE
Improve initial loading rendering, improve loading smoothness

### DIFF
--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -132,7 +132,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 
 int CCountryFlags::GetInitAmount() const
 {
-	return 15;
+	return 10;
 }
 
 void CCountryFlags::OnInit()
@@ -140,7 +140,6 @@ void CCountryFlags::OnInit()
 	// load country flags
 	m_aCountryFlags.clear();
 	LoadCountryflagsIndexfile();
-	m_pClient->m_pMenus->RenderLoading(5);
 	if(!m_aCountryFlags.size())
 	{
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "countryflags", "failed to load country flags. folder='countryflags/'");

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -38,9 +38,6 @@ void CMapLayers::OnStateChange(int NewState, int OldState)
 
 void CMapLayers::LoadBackgroundMap()
 {
-	if(!Config()->m_ClShowMenuMap)
-		return;
-
 	int HourOfTheDay = time_houroftheday();
 	char aBuf[128];
 	// check for the appropriate day/night map
@@ -73,7 +70,7 @@ void CMapLayers::LoadBackgroundMap()
 int CMapLayers::GetInitAmount() const
 {
 	if(m_Type == TYPE_BACKGROUND)
-		return 15;
+		return 1 + (Config()->m_ClShowMenuMap ? 14 : 0);
 	return 0;
 }
 
@@ -84,8 +81,11 @@ void CMapLayers::OnInit()
 		m_pMenuLayers = new CLayers;
 		m_pMenuMap = CreateEngineMap();
 		m_pClient->m_pMenus->RenderLoading(1);
-		LoadBackgroundMap();
-		m_pClient->m_pMenus->RenderLoading(14);
+		if(Config()->m_ClShowMenuMap)
+		{
+			LoadBackgroundMap();
+			m_pClient->m_pMenus->RenderLoading(14);
+		}
 	}
 
 	m_pEggTiles = 0;
@@ -531,7 +531,7 @@ void CMapLayers::BackgroundMapUpdate()
 	{
 		// unload map
 		m_pMenuMap->Unload();
-
-		LoadBackgroundMap();
+		if(Config()->m_ClShowMenuMap)
+			LoadBackgroundMap();
 	}
 }

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1345,14 +1345,7 @@ void CMenus::RenderBackButton(CUIRect MainView)
 	}
 }
 
-int CMenus::MenuImageCountingScan(const char *pName, int IsDir, int DirType, void *pUser)
-{
-	if(!IsDir && str_endswith(pName, ".png"))
-		(*(int *)pUser)++;
-	return 0;
-}
-
-int CMenus::MenuImageLoadingScan(const char *pName, int IsDir, int DirType, void *pUser)
+int CMenus::MenuImageScan(const char *pName, int IsDir, int DirType, void *pUser)
 {
 	CMenus *pSelf = (CMenus *)pUser;
 	if(IsDir || !str_endswith(pName, ".png"))
@@ -1478,9 +1471,7 @@ void CMenus::UpdateVideoModeSettings()
 
 int CMenus::GetInitAmount() const
 {
-	int NumMenuImages = 0;
-	Storage()->ListDirectory(IStorage::TYPE_ALL, "ui/menuimages", MenuImageCountingScan, &NumMenuImages);
-
+	const int NumMenuImages = 5;
 	return 6 + 5 * NumMenuImages;
 }
 
@@ -1494,7 +1485,7 @@ void CMenus::OnInit()
 
 	// load menu images
 	m_lMenuImages.clear();
-	Storage()->ListDirectory(IStorage::TYPE_ALL, "ui/menuimages", MenuImageLoadingScan, this);
+	Storage()->ListDirectory(IStorage::TYPE_ALL, "ui/menuimages", MenuImageScan, this);
 
 	// load filters
 	LoadFilters();

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -374,8 +374,7 @@ private:
 	};
 	array<CMenuImage> m_lMenuImages;
 
-	static int MenuImageCountingScan(const char *pName, int IsDir, int DirType, void *pUser);
-	static int MenuImageLoadingScan(const char *pName, int IsDir, int DirType, void *pUser);
+	static int MenuImageScan(const char *pName, int IsDir, int DirType, void *pUser);
 
 	const CMenuImage *FindMenuImage(const char* pName);
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -374,7 +374,8 @@ private:
 	};
 	array<CMenuImage> m_lMenuImages;
 
-	static int MenuImageScan(const char *pName, int IsDir, int DirType, void *pUser);
+	static int MenuImageCountingScan(const char *pName, int IsDir, int DirType, void *pUser);
+	static int MenuImageLoadingScan(const char *pName, int IsDir, int DirType, void *pUser);
 
 	const CMenuImage *FindMenuImage(const char* pName);
 

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -212,7 +212,7 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 
 int CSkins::GetInitAmount() const
 {
-	return NUM_SKINPARTS*2 + 8;
+	return NUM_SKINPARTS*5 + 8;
 }
 
 void CSkins::OnInit()
@@ -265,7 +265,8 @@ void CSkins::OnInit()
 			DummySkinPart.m_BloodColor = vec3(1.0f, 1.0f, 1.0f);
 			m_aaSkinParts[p].add(DummySkinPart);
 		}
-		m_pClient->m_pMenus->RenderLoading(2);
+
+		m_pClient->m_pMenus->RenderLoading(5);
 	}
 
 	// create dummy skin

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -346,10 +346,10 @@ void CGameClient::OnInit()
 	int64 Start = time_get();
 
 	// Render load screen at 0% to get graphics sooner.
-	// Render twice to clear front and back buffers and minimize initial flashing color.
+	// Swap again to minimize initial flashing color.
 	m_pMenus->InitLoading(1);
 	m_pMenus->RenderLoading();
-	m_pMenus->RenderLoading();
+	m_pGraphics->Swap();
 
 	// TODO: this should be different
 	// setup item sizes


### PR DESCRIPTION
- Render the loading screen sooner and more often. Closes #2606.
   - At the beginning the loading screen is rendered at 0% twice to clear front & backbuffer properly. This mostly prevents the black flash at the beginning. What remains is one short period of black screen, but that happens with every fullscreen application.
   - Remove the `!Graphics()->IsIdle()` check, which was causing few frames to be rendered and sometimes prevented the initial rendering. This will slightly increase loading time.
   - Loading the font and localization moved after initializing the loading screen. First few frames will be rendered without the text therefore.
 - Tweak some loading amounts to smooth the loading progress even more.
    - Check whether background map is supposed to be loaded at all.
    - Count the menu images before loading all of them.
- Minor refactoring.