### PR TITLE
Remove notice that bam is faster

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,8 @@ Originally written by Magnus Auvinen.
 
 ---
 
-Teeworlds supports two build systems: CMake (widely used) and bam (fast build times).
+Teeworlds supports two build systems: CMake (widely used) and bam (our own
+build system).
 
 Building on Linux or macOS (CMake)
 ==========================


### PR DESCRIPTION
As discussed in the PR, we were unable to reproduce significant speed
differences between CMake+Ninja and bam.