### PR TITLE
Delete existing corrupted map file before renaming tmp

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1229,6 +1229,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 				m_MapdownloadAmount = 0;
 				m_MapdownloadTotalsize = -1;
 
+				Storage()->RemoveFile(m_aMapdownloadFilename, IStorage::TYPE_SAVE);
 				Storage()->RenameFile(m_aMapdownloadFilenameTemp, m_aMapdownloadFilename, IStorage::TYPE_SAVE);
 
 				// load map


### PR DESCRIPTION
Just delete the file if it exists before renaming the .tmp file. It only exists if it has been corrupted and its hash does not match the filename. Closes #2628.