### PR TITLE
Fix important server browser message overflow

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1233,28 +1233,6 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		}
 	}
 
-	// display important messages in the middle of the screen so no user misses it
-	{
-		const char *pImportantMessage = NULL;
-		if(m_ActivePage == PAGE_INTERNET && ServerBrowser()->IsRefreshingMasters())
-			pImportantMessage = Localize("Refreshing master servers");
-		else if(SelectedFilter == -1)
-			pImportantMessage = Localize("No filter category is selected");
-		else if(ServerBrowser()->IsRefreshing() && !NumServers)
-			pImportantMessage = Localize("Fetching server info");
-		else if(!ServerBrowser()->NumServers())
-			pImportantMessage = Localize("No servers found");
-		else if(ServerBrowser()->NumServers() && !NumServers)
-			pImportantMessage = Localize("No servers match your filter criteria");
-
-		if(pImportantMessage)
-		{
-			CUIRect MsgBox = View;
-			MsgBox.y += View.h/3;
-			UI()->DoLabel(&MsgBox, pImportantMessage, 16.0f, CUI::ALIGN_CENTER);
-		}
-	}
-
 	// scrollbar
 	static CScrollRegion s_ScrollRegion;
 	vec2 ScrollOffset(0, 0);
@@ -1363,6 +1341,32 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	{
 		UpdateServerBrowserAddress();
 		m_AddressSelection &= ~ADDR_SELECTION_UPDATE_ADDRESS;
+	}
+
+	// display important messages in the middle of the screen so no user misses it
+	if(!NumServers)
+	{
+		CUIRect MsgBox = View;
+		if(MsgBox.h < 50.0f)
+			MsgBox.h = 50.0f;
+		s_ScrollRegion.AddRect(MsgBox);
+		if(!s_ScrollRegion.IsRectClipped(MsgBox))
+		{
+			const char *pImportantMessage;
+			if(m_ActivePage == PAGE_INTERNET && ServerBrowser()->IsRefreshingMasters())
+				pImportantMessage = Localize("Refreshing master servers");
+			else if(SelectedFilter == -1)
+				pImportantMessage = Localize("No filter category is selected");
+			else if(ServerBrowser()->IsRefreshing())
+				pImportantMessage = Localize("Fetching server info");
+			else if(!ServerBrowser()->NumServers())
+				pImportantMessage = Localize("No servers found");
+			else
+				pImportantMessage = Localize("No servers match your filter criteria");
+
+			MsgBox.y += MsgBox.h/3.0f;
+			UI()->DoLabel(&MsgBox, pImportantMessage, 16.0f, CUI::ALIGN_CENTER);
+		}
 	}
 
 	s_ScrollRegion.End();


### PR DESCRIPTION
- Only show important server browser message if there are no servers. Closes #2616.
- Also fix message overflowing with the closed filter headers when there are many filters, by making the message part of the scroll region. The message is still centered in the remaining space like before. If there is not enough space, the message also scrolls:
![screenshot_2020-05-04_00-39-27](https://user-images.githubusercontent.com/23437060/80927900-20565000-8da1-11ea-8d10-06038e70305e.png)
