### PR TITLE
Add more information on map load error

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -818,7 +818,7 @@ const char *CClient::LoadMap(const char *pName, const char *pFilename, const SHA
 		char aWantedSha256[SHA256_MAXSTRSIZE];
 		sha256_str(m_pMap->Sha256(), aSha256, sizeof(aSha256));
 		sha256_str(*pWantedSha256, aWantedSha256, sizeof(aWantedSha256));
-		str_format(aErrorMsg, sizeof(aErrorMsg), "map differs from the server. %s != %s", aSha256, aWantedSha256);
+		str_format(aErrorMsg, sizeof(aErrorMsg), "map differs from the server. found = %s wanted = %s", aSha256, aWantedSha256);
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", aErrorMsg);
 		m_pMap->Unload();
 		return aErrorMsg;
@@ -827,7 +827,7 @@ const char *CClient::LoadMap(const char *pName, const char *pFilename, const SHA
 	// get the crc of the map
 	if(m_pMap->Crc() != WantedCrc)
 	{
-		str_format(aErrorMsg, sizeof(aErrorMsg), "map differs from the server. %08x != %08x", m_pMap->Crc(), WantedCrc);
+		str_format(aErrorMsg, sizeof(aErrorMsg), "map differs from the server. found = %08x wanted = %08x", m_pMap->Crc(), WantedCrc);
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", aErrorMsg);
 		m_pMap->Unload();
 		return aErrorMsg;


### PR DESCRIPTION
I always had to look into the source code to know which hash belongs to the map I have and which to the map I am missing. It also would be nice to split lines for the long sha sums. In the console and also in the UI. But I did not want to rewrite Popup code just for that.

```
[2020-06-17 11:41:57][client]: map differs from the server. found = 7804361930b6ee50f59bfe49bf9da3b901ed0147a5f2ecae25b2a417ac955f01 wanted = 3804361930b6ee50f59bfe49bf9da3b901ed0147a5f2ecae25b2a417ac955f01
[2020-06-17 11:41:57][client]: disconnecting. reason='map differs from the server. found = 7804361930b6ee50f59bfe49bf9da3b901ed0147a5f2ecae25b2a417ac955f01 wanted = 3804361930b6ee50f59bfe49bf9da3b901ed0147a5f2ecae25b2a417ac955f01'
```

![image](https://user-images.githubusercontent.com/20344300/84882454-9122a480-b08f-11ea-9c99-27e4b7605bf5.png)
