### PR TITLE
Fix rand init error message

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2599,11 +2599,7 @@ int main(int argc, const char **argv) // ignore_convention
 		}
 	}
 
-	if(secure_random_init() != 0)
-	{
-		dbg_msg("secure", "could not initialize secure RNG");
-		return -1;
-	}
+	bool RandInitFailed = secure_random_init() != 0;
 
 	CClient *pClient = CreateClient();
 	IKernel *pKernel = IKernel::Create();
@@ -2621,6 +2617,12 @@ int main(int argc, const char **argv) // ignore_convention
 	IEngineTextRender *pEngineTextRender = CreateEngineTextRender();
 	IEngineMap *pEngineMap = CreateEngineMap();
 	IEngineMasterServer *pEngineMasterServer = CreateEngineMasterServer();
+
+	if(RandInitFailed)
+	{
+		dbg_msg("secure", "could not initialize secure RNG");
+		return -1;
+	}
 
 	{
 		bool RegisterFail = false;


### PR DESCRIPTION
The error message would not appear because ``dbg_msg()`` requires https://github.com/teeworlds/teeworlds/blob/d716201687fce903613fcadc3f2f75e77e0df4c0/src/engine/shared/engine.cpp#L54 which happens in the engine creation.

Reported by a anonymous tee and improved by @msiglreith

https://github.com/ddnet/ddnet/pull/976