### PR TITLE
Validate variables of the snap-item base class

### DIFF
--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -269,7 +269,10 @@ if gen_network_source:
 	lines += ['\t{']
 
 	for item in network.Objects:
-		for line in item.emit_validate():
+		base_item = None
+		if item.base:
+			base_item = next(i for i in network.Objects if i.name == item.base)
+		for line in item.emit_validate(base_item):
 			lines += ["\t" + line]
 		lines += ['\t']
 	lines += ['\t}']

--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -229,12 +229,15 @@ class NetObject:
 			lines += ["\t"+line for line in v.emit_declaration()]
 		lines += ["};"]
 		return lines
-	def emit_validate(self):
+	def emit_validate(self, base_item):
 		lines = ["case %s:" % self.enum_name]
 		lines += ["{"]
-		lines += ["\t%s *pObj = (%s *)pData;"%(self.struct_name, self.struct_name)]
+		lines += ["\tconst %s *pObj = (const %s *)pData;"%(self.struct_name, self.struct_name)]
 		lines += ["\tif(sizeof(*pObj) != Size) return -1;"]
-		for v in self.variables:
+		variables = self.variables
+		if base_item:
+			variables += base_item.variables
+		for v in variables:
 			lines += ["\t"+line for line in v.emit_validate()]
 		lines += ["\treturn 0;"]
 		lines += ["}"]

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -159,7 +159,7 @@ Objects = [
 		NetIntRange("m_Direction", -1, 1),
 
 		NetIntRange("m_Jumped", 0, 3),
-		NetIntRange("m_HookedPlayer", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_HookedPlayer", -1, 'MAX_CLIENTS-1'),
 		NetIntRange("m_HookState", -1, 5),
 		NetTick("m_HookTick"),
 


### PR DESCRIPTION
Snap item validation for objects with a base class never worked.
For example in case of `Character:CharacterCore` the variables of `CharacterCore` were not validated.