### PR TITLE
Separate mouse/joystick cursor movement, add joystick ui sens, make joystick speed consistent

### DIFF
--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -43,7 +43,8 @@ public:
 	CInput();
 	~CInput();
 
-	virtual void Init();
+	void Init();
+	int Update();
 
 	bool KeyIsPressed(int Key) const { return KeyState(Key); }
 	bool KeyPress(int Key, bool CheckCounter) const { return CheckCounter ? (m_aInputCount[Key] == m_InputCounter) : m_aInputCount[Key]; }
@@ -54,15 +55,15 @@ public:
 	const char* GetJoystickName();
 	int GetJoystickNumAxes();
 	float GetJoystickAxisValue(int Axis);
+	bool JoystickRelative(float *pX, float *pY);
 
-	virtual void MouseRelative(float *x, float *y);
-	virtual void MouseModeAbsolute();
-	virtual void MouseModeRelative();
-	virtual int MouseDoubleClick();
-	virtual const char *GetClipboardText();
-	virtual void SetClipboardText(const char *pText);
+	void MouseModeRelative();
+	void MouseModeAbsolute();
+	int MouseDoubleClick();
+	bool MouseRelative(float *pX, float *pY);
 
-	virtual int Update();
+	const char *GetClipboardText();
+	void SetClipboardText(const char *pText);
 };
 
 #endif

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -39,6 +39,10 @@ public:
 		FLAG_RELEASE=2,
 		FLAG_REPEAT=4,
 		FLAG_TEXT=8,
+
+		CURSOR_NONE = 0,
+		CURSOR_MOUSE,
+		CURSOR_JOYSTICK
 	};
 
 	// events
@@ -53,12 +57,12 @@ public:
 		}
 		return m_aInputEvents[Index];
 	}
+	virtual void Clear() = 0;
 
 	// keys
 	virtual bool KeyIsPressed(int Key) const = 0;
 	virtual bool KeyPress(int Key, bool CheckCounter=false) const = 0;
 	const char *KeyName(int Key) const { return (Key >= 0 && Key < g_MaxKeys) ? g_aaKeyStrings[Key] : g_aaKeyStrings[0]; }
-	virtual void Clear() = 0;
 
 	// joystick
 	virtual int NumJoysticks() const = 0;
@@ -67,15 +71,26 @@ public:
 	virtual const char* GetJoystickName() = 0;
 	virtual int GetJoystickNumAxes() = 0;
 	virtual float GetJoystickAxisValue(int Axis) = 0;
+	virtual bool JoystickRelative(float *pX, float *pY) = 0;
 
 	// mouse
 	virtual void MouseModeRelative() = 0;
 	virtual void MouseModeAbsolute() = 0;
 	virtual int MouseDoubleClick() = 0;
+	virtual bool MouseRelative(float *pX, float *pY) = 0;
+
+	// clipboard
 	virtual const char* GetClipboardText() = 0;
 	virtual void SetClipboardText(const char *pText) = 0;
 
-	virtual void MouseRelative(float *x, float *y) = 0;
+	int CursorRelative(float *pX, float *pY)
+	{
+		if (MouseRelative(pX, pY))
+			return CURSOR_MOUSE;
+		if (JoystickRelative(pX, pY))
+			return CURSOR_JOYSTICK;
+		return CURSOR_NONE;
+	}
 };
 
 

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -43,7 +43,7 @@ public:
 	virtual void OnRelease() {};
 	virtual void OnMapLoad() {};
 	virtual void OnMessage(int Msg, void *pRawMsg) {}
-	virtual bool OnMouseMove(float x, float y) { return false; }
+	virtual bool OnCursorMove(float x, float y, int CursorType) { return false; }
 	virtual bool OnInput(IInput::CEvent e) { return false; }
 };
 

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -207,13 +207,23 @@ void CControls::OnRender()
 		m_TargetPos = m_MousePos;
 }
 
-bool CControls::OnMouseMove(float x, float y)
+bool CControls::OnCursorMove(float x, float y, int CursorType)
 {
 	if(m_pClient->IsWorldPaused() || (m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_pChat->IsActive()))
 		return false;
 
-	m_MousePos += vec2(x, y); // TODO: ugly
+	float Factor = 1.0f;
+	switch(CursorType)
+	{
+		case IInput::CURSOR_MOUSE:
+			Factor = Config()->m_InpMousesens/100.0f;
+			break;
+		case IInput::CURSOR_JOYSTICK:
+			Factor = Config()->m_JoystickSens/100.0f;
+			break;
+	}
 
+	m_MousePos += vec2(x, y) * Factor;
 	return true;
 }
 

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -22,7 +22,7 @@ public:
 	virtual void OnRelease();
 	virtual void OnRender();
 	virtual void OnMessage(int MsgType, void *pRawMsg);
-	virtual bool OnMouseMove(float x, float y);
+	virtual bool OnCursorMove(float x, float y, int CursorType);
 	virtual void OnConsoleInit();
 	virtual void OnPlayerDeath();
 

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -48,13 +48,13 @@ void CEmoticon::OnMessage(int MsgType, void *pRawMsg)
 {
 }
 
-bool CEmoticon::OnMouseMove(float x, float y)
+bool CEmoticon::OnCursorMove(float x, float y, int CursorType)
 {
 	if(!m_Active)
 		return false;
 
-	UI()->ConvertMouseMove(&x, &y);
-	m_SelectorMouse += vec2(x,y);
+	UI()->ConvertCursorMove(&x, &y, CursorType);
+	m_SelectorMouse += vec2(x, y);
 	return true;
 }
 

--- a/src/game/client/components/emoticon.h
+++ b/src/game/client/components/emoticon.h
@@ -26,7 +26,7 @@ public:
 	virtual void OnRender();
 	virtual void OnRelease();
 	virtual void OnMessage(int MsgType, void *pRawMsg);
-	virtual bool OnMouseMove(float x, float y);
+	virtual bool OnCursorMove(float x, float y, int CursorType);
 
 	void Emote(int Emoticon);
 };

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2190,7 +2190,7 @@ void CMenus::OnReset()
 {
 }
 
-bool CMenus::OnMouseMove(float x, float y)
+bool CMenus::OnCursorMove(float x, float y, int CursorType)
 {
 	m_LastInput = time_get();
 
@@ -2200,7 +2200,7 @@ bool CMenus::OnMouseMove(float x, float y)
 	// prev mouse position
 	m_PrevMousePos = m_MousePos;
 
-	UI()->ConvertMouseMove(&x, &y);
+	UI()->ConvertCursorMove(&x, &y, CursorType);
 	m_MousePos.x += x;
 	m_MousePos.y += y;
 	if(m_MousePos.x < 0) m_MousePos.x = 0;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -901,6 +901,6 @@ public:
 	virtual void OnReset();
 	virtual void OnRender();
 	virtual bool OnInput(IInput::CEvent Event);
-	virtual bool OnMouseMove(float x, float y);
+	virtual bool OnCursorMove(float x, float y, int CursorType);
 };
 #endif

--- a/src/game/client/components/menus_callback.cpp
+++ b/src/game/client/components/menus_callback.cpp
@@ -168,12 +168,12 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 		{
 			NumOptions++; // joystick selection
 		}
-		NumOptions += 2; // sensitivity & tolerance
+		NumOptions += 3; // ingame sens, ui sens, tolerance
 		NumOptions += m_pClient->Input()->GetJoystickNumAxes(); // axis selection
 	}
-	float ButtonHeight = 20.0f;
-	float Spacing = 2.0f;
-	float BackgroundHeight = (float)NumOptions*ButtonHeight+(float)NumOptions*Spacing+Spacing;
+	const float ButtonHeight = 20.0f;
+	const float Spacing = 2.0f;
+	const float BackgroundHeight = NumOptions*(ButtonHeight+Spacing)+Spacing;
 
 	View.HSplitTop(BackgroundHeight, &View, 0);
 	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
@@ -206,7 +206,11 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 
 			View.HSplitTop(Spacing, 0, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);
-			DoScrollbarOption(&Config()->m_JoystickSens, &Config()->m_JoystickSens, &Button, Localize("Joystick sens."), 1, 500, &LogarithmicScrollbarScale);
+			DoScrollbarOption(&Config()->m_JoystickSens, &Config()->m_JoystickSens, &Button, Localize("Ingame joystick sens."), 1, 500, &LogarithmicScrollbarScale);
+
+			View.HSplitTop(Spacing, 0, &View);
+			View.HSplitTop(ButtonHeight, &Button, &View);
+			DoScrollbarOption(&Config()->m_UiJoystickSens, &Config()->m_UiJoystickSens, &Button, Localize("Menu/Editor joystick sens."), 1, 500, &LogarithmicScrollbarScale);
 
 			View.HSplitTop(Spacing, 0, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -128,13 +128,13 @@ void CSpectator::OnConsoleInit()
 	Console()->Register("spectate_previous", "", CFGFLAG_CLIENT, ConSpectatePrevious, this, "Spectate the previous player");
 }
 
-bool CSpectator::OnMouseMove(float x, float y)
+bool CSpectator::OnCursorMove(float x, float y, int CursorType)
 {
 	if(!m_Active)
 		return false;
 
-	UI()->ConvertMouseMove(&x, &y);
-	m_SelectorMouse += vec2(x,y);
+	UI()->ConvertCursorMove(&x, &y, CursorType);
+	m_SelectorMouse += vec2(x, y);
 	return true;
 }
 

--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -32,7 +32,7 @@ public:
 	CSpectator();
 
 	virtual void OnConsoleInit();
-	virtual bool OnMouseMove(float x, float y);
+	virtual bool OnCursorMove(float x, float y, int CursorType);
 	virtual void OnRender();
 	virtual void OnRelease();
 	virtual void OnReset();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -420,14 +420,14 @@ void CGameClient::OnInit()
 
 void CGameClient::OnUpdate()
 {
-	// handle mouse movement
+	// handle mouse and joystick movement, prefer mouse movement
 	float x = 0.0f, y = 0.0f;
-	Input()->MouseRelative(&x, &y);
-	if(x != 0.0f || y != 0.0f)
+	int CursorType = Input()->CursorRelative(&x, &y);
+	if(CursorType != IInput::CURSOR_NONE)
 	{
 		for(int h = 0; h < m_Input.m_Num; h++)
 		{
-			if(m_Input.m_paComponents[h]->OnMouseMove(x, y))
+			if(m_Input.m_paComponents[h]->OnCursorMove(x, y, CursorType))
 				break;
 		}
 	}

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -5,6 +5,7 @@
 #include <engine/shared/config.h>
 #include <engine/graphics.h>
 #include <engine/textrender.h>
+#include <engine/input.h>
 #include "ui.h"
 
 /********************************************************
@@ -67,11 +68,20 @@ bool CUI::MouseInsideClip() const
 	return !IsClipped() || MouseInside(ClipArea());
 }
 
-void CUI::ConvertMouseMove(float *x, float *y) const
+void CUI::ConvertCursorMove(float *pX, float *pY, int CursorType) const
 {
-	const float Fac = m_pConfig->m_UiMousesens/float(m_pConfig->m_InpMousesens);
-	*x = *x * Fac;
-	*y = *y * Fac;
+	float Factor = 1.0f;
+	switch(CursorType)
+	{
+		case IInput::CURSOR_MOUSE:
+			Factor = Config()->m_UiMousesens/100.0f;
+			break;
+		case IInput::CURSOR_JOYSTICK:
+			Factor = Config()->m_UiJoystickSens/100.0f;
+			break;
+	}
+	*pX *= Factor;
+	*pY *= Factor;
 }
 
 CUIRect *CUI::Screen()

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -117,7 +117,7 @@ public:
 
 	bool MouseInside(const CUIRect *pRect) const;
 	bool MouseInsideClip() const;
-	void ConvertMouseMove(float *x, float *y) const;
+	void ConvertCursorMove(float *pX, float *pY, int CursorType) const;
 
 	CUIRect *Screen();
 	float PixelSize();

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4641,12 +4641,13 @@ void CEditor::UpdateAndRender()
 	ms_pUiGotContext = 0;
 	UI()->StartCheck();
 
-	// handle mouse movement
-	float mx, my, Mwx, Mwy, Mdx, Mdy;
-	float rx = 0.0f, ry = 0.0f;
+	// handle cursor movement
 	{
-		Input()->MouseRelative(&rx, &ry);
-		UI()->ConvertMouseMove(&rx, &ry);
+		float mx, my, Mwx, Mwy, Mdx, Mdy;
+		float rx = 0.0f, ry = 0.0f;
+		int CursorType = Input()->CursorRelative(&rx, &ry);
+		UI()->ConvertCursorMove(&rx, &ry, CursorType);
+
 		m_MouseDeltaX = rx;
 		m_MouseDeltaY = ry;
 

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -84,6 +84,7 @@ MACRO_CONFIG_INT(UiSettingsPage, ui_settings_page, 0, 0, 5, CFGFLAG_CLIENT|CFGFL
 MACRO_CONFIG_STR(UiServerAddress, ui_server_address, 64, "localhost:8303", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface server address (Internet page)")
 MACRO_CONFIG_STR(UiServerAddressLan, ui_server_address_lan, 64, "localhost:8303", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Interface server address (LAN page)")
 MACRO_CONFIG_INT(UiMousesens, ui_mousesens, 100, 1, 100000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Mouse sensitivity for menus/editor")
+MACRO_CONFIG_INT(UiJoystickSens, ui_joystick_sens, 100, 1, 100000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick sensitivity for menus/editor")
 MACRO_CONFIG_INT(UiAutoswitchInfotab, ui_autoswitch_infotab, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Switch to the info tab when clicking on a server")
 MACRO_CONFIG_INT(UiWideview, ui_wideview, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Extended menus GUI")
 


### PR DESCRIPTION
- Separate mouse and joystick movement in engine.
- Change `CComponent::OnMouseMove` to `OnCursorMove` with additional `CursorType` parameter being `CURSOR_MOUSE` or `CURSOR_JOYSTICK`.
- Add joystick ui sens. config variable. The joystick and mouse position deltas returned by the engine are not scaled by any config variables now. Instead the `CControls::OnCursorMove` method scales them using the ingame sens. values and all other components use the `CUI::ConvertCursorMove` method to use the ui sens. values.
- Adjust joystick speed factor formula to get consistent range of speed and precision with most joystick tolerances.
  - The 0.1f factor is there because all joystick delta values are comparatively large compared to mouse delta values. This brings them into a more similar range of speed.
- Reorder some method declarations in header files to be more consistent. Rename some parameters to be consistent with naming conventions.

Closes #2653.