### PR TITLE
Click on friend to select server, double click to connect, refactoring

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -691,10 +691,10 @@ private:
 		SIDEBAR_TAB_FRIEND,
 		NUM_SIDEBAR_TABS,
 
-		ADDR_SELECTION_CHANGE = 1,
-		ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND = 2,
-		ADDR_SELECTION_REVEAL = 4,
-		ADDR_SELECTION_UPDATE_ADDRESS = 8,
+		ADDR_SELECTION_CHANGE = 1, // select the server based on server address input
+		ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND = 2, // clear selection if ADDR_SELECTION_CHANGE did not match any server
+		ADDR_SELECTION_REVEAL = 4, // scroll to the selected server
+		ADDR_SELECTION_UPDATE_ADDRESS = 8, // update address input to the selected server's address
 	};
 	int m_SidebarTab;
 	bool m_SidebarActive;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1265,16 +1265,23 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 				// select server if address changed and match found
 				bool IsSelected = m_aSelectedFilters[BrowserType] == FilterIndex && m_aSelectedServers[BrowserType] == ServerIndex;
-				if(m_AddressSelection&ADDR_SELECTION_CHANGE && !str_comp(pItem->m_aAddress, pAddress))
+				if(m_AddressSelection&ADDR_SELECTION_CHANGE)
 				{
-					if(!IsSelected)
+					if (!str_comp(pItem->m_aAddress, pAddress))
 					{
-						m_ShowServerDetails = true;
-						m_aSelectedFilters[BrowserType] = FilterIndex;
-						m_aSelectedServers[BrowserType] = ServerIndex;
-						IsSelected = true;
+						if(!IsSelected)
+						{
+							m_ShowServerDetails = true;
+							m_aSelectedFilters[BrowserType] = FilterIndex;
+							m_aSelectedServers[BrowserType] = ServerIndex;
+							IsSelected = true;
+						}
+						m_AddressSelection &= ~(ADDR_SELECTION_CHANGE|ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND);
 					}
-					m_AddressSelection &= ~(ADDR_SELECTION_CHANGE|ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND);
+					else
+					{
+						IsSelected = false;
+					}
 				}
 
 				float ItemHeight = HeaderHeight;


### PR DESCRIPTION
- Clicking on a friend selects the server in the current browser view (closes #2666).
  - Remove the explicit join button, use double click to join instead. The "Join" text was also tricky to translate because of limited space. This UX seems intuitive to me.
  - The items change color on hover.
  - Fix scolling to reveal server entry sometimes not working, because an existing selection was consuming the flag first.
- Add comments for the ADDR_SELECTION_* flags. Actually use ADDR_SELECTION_CHANGE where it was supposed.
- Add spacing between the Name/Clan textboxes and the Add button.
- Slightly change the blue (clan) color to similar values inside the 0.0f-1.0f range.
- Also include the spacing between items in the scrollarea of the friend- and serverlist, which was cutting the scrollarea slightly too short.

![screenshot_2020-07-07_00-11-41](https://user-images.githubusercontent.com/23437060/86657003-2f978b00-bfe8-11ea-94c7-4dfe941b44f7.png)
