### PR TITLE
Update readme with instructions for bam, minor fixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -182,6 +182,7 @@ Run the `x64 Native Tools Command Prompt` (or `x86` for 32-bit) from the start m
     # Build bam (use make_win32_msvc.bat for 32-bit)
     cd bam
     make_win64_msvc.bat
+    copy bam ..
     cd ..
     
     # Build Teeworlds

--- a/readme.md
+++ b/readme.md
@@ -23,8 +23,11 @@ the game, including new versions, custom maps and much more.
 
 Originally written by Magnus Auvinen.
 
+---
 
-Building on Linux or macOS
+Teeworlds supports two build systems: CMake (widely used) and bam (fast build times).
+
+Building on Linux or macOS (CMake)
 ==========================
 
 Installing dependencies
@@ -32,13 +35,13 @@ Installing dependencies
 
     # Debian/Ubuntu
     sudo apt install build-essential cmake git libfreetype6-dev libsdl2-dev libpnglite-dev libwavpack-dev python3
-
+    
     # Fedora
     sudo dnf install @development-tools cmake gcc-c++ git freetype-devel pnglite-devel python3 SDL2-devel wavpack-devel
-
+    
     # Arch Linux (doesn't have pnglite in its repositories)
     sudo pacman -S --needed base-devel cmake freetype2 git python sdl2 wavpack
-
+    
     # macOS
     brew install cmake freetype sdl2
 
@@ -48,7 +51,7 @@ Downloading repository
 
     git clone https://github.com/teeworlds/teeworlds --recurse-submodules
     cd teeworlds
-
+    
     # If you already cloned the repository before, use:
     # git submodule update --init
 
@@ -74,7 +77,7 @@ The following options can be passed to the `cmake ..` command line (between the
 `cmake` and `..`) in the "Building" step above.
 
 `-GNinja`: Use the Ninja build system instead of Make. This automatically
-parallizes the build and is generally **faster**. (Needs `sudo apt install
+parallelizes the build and is generally **faster**. (Needs `sudo apt install
 ninja-build` on Debian, `sudo dnf install ninja-build` on Fedora, and `sudo
 pacman -S --needed ninja` on Arch Linux.)
 
@@ -84,12 +87,64 @@ pacman -S --needed ninja` on Arch Linux.)
 `-DCLIENT=OFF`: Disable generation of the client target. Can be useful on
 headless servers which don't have graphics libraries like SDL2 installed.
 
+Building on Linux or macOS (bam)
+==========================
 
-Building on Windows with Visual Studio
-======================================
+Installing dependencies
+-----------------------
+
+    # Debian/Ubuntu 19.10+
+    sudo apt install bam git libfreetype6-dev libsdl2-dev libpnglite-dev libwavpack-dev python3
+    
+    # Fedora
+    sudo dnf install bam gcc-c++ git freetype-devel pnglite-devel python3 SDL2-devel wavpack-devel
+    
+    # Arch Linux (doesn't have pnglite in its repositories)
+    sudo pacman -S --needed base-devel bam freetype2 git python sdl2 wavpack
+    
+    # macOS
+    brew install bam freetype sdl2
+    
+    # other (add bam to your path)
+    git clone https://github.com/teeworlds/bam
+    cd bam
+    ./make_unix.sh
+
+
+Downloading repository
+----------------------
+
+    git clone https://github.com/teeworlds/teeworlds --recurse-submodules
+    cd teeworlds
+    
+    # If you already cloned the repository before, use:
+    # git submodule update --init
+
+
+Building
+--------
+
+    bam
+
+The compiled game is located in a sub-folder of `build`. You can run the client from there with `./teeworlds` and the server with `./teeworlds_srv`.
+
+
+Build options
+-------------
+
+One of the following targets can be added to the `bam` command line: `game` (default), `server`, `client`, `content`, `masterserver`, `tools`.
+
+The following options can also be added.
+
+`conf=release` to build in release mode (defaults to `conf=debug`).
+
+`arch=x86` or `arch=x86_64` to force select an architecture.
+
+Building on Windows with Visual Studio & CMake
+======================
 
 Download and install some version of [Microsoft Visual
-Studio](https://www.visualstudio.com/) (as of writing, MSVS Community 2017)
+Studio](https://www.visualstudio.com/) (as of writing, MSVS Community 2019)
 with the following components:
 
 * Desktop development with C++ (on the main page)
@@ -110,9 +165,32 @@ arrow. Wait for the compilation to finish.
 For subsequent builds you only have to click the button with the green arrow
 again.
 
+Building on Windows with MSVC build tools & bam
+======================
 
-Building on Windows with MinGW
-==============================
+Download and install [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) and [Python](https://www.python.org/downloads/).
+
+Download and unzip [Teeworlds stable sources](https://github.com/teeworlds/teeworlds/releases) or [Teeworlds latest sources](https://github.com/teeworlds/teeworlds/archive/master.zip).
+
+Download and unzip [bam](https://github.com/matricks/bam/archive/v0.5.1.tar.gz) to `teeworlds-version\bam`.
+
+Run the `x64 Native Tools Command Prompt` (or `x86` for 32-bit) from the start menu.
+
+    # Navigate to the Teeworlds source directory
+    cd ...\teeworlds-version
+    
+    # Build bam (use make_win32_msvc.bat for 32-bit)
+    cd bam
+    make_win64_msvc.bat
+    cd ..
+    
+    # Build Teeworlds
+    bam conf=release
+
+Use `conf=debug` to build the debug version instead. You can also provide a target after the `bam` command : `game` (default), `server`, `client`, `content`, `masterserver`, `tools`.
+
+Building on Windows with MinGW & CMake
+======================
 
 Download and install MinGW with at least the following components:
 
@@ -133,10 +211,3 @@ click "Finish". Wait a bit (until the progress bar is full). Then click
 "Generate".
 
 You can now build Teeworlds by executing `mingw32-make` in the build directory.
-
-
-Building with bam, guides for all operating systems
-===================================================
-
-You can also compile Teeworlds with bam, a custom build system. Instructions
-for that can be found at https://www.teeworlds.com/?page=docs&wiki=hacking.


### PR DESCRIPTION
Some say bam should be phased out and replaced by CMake. I had people think bam was deprecated because of the lack of instructions in the readme. The ambiguity should be cleared up if bam support is to be continued.

Note I left CMake first in all sections.