### PR TITLE
Add 'auto' theme based on season

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1871,6 +1871,36 @@ int time_houroftheday()
 	return time_info->tm_hour;
 }
 
+int time_season()
+{
+	time_t time_data;
+	struct tm *time_info;
+
+	time(&time_data);
+	time_info = localtime(&time_data);
+
+	switch(time_info->tm_mon)
+	{
+		case 11:
+		case 0:
+		case 1:
+			return SEASON_WINTER;
+		case 2:
+		case 3:
+		case 4:
+			return SEASON_SPRING;
+		case 5:
+		case 6:
+		case 7:
+			return SEASON_SUMMER;
+		case 8:
+		case 9:
+		case 10:
+			return SEASON_AUTUMN;
+	}
+	return SEASON_SPRING; // should never happen
+}
+
 int time_isxmasday()
 {
 	time_t time_data;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -539,12 +539,30 @@ int time_timestamp();
 
 /*
 	Function: time_houroftheday
-		Retrives the hours since midnight (0..23)
+		Retrieves the hours since midnight (0..23)
 
 	Returns:
 		The current hour of the day
 */
 int time_houroftheday();
+
+
+enum
+{
+	SEASON_SPRING = 0,
+	SEASON_SUMMER,
+	SEASON_AUTUMN,
+	SEASON_WINTER
+};
+
+/*
+	Function: time_season
+		Retrieves the current season of the year.
+
+	Returns:
+		one of the SEASON_* enum literals
+*/
+int time_season();
 
 /*
 	Function: time_isxmasday

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -19,9 +19,9 @@
 #include "menus.h"
 #include "maplayers.h"
 
-CMapLayers::CMapLayers(int t)
+CMapLayers::CMapLayers(int Type)
 {
-	m_Type = t;
+	m_Type = Type;
 	m_CurrentLocalTick = 0;
 	m_LastLocalTick = 0;
 	m_EnvelopeUpdate = false;
@@ -38,28 +38,50 @@ void CMapLayers::OnStateChange(int NewState, int OldState)
 
 void CMapLayers::LoadBackgroundMap()
 {
-	int HourOfTheDay = time_houroftheday();
+	const char *pMenuMap = Config()->m_ClMenuMap;
+	if(str_comp(pMenuMap, "auto") == 0)
+	{
+		switch(time_season())
+		{
+			case SEASON_SPRING:
+				pMenuMap = "heavens";
+				break;
+			case SEASON_SUMMER:
+				pMenuMap = "jungle";
+				break;
+			case SEASON_AUTUMN:
+				pMenuMap = "autumn";
+				break;
+			case SEASON_WINTER:
+				pMenuMap = "winter";
+				break;
+		}
+	}
+
+	const int HourOfTheDay = time_houroftheday();
+	const bool IsDaytime = HourOfTheDay >= 6 && HourOfTheDay < 18;
+
 	char aBuf[128];
 	// check for the appropriate day/night map
-	str_format(aBuf, sizeof(aBuf), "ui/themes/%s_%s.map", Config()->m_ClMenuMap, (HourOfTheDay >= 6 && HourOfTheDay < 18) ? "day" : "night");
+	str_format(aBuf, sizeof(aBuf), "ui/themes/%s_%s.map", pMenuMap, IsDaytime ? "day" : "night");
 	if(!m_pMenuMap->Load(aBuf, m_pClient->Storage()))
 	{
 		// fall back on generic map
-		str_format(aBuf, sizeof(aBuf), "ui/themes/%s.map", Config()->m_ClMenuMap);
+		str_format(aBuf, sizeof(aBuf), "ui/themes/%s.map", pMenuMap);
 		if(!m_pMenuMap->Load(aBuf, m_pClient->Storage()))
 		{
 			// fall back on day/night alternative map
-			str_format(aBuf, sizeof(aBuf), "ui/themes/%s_%s.map", Config()->m_ClMenuMap, (HourOfTheDay >= 6 && HourOfTheDay < 18) ? "night" : "day");
+			str_format(aBuf, sizeof(aBuf), "ui/themes/%s_%s.map", pMenuMap, IsDaytime ? "night" : "day");
 			if(!m_pMenuMap->Load(aBuf, m_pClient->Storage()))
 			{
-				str_format(aBuf, sizeof(aBuf), "map '%s' not found", Config()->m_ClMenuMap);
+				str_format(aBuf, sizeof(aBuf), "map '%s' not found", pMenuMap);
 				Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", aBuf);
 				return;
 			}
 		}
 	}
 
-	str_format(aBuf, sizeof(aBuf), "loaded map '%s'", Config()->m_ClMenuMap);
+	str_format(aBuf, sizeof(aBuf), "loaded map '%s'", pMenuMap);
 	Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", aBuf);
 
 	m_pMenuLayers->Init(Kernel(), m_pMenuMap);
@@ -91,113 +113,15 @@ void CMapLayers::OnInit()
 	m_pEggTiles = 0;
 }
 
-static void PlaceEggDoodads(int LayerWidth, int LayerHeight, CTile* aOutTiles, CTile* aGameLayerTiles, int ItemWidth, int ItemHeight, const int* aImageTileID, int ImageTileIDCount, int Freq)
-{
-	for(int y = 0; y < LayerHeight-ItemHeight; y++)
-	{
-		for(int x = 0; x < LayerWidth-ItemWidth; x++)
-		{
-			bool Overlap = false;
-			bool ObstructedByWall = false;
-			bool HasGround = true;
-
-			for(int iy = 0; iy < ItemHeight; iy++)
-			{
-				for(int ix = 0; ix < ItemWidth; ix++)
-				{
-					int Tid = (y+iy) * LayerWidth + (x+ix);
-					int DownTid = (y+iy+1) * LayerWidth + (x+ix);
-
-					if(aOutTiles[Tid].m_Index != 0)
-					{
-						Overlap = true;
-						break;
-					}
-
-					if(aGameLayerTiles[Tid].m_Index == 1)
-					{
-						ObstructedByWall = true;
-						break;
-					}
-
-					if(iy == ItemHeight-1 && aGameLayerTiles[DownTid].m_Index != 1)
-					{
-						HasGround = false;
-						break;
-					}
-				}
-			}
-
-			if(!Overlap && !ObstructedByWall && HasGround && random_int()%Freq == 0)
-			{
-				const int BaskerStartID = aImageTileID[random_int()%ImageTileIDCount];
-
-				for(int iy = 0; iy < ItemHeight; iy++)
-				{
-					for(int ix = 0; ix < ItemWidth; ix++)
-					{
-						int Tid = (y+iy) * LayerWidth + (x+ix);
-						aOutTiles[Tid].m_Index = BaskerStartID + iy * 16 + ix;
-					}
-				}
-			}
-		}
-	}
-}
-
 void CMapLayers::OnMapLoad()
 {
 	if(Layers())
+	{
 		LoadEnvPoints(Layers(), m_lEnvPoints);
 
-	// easter time, place eggs
-	if(m_pClient->IsEaster())
-	{
-		CMapItemLayerTilemap* pGameLayer = Layers()->GameLayer();
-		if(m_pEggTiles)
-			mem_free(m_pEggTiles);
-
-		m_EggLayerWidth = pGameLayer->m_Width;
-		m_EggLayerHeight = pGameLayer->m_Height;
-		m_pEggTiles = (CTile*)mem_alloc(sizeof(CTile) * m_EggLayerWidth * m_EggLayerHeight,1);
-		mem_zero(m_pEggTiles, sizeof(CTile) * m_EggLayerWidth * m_EggLayerHeight);
-		CTile* aGameLayerTiles = (CTile*)Layers()->Map()->GetData(pGameLayer->m_Data);
-
-		// first pass: baskets
-		static const int s_aBasketIDs[] = {
-			38,
-			86
-		};
-
-		static const int s_BasketCount = sizeof(s_aBasketIDs)/sizeof(s_aBasketIDs[0]);
-		PlaceEggDoodads(m_EggLayerWidth, m_EggLayerHeight, m_pEggTiles, aGameLayerTiles, 3, 2, s_aBasketIDs, s_BasketCount, 250);
-
-		// second pass: double eggs
-		static const int s_aDoubleEggIDs[] = {
-			9,
-			25,
-			41,
-			57,
-			73,
-			89
-		};
-
-		static const int s_DoubleEggCount = sizeof(s_aDoubleEggIDs)/sizeof(s_aDoubleEggIDs[0]);
-		PlaceEggDoodads(m_EggLayerWidth, m_EggLayerHeight, m_pEggTiles, aGameLayerTiles, 2, 1, s_aDoubleEggIDs, s_DoubleEggCount, 100);
-
-		// third pass: eggs
-		static const int s_aEggIDs[] = {
-			1, 2, 3, 4, 5,
-			17, 18, 19, 20,
-			33, 34, 35, 36,
-			49, 50,     52,
-			65, 66,
-				82,
-				98
-		};
-
-		static const int s_EggCount = sizeof(s_aEggIDs)/sizeof(s_aEggIDs[0]);
-		PlaceEggDoodads(m_EggLayerWidth, m_EggLayerHeight, m_pEggTiles, aGameLayerTiles, 1, 1, s_aEggIDs, s_EggCount, 30);
+		// easter time, place eggs
+		if(m_pClient->IsEaster())
+			PlaceEasterEggs(Layers());
 	}
 }
 
@@ -534,4 +458,107 @@ void CMapLayers::BackgroundMapUpdate()
 		if(Config()->m_ClShowMenuMap)
 			LoadBackgroundMap();
 	}
+}
+
+static void PlaceEggDoodads(int LayerWidth, int LayerHeight, CTile* aOutTiles, CTile* aGameLayerTiles, int ItemWidth, int ItemHeight, const int* aImageTileID, int ImageTileIDCount, int Freq)
+{
+	for(int y = 0; y < LayerHeight-ItemHeight; y++)
+	{
+		for(int x = 0; x < LayerWidth-ItemWidth; x++)
+		{
+			bool Overlap = false;
+			bool ObstructedByWall = false;
+			bool HasGround = true;
+
+			for(int iy = 0; iy < ItemHeight; iy++)
+			{
+				for(int ix = 0; ix < ItemWidth; ix++)
+				{
+					int Tid = (y+iy) * LayerWidth + (x+ix);
+					int DownTid = (y+iy+1) * LayerWidth + (x+ix);
+
+					if(aOutTiles[Tid].m_Index != 0)
+					{
+						Overlap = true;
+						break;
+					}
+
+					if(aGameLayerTiles[Tid].m_Index == 1)
+					{
+						ObstructedByWall = true;
+						break;
+					}
+
+					if(iy == ItemHeight-1 && aGameLayerTiles[DownTid].m_Index != 1)
+					{
+						HasGround = false;
+						break;
+					}
+				}
+			}
+
+			if(!Overlap && !ObstructedByWall && HasGround && random_int()%Freq == 0)
+			{
+				const int BaskerStartID = aImageTileID[random_int()%ImageTileIDCount];
+
+				for(int iy = 0; iy < ItemHeight; iy++)
+				{
+					for(int ix = 0; ix < ItemWidth; ix++)
+					{
+						int Tid = (y+iy) * LayerWidth + (x+ix);
+						aOutTiles[Tid].m_Index = BaskerStartID + iy * 16 + ix;
+					}
+				}
+			}
+		}
+	}
+}
+
+void CMapLayers::PlaceEasterEggs(const CLayers *pLayers)
+{
+	CMapItemLayerTilemap* pGameLayer = pLayers->GameLayer();
+	if(m_pEggTiles)
+		mem_free(m_pEggTiles);
+
+	m_EggLayerWidth = pGameLayer->m_Width;
+	m_EggLayerHeight = pGameLayer->m_Height;
+	m_pEggTiles = (CTile*)mem_alloc(sizeof(CTile) * m_EggLayerWidth * m_EggLayerHeight,1);
+	mem_zero(m_pEggTiles, sizeof(CTile) * m_EggLayerWidth * m_EggLayerHeight);
+	CTile* aGameLayerTiles = (CTile*)pLayers->Map()->GetData(pGameLayer->m_Data);
+
+	// first pass: baskets
+	static const int s_aBasketIDs[] = {
+		38,
+		86
+	};
+
+	static const int s_BasketCount = sizeof(s_aBasketIDs)/sizeof(s_aBasketIDs[0]);
+	PlaceEggDoodads(m_EggLayerWidth, m_EggLayerHeight, m_pEggTiles, aGameLayerTiles, 3, 2, s_aBasketIDs, s_BasketCount, 250);
+
+	// second pass: double eggs
+	static const int s_aDoubleEggIDs[] = {
+		9,
+		25,
+		41,
+		57,
+		73,
+		89
+	};
+
+	static const int s_DoubleEggCount = sizeof(s_aDoubleEggIDs)/sizeof(s_aDoubleEggIDs[0]);
+	PlaceEggDoodads(m_EggLayerWidth, m_EggLayerHeight, m_pEggTiles, aGameLayerTiles, 2, 1, s_aDoubleEggIDs, s_DoubleEggCount, 100);
+
+	// third pass: eggs
+	static const int s_aEggIDs[] = {
+		1, 2, 3, 4, 5,
+		17, 18, 19, 20,
+		33, 34, 35, 36,
+		49, 50,     52,
+		65, 66,
+			82,
+			98
+	};
+
+	static const int s_EggCount = sizeof(s_aEggIDs)/sizeof(s_aEggIDs[0]);
+	PlaceEggDoodads(m_EggLayerWidth, m_EggLayerHeight, m_pEggTiles, aGameLayerTiles, 1, 1, s_aEggIDs, s_EggCount, 30);
 }

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -28,6 +28,8 @@ class CMapLayers : public CComponent
 	void LoadEnvPoints(const CLayers *pLayers, array<CEnvPoint>& lEnvPoints);
 	void LoadBackgroundMap();
 
+	void PlaceEasterEggs(const CLayers *pLayers);
+
 public:
 	enum
 	{

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -90,7 +90,7 @@ MACRO_CONFIG_INT(UiWideview, ui_wideview, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, 
 
 MACRO_CONFIG_INT(GfxNoclip, gfx_noclip, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Disable clipping")
 
-MACRO_CONFIG_STR(ClMenuMap, cl_menu_map, 64, "heavens", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Background map in the menu")
+MACRO_CONFIG_STR(ClMenuMap, cl_menu_map, 64, "auto", CFGFLAG_CLIENT|CFGFLAG_SAVE, "Background map in the menu, auto = automatic based on season")
 MACRO_CONFIG_INT(ClShowMenuMap, cl_show_menu_map, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Display background map in the menu")
 MACRO_CONFIG_INT(ClMenuAlpha, cl_menu_alpha, 25, 0, 75, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Transparency of the menu background")
 MACRO_CONFIG_INT(ClRotationRadius, cl_rotation_radius, 30, 1, 500, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Menu camera rotation radius")


### PR DESCRIPTION
- Setting the menu map to `auto` will choose one of the themes based on the current season.
- For simplicity, all seasons are 3 months long, with Winter starting in December.
- Season to theme-mapping:
  - Spring: heavens
  - Summer: jungle
  - Autumn: autumn (#2682 )
  - Winter: winter
- Fix theme selection not being updated when changing the config variable manually.
- Still needs an `auto.png` icon. Can also be a separate issue.