### PR TITLE
Fix bottom right area of sprites being cut off

### DIFF
--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -37,9 +37,9 @@ void CRenderTools::SelectSprite(CDataSprite *pSpr, int Flags, int sx, int sy)
 	gs_SpriteHScale = h/f;
 
 	float x1 = x/(float)cx;
-	float x2 = (x+w-1/32.0f)/(float)cx;
+	float x2 = (x+w)/(float)cx;
 	float y1 = y/(float)cy;
-	float y2 = (y+h-1/32.0f)/(float)cy;
+	float y2 = (y+h)/(float)cy;
 	float Temp = 0;
 
 	if(Flags&SPRITE_FLAG_FLIP_Y)

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -36,10 +36,11 @@ void CRenderTools::SelectSprite(CDataSprite *pSpr, int Flags, int sx, int sy)
 	gs_SpriteWScale = w/f;
 	gs_SpriteHScale = h/f;
 
-	float x1 = x/(float)cx;
-	float x2 = (x+w)/(float)cx;
-	float y1 = y/(float)cy;
-	float y2 = (y+h)/(float)cy;
+	float x1 = x/(float)cx + 0.5f/(float)(cx*32);
+	float x2 = (x+w)/(float)cx - 0.5f/(float)(cx*32);
+	float y1 = y/(float)cy + 0.5f/(float)(cy*32);
+	float y2 = (y+h)/(float)cy - 0.5f/(float)(cy*32);
+
 	float Temp = 0;
 
 	if(Flags&SPRITE_FLAG_FLIP_Y)


### PR DESCRIPTION
This reverts commit 8eaa040e3ed2a7a40fdb21eec284d85c2540505e. For some reason the commit causing the issue isn't in 0.6, but it is in 0.7.

I originally looked into it because the skins looked smushed to the right, which made the tees look a lot worse than in 0.6.

### Before
![before](https://user-images.githubusercontent.com/20409621/84224295-20392680-aaaa-11ea-8c52-f348b4c229b4.png)

### After
![after](https://user-images.githubusercontent.com/20409621/84224315-31823300-aaaa-11ea-85d2-a7262553de51.png)

---

### Before
![before_m](https://user-images.githubusercontent.com/20409621/84224340-4363d600-aaaa-11ea-8ce3-24b430d10908.png)

### After
![after_m](https://user-images.githubusercontent.com/20409621/84224345-46f75d00-aaaa-11ea-8e18-43d5fa1d66ab.png)
