### PR TITLE
Fix network token issues. Closes #2669

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -764,7 +764,9 @@ static void sockaddr_to_netaddr(const struct sockaddr *src, NETADDR *dst)
 
 int net_addr_comp(const NETADDR *a, const NETADDR *b)
 {
-	return mem_comp(a, b, sizeof(NETADDR));
+	if(mem_comp(a->ip, b->ip, sizeof(a->ip)) == 0 && a->port == b->port && a->type == b->type)
+		return 0;
+	return -1;
 }
 
 void net_addr_str(const NETADDR *addr, char *string, int max_length, int add_port)

--- a/src/engine/shared/network_token.cpp
+++ b/src/engine/shared/network_token.cpp
@@ -95,8 +95,10 @@ TOKEN CNetTokenManager::GenerateToken(const NETADDR *pAddr, int64 Seed)
 	if(pAddr->type & NETTYPE_LINK_BROADCAST)
 		return GenerateToken(&NullAddr, Seed);
 
-	Addr = *pAddr;
-	Addr.port = 0;
+	mem_zero(&Addr, sizeof(NETADDR));
+	mem_copy(Addr.ip, pAddr->ip, sizeof(Addr.ip));
+	Addr.type = pAddr->type;
+
 	mem_copy(aBuf, &Addr, sizeof(NETADDR));
 	mem_copy(aBuf + sizeof(NETADDR), &Seed, sizeof(int64));
 


### PR DESCRIPTION
This fixes two issues with the token handling:

- Broken token cache due to incorrect results from `net_addr_comp`
- `GenerateToken` returned different tokens for the same IP

Both issues were caused by uninitialized padding bytes in `NETADDR`.

Closes #2669