### PR TITLE
Directory support for automap rules (closed #2434)

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -279,7 +279,16 @@ public:
 	~CEditorImage();
 
 	void AnalyseTileFlags();
+	void LoadAutoMapperFile(const char *pFile);
 	void LoadAutoMapper();
+
+	static int AutoMapEntryCallback(const char *pFilename, int IsDir, int StorageType, void *pUser);
+
+	struct CAutoMapEntryCallbackUserdata
+	{
+		CEditorImage *m_pEditorImage;
+		char m_aPath[IO_MAX_PATH_LENGTH];
+	};
 
 	IGraphics::CTextureHandle m_Texture;
 	int m_External;


### PR DESCRIPTION
Add directory support so one ruleset can be represented in multiple json files. So rules can be more easily combined without the need of touching json. 

```
automap/
├── desert_main.json
├── grass_doodads.json
├── grass_main
│   └── test.json
├── grass_main.json
├── jungle_deathtiles.json
├── jungle_main.json
└── winter_main.json
```

![image](https://user-images.githubusercontent.com/20344300/84435288-d8450b80-ac31-11ea-9053-cb2afe00558d.png)
