### PR TITLE
Add gametype exclusion filter

### DIFF
--- a/src/engine/client/serverbrowser_filter.cpp
+++ b/src/engine/client/serverbrowser_filter.cpp
@@ -32,7 +32,10 @@ CServerBrowserFilter::CServerFilter::CServerFilter()
 	m_FilterInfo.m_Country = 0;
 	m_FilterInfo.m_ServerLevel = 0;
 	for(int i = 0; i < CServerFilterInfo::MAX_GAMETYPES; ++i)
+	{
 		m_FilterInfo.m_aGametype[i][0] = 0;
+		m_FilterInfo.m_aGametypeExclusive[i] = false;
+	}
 	m_FilterInfo.m_aAddress[0] = 0;
 
 	m_NumSortedPlayers = 0;
@@ -60,9 +63,15 @@ CServerBrowserFilter::CServerFilter& CServerBrowserFilter::CServerFilter::operat
 		for(int i = 0; i < CServerFilterInfo::MAX_GAMETYPES; ++i)
 		{
 			if(Other.m_FilterInfo.m_aGametype[i][0])
+			{
 				str_copy(m_FilterInfo.m_aGametype[i], Other.m_FilterInfo.m_aGametype[i], sizeof(m_FilterInfo.m_aGametype[i]));
+				m_FilterInfo.m_aGametypeExclusive[i] = Other.m_FilterInfo.m_aGametypeExclusive[i];
+			}
 			else
+			{
 				m_FilterInfo.m_aGametype[i][0] = 0;
+				m_FilterInfo.m_aGametypeExclusive[i] = false;
+			}
 		}
 		str_copy(m_FilterInfo.m_aAddress, Other.m_FilterInfo.m_aAddress, sizeof(m_FilterInfo.m_aAddress));
 
@@ -135,9 +144,9 @@ void CServerBrowserFilter::CServerFilter::Filter()
 				{
 					if(!m_FilterInfo.m_aGametype[Index][0])
 						break;
-					if(m_FilterInfo.m_aGametype[Index][0] == '-' && m_FilterInfo.m_aGametype[Index][1])
+					if(m_FilterInfo.m_aGametypeExclusive[Index])
 					{
-						if(!str_comp_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aGameType, m_FilterInfo.m_aGametype[Index]+1))
+						if(!str_comp_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aGameType, m_FilterInfo.m_aGametype[Index]))
 						{
 							Excluded = true;
 							break;
@@ -386,7 +395,10 @@ int CServerBrowserFilter::AddFilter(const CServerFilterInfo *pFilterInfo)
 	Filter.m_FilterInfo.m_Country = pFilterInfo->m_Country;
 	Filter.m_FilterInfo.m_ServerLevel = pFilterInfo->m_ServerLevel;
 	for(int i = 0; i < CServerFilterInfo::MAX_GAMETYPES; ++i)
+	{
 		str_copy(Filter.m_FilterInfo.m_aGametype[i], pFilterInfo->m_aGametype[i], sizeof(Filter.m_FilterInfo.m_aGametype[i]));
+		Filter.m_FilterInfo.m_aGametypeExclusive[i] = pFilterInfo->m_aGametypeExclusive[i];
+	}
 	str_copy(Filter.m_FilterInfo.m_aAddress, pFilterInfo->m_aAddress, sizeof(Filter.m_FilterInfo.m_aAddress));
 	Filter.m_pSortedServerlist = 0;
 	Filter.m_NumSortedPlayers = 0;
@@ -406,7 +418,10 @@ void CServerBrowserFilter::GetFilter(int Index, CServerFilterInfo *pFilterInfo) 
 	pFilterInfo->m_Country = pFilter->m_FilterInfo.m_Country;
 	pFilterInfo->m_ServerLevel = pFilter->m_FilterInfo.m_ServerLevel;
 	for(int i = 0; i < CServerFilterInfo::MAX_GAMETYPES; ++i)
+	{
 		str_copy(pFilterInfo->m_aGametype[i], pFilter->m_FilterInfo.m_aGametype[i], sizeof(pFilterInfo->m_aGametype[i]));
+		pFilterInfo->m_aGametypeExclusive[i] = pFilter->m_FilterInfo.m_aGametypeExclusive[i];
+	}
 	str_copy(pFilterInfo->m_aAddress, pFilter->m_FilterInfo.m_aAddress, sizeof(pFilterInfo->m_aAddress));
 }
 
@@ -418,7 +433,10 @@ void CServerBrowserFilter::SetFilter(int Index, const CServerFilterInfo *pFilter
 	pFilter->m_FilterInfo.m_Country = pFilterInfo->m_Country;
 	pFilter->m_FilterInfo.m_ServerLevel = pFilterInfo->m_ServerLevel;
 	for(int i = 0; i < CServerFilterInfo::MAX_GAMETYPES; ++i)
+	{
 		str_copy(pFilter->m_FilterInfo.m_aGametype[i], pFilterInfo->m_aGametype[i], sizeof(pFilter->m_FilterInfo.m_aGametype[i]));
+		pFilter->m_FilterInfo.m_aGametypeExclusive[i] = pFilterInfo->m_aGametypeExclusive[i];
+	}
 	str_copy(pFilter->m_FilterInfo.m_aAddress, pFilterInfo->m_aAddress, sizeof(pFilter->m_FilterInfo.m_aAddress));
 
 	pFilter->Sort();

--- a/src/engine/client/serverbrowser_filter.cpp
+++ b/src/engine/client/serverbrowser_filter.cpp
@@ -130,20 +130,33 @@ void CServerBrowserFilter::CServerFilter::Filter()
 		{
 			if(m_FilterInfo.m_aGametype[0][0])
 			{
-				Filtered = 1;
+				bool Excluded = false, DoInclude = false, Included = false;
 				for(int Index = 0; Index < CServerFilterInfo::MAX_GAMETYPES; ++Index)
 				{
 					if(!m_FilterInfo.m_aGametype[Index][0])
 						break;
-					if(!str_comp_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aGameType, m_FilterInfo.m_aGametype[Index]))
+					if(m_FilterInfo.m_aGametype[Index][0] == '-' && m_FilterInfo.m_aGametype[Index][1])
 					{
-						Filtered = 0;
-						break;
+						if(!str_comp_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aGameType, m_FilterInfo.m_aGametype[Index]+1))
+						{
+							Excluded = true;
+							break;
+						}
+					}
+					else
+					{
+						DoInclude = true;
+						if(!str_comp_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aGameType, m_FilterInfo.m_aGametype[Index]))
+						{
+							Included = true;
+							break;
+						}
 					}
 				}
+				Filtered = Excluded || (DoInclude && !Included);
 			}
 
-			if(m_FilterInfo.m_SortHash&IServerBrowser::FILTER_COUNTRY)
+			if(!Filtered && m_FilterInfo.m_SortHash&IServerBrowser::FILTER_COUNTRY)
 			{
 				Filtered = 1;
 				// match against player country

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -82,6 +82,7 @@ public:
 	int m_Country;
 	int m_ServerLevel;
 	char m_aGametype[MAX_GAMETYPES][16];
+	char m_aGametypeExclusive[MAX_GAMETYPES];
 	char m_aAddress[NETADDR_MAXSTRSIZE];
 
 	void ToggleLevel(int Level)

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1888,9 +1888,11 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 	{
 		if(FilterInfo.m_aGametype[i][0])
 		{
+			const bool IsExclusive = FilterInfo.m_aGametype[i][0] == '-' && FilterInfo.m_aGametype[i][1];
 			float CurLength = TextRender()->TextWidth(0, FontSize, FilterInfo.m_aGametype[i], -1, -1.0f) + 12.0f;
 			Button.VSplitLeft(CurLength, &Icon, &Button);
-			RenderTools()->DrawUIRect(&Icon, vec4(0.75, 0.75, 0.75, 0.25f), CUI::CORNER_ALL, 3.0f);
+			RenderTools()->DrawUIRect(&Icon, IsExclusive ? vec4(0.75f, 0.25f, 0.25f, 0.25f) : vec4(0.75f, 0.75f, 0.75f, 0.25f), CUI::CORNER_ALL, 3.0f);
+			Icon.VSplitLeft(2.0f, 0, &Icon);
 			UI()->DoLabel(&Icon, FilterInfo.m_aGametype[i], FontSize, CUI::ALIGN_LEFT);
 			Icon.VSplitRight(10.0f, 0, &Icon);
 			if(DoButton_SpriteClean(IMAGE_TOOLICONS, SPRITE_TOOL_X_B, &Icon))

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1915,7 +1915,7 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 			const float ItemLength = TextRender()->TextWidth(0, FontSize, FilterInfo.m_aGametype[i], -1, -1.0f) + IconWidth + Spacing;
 			CUIRect FilterItem;
 			Button.VSplitLeft(ItemLength, &FilterItem, &Button);
-			RenderTools()->DrawUIRect(&FilterItem, FilterInfo.m_aGametypeExclusive[i] ? vec4(0.75f, 0.25f, 0.25f, 0.25f) : vec4(0.75f, 0.75f, 0.75f, 0.25f), CUI::CORNER_ALL, 3.0f);
+			RenderTools()->DrawUIRect(&FilterItem, FilterInfo.m_aGametypeExclusive[i] ? vec4(0.75f, 0.25f, 0.25f, 0.25f) : vec4(0.25f, 0.75f, 0.25f, 0.25f), CUI::CORNER_ALL, 3.0f);
 			FilterItem.VSplitLeft(Spacing, 0, &FilterItem);
 			UI()->DoLabel(&FilterItem, FilterInfo.m_aGametype[i], FontSize, CUI::ALIGN_LEFT);
 			FilterItem.VSplitRight(IconWidth, 0, &FilterItem);


### PR DESCRIPTION
- Game type filters can either be inclusive or exclusive (closes #2621).
- Servers are filtered (i.e. excluded) if any exclusion filter matches, or if any inclusion filter exists but none matches.
- You can specify positive and negative filters at once, but it would be redundant to do so.
  - `ddrace -ddrace` matches nothing. Could also give priority to inclusive filters if that feels better to use.

Inclusive:
![screenshot_2020-08-27_09-38-27](https://user-images.githubusercontent.com/23437060/91412413-0c4fc600-e84a-11ea-91bb-49d199f0a494.png)

Exclusive:
![screenshot_2020-05-10_14-06-43](https://user-images.githubusercontent.com/23437060/81498901-dd780900-92c7-11ea-856b-696a276a65be.png)