### PR TITLE
Fix too fast joystick in menus, allow swapping axis, refactoring

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -18,6 +18,9 @@
 #undef KEYS_INCLUDE
 
 // support older SDL version (pre 2.0.6)
+#ifndef SDL_JOYSTICK_AXIS_MIN
+	#define SDL_JOYSTICK_AXIS_MIN -32768
+#endif
 #ifndef SDL_JOYSTICK_AXIS_MAX
 	#define SDL_JOYSTICK_AXIS_MAX 32767
 #endif

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -47,7 +47,7 @@ CInput::CInput()
 	m_pGraphics = 0;
 
 	m_InputCounter = 1;
-	m_InputGrabbed = 0;
+	m_MouseInputRelative = false;
 	m_pClipboardText = 0;
 
 	m_SelectedJoystickIndex = -1;
@@ -100,10 +100,10 @@ void CInput::InitJoysticks()
 		for(int i = 0; i < NumJoysticks; i++)
 		{
 			SDL_Joystick *pJoystick = SDL_JoystickOpen(i);
-
-			if(!pJoystick) {
+			if(!pJoystick)
+			{
 				dbg_msg("joystick", "Could not open joystick %d: %s", i, SDL_GetError());
-				return;
+				continue;
 			}
 			m_apJoysticks.add(pJoystick);
 
@@ -188,7 +188,7 @@ float CInput::GetJoystickAxisValue(int Axis)
 {
 	SDL_Joystick* pJoystick = GetActiveJoystick();
 	dbg_assert((bool)pJoystick, "Requesting joystick axis value, but no joysticks were initialized");
-	return static_cast<float>(SDL_JoystickGetAxis(pJoystick, Axis)) / (float)(SDL_JOYSTICK_AXIS_MAX+1);
+	return (SDL_JoystickGetAxis(pJoystick, Axis)-SDL_JOYSTICK_AXIS_MIN)/float(SDL_JOYSTICK_AXIS_MAX-SDL_JOYSTICK_AXIS_MIN)*2.0f - 1.0f;
 }
 
 int CInput::GetJoystickNumAxes()
@@ -200,43 +200,36 @@ int CInput::GetJoystickNumAxes()
 
 void CInput::MouseRelative(float *x, float *y)
 {
-	if(!m_InputGrabbed)
+	if(!m_MouseInputRelative)
 		return;
 
-	int nx = 0, ny = 0;
-	float MouseSens = m_pConfig->m_InpMousesens/100.0f;
-	float JoystickSens = m_pConfig->m_JoystickSens/100.0f;
+	int MouseX = 0, MouseY = 0;
+	SDL_GetRelativeMouseState(&MouseX, &MouseY);
 
-	SDL_GetRelativeMouseState(&nx,&ny);
-
-	vec2 j = vec2(0.0f, 0.0f);
-
+	vec2 JoystickPos = vec2(0.0f, 0.0f);
 	if(m_pConfig->m_JoystickEnable && GetActiveJoystick())
 	{
-		const float Max = 50.0f;
-		j = vec2(GetJoystickAxisValue(m_pConfig->m_JoystickX), GetJoystickAxisValue(m_pConfig->m_JoystickY)) * Max;
-		const float Len = length(j);
-
-		if(Len/sqrtf(2.0f) <= m_pConfig->m_JoystickTolerance)
+		const vec2 RawJoystickPos = vec2(GetJoystickAxisValue(m_pConfig->m_JoystickX), GetJoystickAxisValue(m_pConfig->m_JoystickY));
+		const float Len = length(RawJoystickPos);
+		const float DeadZone = m_pConfig->m_JoystickTolerance/50.0f;
+		const float JoystickSens = m_pConfig->m_JoystickSens/100.0f;
+		if(Len >= DeadZone) // >= to allow max tolerance value
 		{
-			j = vec2(0.0f, 0.0f);
-		}
-		else
-		{
-			const vec2 nj = Len > 0.0f ? j / Len : vec2(0.0f, 0.0f);
-			j = nj * min(Len, Max) - nj * m_pConfig->m_JoystickTolerance;
+			JoystickPos = RawJoystickPos * (JoystickSens * max(Len - DeadZone, 0.001f) / Len);
 		}
 	}
 
-	*x = nx*MouseSens + j.x*JoystickSens;
-	*y = ny*MouseSens + j.y*JoystickSens;
+	const float MouseSens = m_pConfig->m_InpMousesens/100.0f;
+
+	*x = MouseX * MouseSens + JoystickPos.x;
+	*y = MouseY * MouseSens + JoystickPos.y;
 }
 
 void CInput::MouseModeAbsolute()
 {
-	if(m_InputGrabbed)
+	if(m_MouseInputRelative)
 	{
-		m_InputGrabbed = 0;
+		m_MouseInputRelative = false;
 		SDL_ShowCursor(SDL_ENABLE);
 		SDL_SetRelativeMouseMode(SDL_FALSE);
 	}
@@ -244,9 +237,9 @@ void CInput::MouseModeAbsolute()
 
 void CInput::MouseModeRelative()
 {
-	if(!m_InputGrabbed)
+	if(!m_MouseInputRelative)
 	{
-		m_InputGrabbed = 1;
+		m_MouseInputRelative = true;
 		SDL_ShowCursor(SDL_DISABLE);
 		if(SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, m_pConfig->m_InpGrab ? "0" : "1", SDL_HINT_OVERRIDE) == SDL_FALSE)
 		{

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -18,7 +18,7 @@ class CInput : public IEngineInput
 	void InitJoysticks();
 	void CloseJoysticks();
 
-	int m_InputGrabbed;
+	bool m_MouseInputRelative;
 	char *m_pClipboardText;
 
 	int m_PreviousHat;

--- a/src/game/client/components/menus_callback.cpp
+++ b/src/game/client/components/menus_callback.cpp
@@ -143,9 +143,11 @@ float CMenus::RenderSettingsControlsMouse(CUIRect View)
 	{
 		Config()->m_InpGrab ^= 1;
 	}
+
 	View.HSplitTop(Spacing, 0, &View);
 	View.HSplitTop(ButtonHeight, &Button, &View);
 	DoScrollbarOption(&Config()->m_InpMousesens, &Config()->m_InpMousesens, &Button, Localize("Ingame mouse sens."), 1, 500, &LogarithmicScrollbarScale);
+
 	View.HSplitTop(Spacing, 0, &View);
 	View.HSplitTop(ButtonHeight, &Button, &View);
 	DoScrollbarOption(&Config()->m_UiMousesens, &Config()->m_UiMousesens, &Button, Localize("Menu mouse sens."), 1, 500, &LogarithmicScrollbarScale);
@@ -412,11 +414,19 @@ void CMenus::DoJoystickAxisPicker(CUIRect View)
 		// Bind to X,Y
 		Row.VSplitLeft(2*StatusMargin, 0, &Row);
 		Row.VSplitLeft(BindWidth, &Button, &Row);
-		if(DoButton_CheckBox(&s_aActive[i][0], "X", Config()->m_JoystickX == i, &Button, Config()->m_JoystickY == i))
+		if(DoButton_CheckBox(&s_aActive[i][0], "X", Config()->m_JoystickX == i, &Button))
+		{
+			if(Config()->m_JoystickY == i)
+				Config()->m_JoystickY = Config()->m_JoystickX;
 			Config()->m_JoystickX = i;
+		}
 		Row.VSplitLeft(BindWidth, &Button, &Row);
-		if(DoButton_CheckBox(&s_aActive[i][1], "Y", Config()->m_JoystickY == i, &Button, Config()->m_JoystickX == i))
+		if(DoButton_CheckBox(&s_aActive[i][1], "Y", Config()->m_JoystickY == i, &Button))
+		{
+			if(Config()->m_JoystickX == i)
+				Config()->m_JoystickX = Config()->m_JoystickY;
 			Config()->m_JoystickY = i;
+		}
 		Row.VSplitLeft(StatusMargin, 0, &Row);
 	}
 }

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -63,9 +63,9 @@ bool CUI::MouseInsideClip() const
 
 void CUI::ConvertMouseMove(float *x, float *y) const
 {
-	float Fac = (float)(m_pConfig->m_UiMousesens)/m_pConfig->m_InpMousesens;
-	*x = *x*Fac;
-	*y = *y*Fac;
+	float Fac = m_pConfig->m_UiMousesens/100.0f;
+	*x = *x * Fac;
+	*y = *y * Fac;
 }
 
 CUIRect *CUI::Screen()

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -63,7 +63,7 @@ bool CUI::MouseInsideClip() const
 
 void CUI::ConvertMouseMove(float *x, float *y) const
 {
-	float Fac = m_pConfig->m_UiMousesens/100.0f;
+	const float Fac = m_pConfig->m_UiMousesens/float(m_pConfig->m_InpMousesens);
 	*x = *x * Fac;
 	*y = *y * Fac;
 }


### PR DESCRIPTION
- Make UI mouse sens settings not relative to the ingame mouse sens. This was making joystick input in the menus way to fast.
  - This means menu sens now stacks multiplicatively with mouse and joystick sens, instead of just with joystick sens in a weird way.
  - Would need to differenciate between MouseMove and JoystickMove in the UI and gameclient to make it completely independent or to introduce a separate "joystick menu sens".
- Allow swapping joystick axis in the UI. Selecting an axis when another one is already selected will swap the axis selection. Otherwise it's not possible to change axis when only two axis are available.
- Improve mapping of joystick value in `GetJoystickAxisValue` to cover the full domain of values.
- Continue instead of returning after failing to open a joystick. The other could still be useable.
- Refactor joystick movement logic.
- Replace `int m_InputGrabbed` with `bool m_MouseInputRelative`.