### PR TITLE
[old editor] don't crash on invalid curve type

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3755,7 +3755,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				const char *paTypeName[] = {
 					"N", "L", "S", "F", "M", "B"
 					};
-				const char *pTypeName = "Invalid";
+				const char *pTypeName = "!?";
 				if(0 <= pEnvelope->m_lPoints[i].m_Curvetype
 						&& pEnvelope->m_lPoints[i].m_Curvetype < (int)(sizeof(paTypeName)/sizeof(const char *)))
 					pTypeName = paTypeName[pEnvelope->m_lPoints[i].m_Curvetype];


### PR DESCRIPTION
Replaced "Invalid" tag with "!?" for because "Invalid" got cut off.
Used my own commit from https://github.com/ddnet/ddnet/pull/2193
fixes crash in https://github.com/teeworlds/teeworlds/issues/2659, ctf8 fix still needed