### PR TITLE
Optimize client-side dead reckoning

### DIFF
--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -194,6 +194,8 @@ public:
 		CTeeRenderInfo m_SkinInfo; // this is what the server reports
 		CTeeRenderInfo m_RenderInfo; // this is what we use
 
+		CNetObj_Character m_Evolved;
+
 		float m_Angle;
 		bool m_Active;
 		bool m_ChatIgnore;


### PR DESCRIPTION
- Use a client-side evolve limit (3 sec, same as server-side) to prevent the client from freezing

- Reuse the evolved character from the last snapshot. Instead of up to 300 evolve calls (3*50 ticks for each Cur and Prev), this usually needs 1 or 2 per character in a snapshot. This is based on https://github.com/ddnet/ddnet/pull/1964