### PR TITLE
Remove unnecessary restriction on snap-item types

### DIFF
--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -172,7 +172,7 @@ CSnapshotDelta::CSnapshotDelta()
 
 void CSnapshotDelta::SetStaticsize(int ItemType, int Size)
 {
-	if(ItemType < 0 || ItemType >= MAX_NETOBJTYPES)
+	if(ItemType < 0 || ItemType >= MAX_NETOBJSIZES)
 		return;
 	m_aItemSizes[ItemType] = Size;
 }
@@ -232,13 +232,15 @@ int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, CSnapshot *pTo, void *pD
 		pCurItem = pTo->GetItem(i); // O(1) .. O(n)
 		PastIndex = aPastIndecies[i];
 
+		bool IncludeSize = pCurItem->Type() >= MAX_NETOBJSIZES || !m_aItemSizes[pCurItem->Type()];
+
 		if(PastIndex != -1)
 		{
 			int *pItemDataDst = pData+3;
 
 			pPastItem = pFrom->GetItem(PastIndex);
 
-			if(m_aItemSizes[pCurItem->Type()])
+			if(!IncludeSize)
 				pItemDataDst = pData+2;
 
 			if(DiffItem(pPastItem->Data(), (int*)pCurItem->Data(), pItemDataDst, ItemSize/4))
@@ -246,7 +248,7 @@ int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, CSnapshot *pTo, void *pD
 
 				*pData++ = pCurItem->Type();
 				*pData++ = pCurItem->ID();
-				if(!m_aItemSizes[pCurItem->Type()])
+				if(IncludeSize)
 					*pData++ = ItemSize/4;
 				pData += ItemSize/4;
 				pDelta->m_NumUpdateItems++;
@@ -256,7 +258,7 @@ int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, CSnapshot *pTo, void *pD
 		{
 			*pData++ = pCurItem->Type();
 			*pData++ = pCurItem->ID();
-			if(!m_aItemSizes[pCurItem->Type()])
+			if(IncludeSize)
 				*pData++ = ItemSize/4;
 
 			mem_copy(pData, pCurItem->Data(), ItemSize);
@@ -356,10 +358,10 @@ int CSnapshotDelta::UnpackDelta(const CSnapshot *pFrom, CSnapshot *pTo, const vo
 			return -1;
 
 		Type = *pData++;
-		if(Type < 0 || Type >= MAX_NETOBJTYPES)
+		if(Type < 0)
 			return -1;
 		ID = *pData++;
-		if(m_aItemSizes[Type])
+		if(Type < MAX_NETOBJSIZES && m_aItemSizes[Type])
 			ItemSize = m_aItemSizes[Type];
 		else
 		{

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -72,9 +72,9 @@ public:
 private:
 	enum
 	{
-		MAX_NETOBJTYPES=64
+		MAX_NETOBJSIZES=64
 	};
-	short m_aItemSizes[MAX_NETOBJTYPES];
+	short m_aItemSizes[MAX_NETOBJSIZES];
 	int m_aSnapshotDataRate[0xffff];
 	int m_aSnapshotDataUpdates[0xffff];
 	int m_SnapshotCurrent;


### PR DESCRIPTION
Commit https://github.com/teeworlds/teeworlds/commit/293209e7227c81e92b99c89890ebfdc264374a4a limited the snap item types to 64, which is not really necessary since `CSnapshotDelta` can embed the size for items that are not included in `m_aItemSizes`.

Several mods and custom clients actually use snap item types way higher than 64 to not collide with vanilla snap items.
When receiving a snapshot with such an item, only the unknown item should be invalidated. Right now the client just fails to unpack the data and drops the whole snapshot.