### PR TITLE
Do not enforce winter theme on new users

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2558,8 +2558,6 @@ void CClient::ConnectOnStart(const char *pAddress)
 
 void CClient::DoVersionSpecificActions()
 {
-	if(Config()->m_ClLastVersionPlayed <= 0x0703)
-		str_copy(Config()->m_ClMenuMap, "winter", sizeof(Config()->m_ClMenuMap));
 	Config()->m_ClLastVersionPlayed = CLIENT_VERSION;
 }
 


### PR DESCRIPTION
``m_ClLastVersionPlayed`` by default is ``0x0703`` so when loading a config only including:

```
cl_menu_map "jungle"
```

It will force you to use winter theme because last version is unset. Also old clients updating should not get a winter theme during summer if they picked a different one already.