### PR TITLE
Remove insecure tempfile.mktemp

### DIFF
--- a/scripts/dmg.py
+++ b/scripts/dmg.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 import os
 import shlex
 import subprocess
-import tempfile
+from tempfile import NamedTemporaryFile
 
 ConfigDmgtools = namedtuple('Config', 'dmg hfsplus newfs_hfs verbose')
 ConfigHdiutil = namedtuple('Config', 'hdiutil verbose')
@@ -54,7 +54,7 @@ class Dmgtools(Dmg):
 	def create(self, dmg, volume_name, directory, symlinks):
 		input_size = sum(os.stat(os.path.join(path, f)).st_size for path, dirs, files in os.walk(directory) for f in files)
 		output_size = max(input_size * 2, 1024**2)
-		hfs = tempfile.mktemp(prefix=dmg + '.', suffix='.hfs')
+		hfs = NamedTemporaryFile(prefix=dmg + '.', suffix='.hfs', delete=False)
 		self._create_hfs(hfs, volume_name, output_size)
 		self._add(hfs, directory)
 		for target, link_name in symlinks:


### PR DESCRIPTION
Found by [lgtm.com](https://lgtm.com/projects/g/teeworlds/teeworlds/?mode=list&severity=error) mentioned by @jxsl13 :)

tempfile.mktemp is deprecated since Python 2.3 and considered weak https://cwe.mitre.org/data/definitions/377.html


**change is untested**

Sadly I could not get all dependencies building (https://github.com/planetbeing/libdmg-hfsplus/issues/14) and thus could not test this branch of code. If one has the binaries for hfsplus please test this.