### PR TITLE
Fix various server browser UI issues, refactoring

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -807,7 +807,7 @@ private:
 	void RenderServerbrowserOverlay();
 	void RenderFilterHeader(CUIRect View, int FilterIndex);
 	void PopupConfirmRemoveFilter();
-	int DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEntry, const CBrowserFilter *pFilter, bool Selected);
+	int DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEntry, const CBrowserFilter *pFilter, bool Selected, bool ShowServerInfo);
 	void RenderServerbrowser(CUIRect MainView);
 	static void ConchainConnect(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainFriendlistUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -427,7 +427,7 @@ void CMenus::SetOverlay(int Type, float x, float y, const void *pData)
 }
 
 // 1 = browser entry click, 2 = server info click
-int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEntry, const CBrowserFilter *pFilter, bool Selected)
+int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEntry, const CBrowserFilter *pFilter, bool Selected, bool ShowServerInfo)
 {
 	// logic
 	int ReturnValue = 0;
@@ -451,18 +451,24 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 	if(Inside)
 	{
 		UI()->SetHotItem(pID);
-		RenderTools()->DrawUIRect(&View, vec4(1.0f, 1.0f, 1.0f, 0.5f), CUI::CORNER_ALL, 4.0f);
+		RenderTools()->DrawRoundRect(&View, vec4(1.0f, 1.0f, 1.0f, 0.5f), 5.0f);
+	}
+	else if(Selected)
+	{
+		RenderTools()->DrawRoundRect(&View, vec4(0.8f, 0.8f, 0.8f, 0.5f), 5.0f);
 	}
 
-	vec3 TextBaseColor = vec3(1.0f, 1.0f, 1.0f);
+	const float FontSize = 12.0f;
+	const float TextAlpha = (pEntry->m_NumClients == pEntry->m_MaxClients) ? 0.5f : 1.0f;
+	vec4 TextBaseColor = vec4(1.0f, 1.0f, 1.0f, TextAlpha);
 	vec4 TextBaseOutlineColor = vec4(0.0, 0.0, 0.0, 0.3f);
+	vec4 HighlightColor = vec4(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextAlpha);
 	if(Selected || Inside)
 	{
-		TextBaseColor = vec3(0.0f, 0.0f, 0.0f);
+		TextBaseColor = vec4(0.0f, 0.0f, 0.0f, TextAlpha);
 		TextBaseOutlineColor = vec4(0.8f, 0.8f, 0.8f, 0.25f);
 	}
 
-	float TextAlpha = (pEntry->m_NumClients == pEntry->m_MaxClients) ? 0.5f : 1.0f;
 	for(int c = 0; c < NUM_BROWSER_COLS; c++)
 	{
 		CUIRect Button = ms_aBrowserCols[c].m_Rect;
@@ -488,9 +494,8 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 
 			Rect.VSplitLeft(Rect.h, &Icon, &Rect);
 			Icon.Margin(2.0f, &Icon);
-			int Level = pEntry->m_ServerLevel;
 
-			DoIcon(IMAGE_LEVELICONS, Level==0 ? SPRITE_LEVEL_A_ON : Level==1 ? SPRITE_LEVEL_B_ON : SPRITE_LEVEL_C_ON, &Icon);
+			DoIcon(IMAGE_LEVELICONS, pEntry->m_ServerLevel==0 ? SPRITE_LEVEL_A_ON : pEntry->m_ServerLevel==1 ? SPRITE_LEVEL_B_ON : SPRITE_LEVEL_C_ON, &Icon);
 
 			Rect.VSplitLeft(Rect.h, &Icon, &Rect);
 			Icon.Margin(2.0f, &Icon);
@@ -518,72 +523,20 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 		}
 		else if(ID == COL_BROWSER_NAME)
 		{
-			CTextCursor Cursor;
-			float tw = TextRender()->TextWidth(0, 12.0f, pEntry->m_aName, -1, -1.0f);
-			if(tw < Button.w)
-				TextRender()->SetCursor(&Cursor, Button.x, Button.y, 12.0f, TEXTFLAG_RENDER);
-			else
-			{
-				TextRender()->SetCursor(&Cursor, Button.x, Button.y, 12.0f, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
-				Cursor.m_LineWidth = Button.w;
-			}
-
-			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
+			TextRender()->TextColor(TextBaseColor);
 			TextRender()->TextOutlineColor(TextBaseOutlineColor);
-
-			if(Config()->m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_SERVERNAME))
-			{
-				// highlight the part that matches
-				const char *pStr = str_find_nocase(pEntry->m_aName, Config()->m_BrFilterString);
-				if(pStr)
-				{
-					TextRender()->TextEx(&Cursor, pEntry->m_aName, (int)(pStr-pEntry->m_aName));
-					TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextAlpha);
-					TextRender()->TextEx(&Cursor, pStr, str_length(Config()->m_BrFilterString));
-					TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
-					TextRender()->TextEx(&Cursor, pStr+str_length(Config()->m_BrFilterString), -1);
-				}
-				else
-					TextRender()->TextEx(&Cursor, pEntry->m_aName, -1);
-			}
-			else
-				TextRender()->TextEx(&Cursor, pEntry->m_aName, -1);
+			Button.y += 2.0f;
+			UI()->DoLabelHighlighted(&Button, pEntry->m_aName, (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_SERVERNAME) ? Config()->m_BrFilterString : 0, FontSize, TextBaseColor, HighlightColor);
 		}
 		else if(ID == COL_BROWSER_MAP)
 		{
-			CTextCursor Cursor;
-			float tw = TextRender()->TextWidth(0, 12.0f, pEntry->m_aMap, -1, -1.0f);
-			if(tw < Button.w)
-				TextRender()->SetCursor(&Cursor, Button.x, Button.y, 12.0f, TEXTFLAG_RENDER);
-			else
-			{
-				TextRender()->SetCursor(&Cursor, Button.x, Button.y, 12.0f, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
-				Cursor.m_LineWidth = Button.w;
-			}
-
-			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
-
-			if(Config()->m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_MAPNAME))
-			{
-				// highlight the part that matches
-				const char *pStr = str_find_nocase(pEntry->m_aMap, Config()->m_BrFilterString);
-				if(pStr)
-				{
-					TextRender()->TextEx(&Cursor, pEntry->m_aMap, (int)(pStr-pEntry->m_aMap));
-					TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextAlpha);
-					TextRender()->TextEx(&Cursor, pStr, str_length(Config()->m_BrFilterString));
-					TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
-					TextRender()->TextEx(&Cursor, pStr+str_length(Config()->m_BrFilterString), -1);
-				}
-				else
-					TextRender()->TextEx(&Cursor, pEntry->m_aMap, -1);
-			}
-			else
-				TextRender()->TextEx(&Cursor, pEntry->m_aMap, -1);
+			TextRender()->TextColor(TextBaseColor);
+			Button.y += 2.0f;
+			UI()->DoLabelHighlighted(&Button, pEntry->m_aMap, (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_MAPNAME) ? Config()->m_BrFilterString : 0, FontSize, TextBaseColor, HighlightColor);
 		}
 		else if(ID == COL_BROWSER_PLAYERS)
 		{
-			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
+			TextRender()->TextColor(TextBaseColor);
 			TextRender()->TextOutlineColor(TextBaseOutlineColor);
 			CServerFilterInfo FilterInfo;
 			pFilter->GetFilter(&FilterInfo);
@@ -609,10 +562,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 			}
 			static float RenderOffset = 0.0f;
 			if(RenderOffset == 0.0f)
-			{
-				char aChar[2] = "0";
-				RenderOffset = TextRender()->TextWidth(0, 12.0f, aChar, -1, -1.0f);
-			}
+				RenderOffset = TextRender()->TextWidth(0, FontSize, "0", -1, -1.0f);
 
 			str_format(aTemp, sizeof(aTemp), "%d/%d", Num, Max);
 			if(Config()->m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_PLAYER))
@@ -625,8 +575,8 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 				Button.x += RenderOffset;
 			if(!Num)
 				TextRender()->TextColor(CUI::ms_TransparentTextColor);
-			UI()->DoLabel(&Button, aTemp, 12.0f, CUI::ALIGN_LEFT);
-			Button.x += TextRender()->TextWidth(0, 12.0f, aTemp, -1, -1.0f);
+			UI()->DoLabel(&Button, aTemp, FontSize, CUI::ALIGN_LEFT);
+			Button.x += TextRender()->TextWidth(0, FontSize, aTemp, -1, -1.0f);
 		}
 		else if(ID == COL_BROWSER_PING)
 		{
@@ -635,7 +585,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 			vec4 Color;
 			if(Selected || Inside)
 			{
-				Color = vec4(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
+				Color = TextBaseColor;
 			}
 			else
 			{
@@ -664,7 +614,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 			TextRender()->TextOutlineColor(TextBaseOutlineColor);
 			Button.y += 2.0f;
 			Button.w -= 4.0f;
-			UI()->DoLabel(&Button, aTemp, 12.0f, CUI::ALIGN_RIGHT);
+			UI()->DoLabel(&Button, aTemp, FontSize, CUI::ALIGN_RIGHT);
 		}
 		else if(ID == COL_BROWSER_GAMETYPE)
 		{
@@ -675,37 +625,15 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 			DoGameIcon(pEntry->m_aGameType, &Icon);
 
 			// gametype text
-			CTextCursor Cursor;
-			TextRender()->SetCursor(&Cursor, Button.x, Button.y, 12.0f, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
-			Cursor.m_LineWidth = Button.w;
-			TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
-
-			if(Config()->m_BrFilterString[0] && (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_GAMETYPE))
-			{
-				// highlight the part that matches
-				const char *pStr = str_find_nocase(pEntry->m_aGameType, Config()->m_BrFilterString);
-				if(pStr)
-				{
-					TextRender()->TextEx(&Cursor, pEntry->m_aGameType, (int)(pStr-pEntry->m_aGameType));
-					TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextAlpha);
-					TextRender()->TextEx(&Cursor, pStr, str_length(Config()->m_BrFilterString));
-					TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
-					TextRender()->TextEx(&Cursor, pStr+str_length(Config()->m_BrFilterString), -1);
-				}
-				else
-					TextRender()->TextEx(&Cursor, pEntry->m_aGameType, -1);
-			}
-			else
-			{
-				TextRender()->TextColor(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha);
-				TextRender()->TextOutlineColor(TextBaseOutlineColor);
-				TextRender()->TextEx(&Cursor, pEntry->m_aGameType, -1);
-			}
+			TextRender()->TextColor(TextBaseColor);
+			TextRender()->TextOutlineColor(TextBaseOutlineColor);
+			Button.y += 2.0f;
+			UI()->DoLabelHighlighted(&Button, pEntry->m_aGameType, (pEntry->m_QuickSearchHit&IServerBrowser::QUICK_GAMETYPE) ? Config()->m_BrFilterString : 0, FontSize, TextBaseColor, HighlightColor);
 		}
 	}
 
 	// show server info
-	if(!m_SidebarActive && m_ShowServerDetails && Selected)
+	if(ShowServerInfo)
 	{
 		CUIRect Info;
 		View.HSplitTop(ms_aBrowserCols[0].m_Rect.h, 0, &View);
@@ -716,9 +644,7 @@ int CMenus::DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEn
 		View.VSplitLeft(160.0f, &Info, &View);
 		RenderDetailInfo(Info, pEntry);
 
-		UI()->ClipEnable(&View);
-		RenderDetailScoreboard(View, pEntry, 4, vec4(TextBaseColor.r, TextBaseColor.g, TextBaseColor.b, TextAlpha), TextBaseOutlineColor);
-		UI()->ClipDisable();
+		RenderDetailScoreboard(View, pEntry, 4, TextBaseColor, TextBaseOutlineColor);
 	}
 
 	TextRender()->TextColor(CUI::ms_DefaultTextColor);
@@ -844,9 +770,10 @@ void CMenus::RenderServerbrowserOverlay()
 		return;
 	}
 
-	int Type = m_InfoOverlay.m_Type;
-	CUIRect View;
+	const int Type = m_InfoOverlay.m_Type;
+	const float FontSize = 12.0f;
 
+	CUIRect View;
 	if(Type == CInfoOverlay::OVERLAY_HEADERINFO)
 	{
 		CBrowserFilter *pFilter = (CBrowserFilter*)m_InfoOverlay.m_pData;
@@ -858,7 +785,7 @@ void CMenus::RenderServerbrowserOverlay()
 		View.h = 30.0f;
 
 		// render background
-		RenderTools()->DrawUIRect(&View, vec4(0.25f, 0.25f, 0.25f, 1.0f), CUI::CORNER_ALL, 6.0f);
+		RenderTools()->DrawRoundRect(&View, vec4(0.25f, 0.25f, 0.25f, 1.0f), 6.0f);
 
 		View.Margin(2.0f, &View);
 		CUIRect NumServers, NumPlayers;
@@ -866,10 +793,10 @@ void CMenus::RenderServerbrowserOverlay()
 
 		char aBuf[128];
 		str_format(aBuf, sizeof(aBuf), "%s: %d", Localize("Servers"), pFilter->NumSortedServers());
-		UI()->DoLabel(&NumServers, aBuf, 12.0f, CUI::ALIGN_CENTER);
+		UI()->DoLabel(&NumServers, aBuf, FontSize, CUI::ALIGN_CENTER);
 
 		str_format(aBuf, sizeof(aBuf), "%s: %d", Localize("Players"), pFilter->NumPlayers());
-		UI()->DoLabel(&NumPlayers, aBuf, 12.0f, CUI::ALIGN_CENTER);
+		UI()->DoLabel(&NumPlayers, aBuf, FontSize, CUI::ALIGN_CENTER);
 	}
 	else if(Type == CInfoOverlay::OVERLAY_SERVERINFO)
 	{
@@ -884,7 +811,7 @@ void CMenus::RenderServerbrowserOverlay()
 			View.y -= View.y+View.h - 590.0f;
 
 		// render background
-		RenderTools()->DrawUIRect(&View, vec4(0.25f, 0.25f, 0.25f, 1.0f), CUI::CORNER_ALL, 6.0f);
+		RenderTools()->DrawRoundRect(&View, vec4(0.25f, 0.25f, 0.25f, 1.0f), 6.0f);
 
 		RenderServerbrowserServerDetail(View, pInfo);
 	}
@@ -914,11 +841,10 @@ void CMenus::RenderServerbrowserOverlay()
 				View.y -= View.y+View.h - 590.0f;
 
 			// render background
-			RenderTools()->DrawUIRect(&View, vec4(1.0f, 1.0f, 1.0f, 0.75f), CUI::CORNER_ALL, 6.0f);
+			RenderTools()->DrawRoundRect(&View, vec4(1.0f, 1.0f, 1.0f, 0.75f), 6.0f);
 
 			CUIRect ServerScoreBoard = View;
 			CTextCursor Cursor;
-			const float FontSize = 12.0f;
 			for (int i = 0; i < pInfo->m_NumClients; i++)
 			{
 				CUIRect Name, Clan, Score, Flag;
@@ -933,9 +859,10 @@ void CMenus::RenderServerbrowserOverlay()
 					Client()->ServerBrowserUpdate();
 				}
 
-				vec4 Colour = pInfo->m_aClients[i].m_FriendState == CContactInfo::CONTACT_NO ? vec4(1.0f, 1.0f, 1.0f, (i%2+1)*0.05f) :
-																									vec4(0.5f, 1.0f, 0.5f, 0.15f+(i%2+1)*0.05f);
-				RenderTools()->DrawUIRect(&Name, Colour, CUI::CORNER_ALL, 4.0f);
+				vec4 BackgroundColor = pInfo->m_aClients[i].m_FriendState == CContactInfo::CONTACT_NO
+						? vec4(1.0f, 1.0f, 1.0f, (i%2+1)*0.05f)
+						: vec4(0.5f, 1.0f, 0.5f, 0.15f+(i%2+1)*0.05f);
+				RenderTools()->DrawRoundRect(&Name, BackgroundColor, 4.0f);
 				Name.VSplitLeft(5.0f, 0, &Name);
 				Name.VSplitLeft(30.0f, &Score, &Name);
 				Name.VSplitRight(34.0f, &Name, &Flag);
@@ -953,52 +880,16 @@ void CMenus::RenderServerbrowserOverlay()
 				}
 
 				// name
-				TextRender()->SetCursor(&Cursor, Name.x, Name.y+(Name.h-FontSize)/4.0f, FontSize, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
-				Cursor.m_LineWidth = Name.w;
-				const char *pName = pInfo->m_aClients[i].m_aName;
-				if(Config()->m_BrFilterString[0])
-				{
-					// highlight the part that matches
-					const char *s = str_find_nocase(pName, Config()->m_BrFilterString);
-					if(s)
-					{
-						TextRender()->TextEx(&Cursor, pName, (int)(s-pName));
-						TextRender()->TextColor(CUI::ms_HighlightTextColor);
-						TextRender()->TextEx(&Cursor, s, str_length(Config()->m_BrFilterString));
-						TextRender()->TextColor(CUI::ms_DefaultTextColor);
-						TextRender()->TextEx(&Cursor, s+str_length(Config()->m_BrFilterString), -1);
-					}
-					else
-						TextRender()->TextEx(&Cursor, pName, -1);
-				}
-				else
-					TextRender()->TextEx(&Cursor, pName, -1);
+				Name.y += 2.0f;
+				UI()->DoLabelHighlighted(&Name, pInfo->m_aClients[i].m_aName, Config()->m_BrFilterString, FontSize, CUI::ms_DefaultTextColor, CUI::ms_HighlightTextColor);
 
 				// clan
-				TextRender()->SetCursor(&Cursor, Clan.x, Clan.y+(Clan.h-FontSize)/4.0f, FontSize, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
-				Cursor.m_LineWidth = Clan.w;
-				const char *pClan = pInfo->m_aClients[i].m_aClan;
-				if(Config()->m_BrFilterString[0])
-				{
-					// highlight the part that matches
-					const char *s = str_find_nocase(pClan, Config()->m_BrFilterString);
-					if(s)
-					{
-						TextRender()->TextEx(&Cursor, pClan, (int)(s-pClan));
-						TextRender()->TextColor(CUI::ms_HighlightTextColor);
-						TextRender()->TextEx(&Cursor, s, str_length(Config()->m_BrFilterString));
-						TextRender()->TextColor(CUI::ms_DefaultTextColor);
-						TextRender()->TextEx(&Cursor, s+str_length(Config()->m_BrFilterString), -1);
-					}
-					else
-						TextRender()->TextEx(&Cursor, pClan, -1);
-				}
-				else
-					TextRender()->TextEx(&Cursor, pClan, -1);
+				Clan.y += 2.0f;
+				UI()->DoLabelHighlighted(&Clan, pInfo->m_aClients[i].m_aClan, Config()->m_BrFilterString, FontSize, CUI::ms_DefaultTextColor, CUI::ms_HighlightTextColor);
 
 				// flag
-				vec4 Color(1.0f, 1.0f, 1.0f, 0.75f);
-				m_pClient->m_pCountryFlags->Render(pInfo->m_aClients[i].m_Country, &Color, Flag.x, Flag.y, Flag.w, Flag.h);
+				vec4 FlagColor(1.0f, 1.0f, 1.0f, 0.75f);
+				m_pClient->m_pCountryFlags->Render(pInfo->m_aClients[i].m_Country, &FlagColor, Flag.x, Flag.y, Flag.w, Flag.h);
 			}
 		}
 		else
@@ -1016,7 +907,7 @@ void CMenus::RenderServerbrowserOverlay()
 				View.y -= View.y+View.h - 590.0f;
 
 			// render background
-			RenderTools()->DrawUIRect(&View, vec4(1.0f, 1.0f, 1.0f, 0.75f), CUI::CORNER_ALL, 6.0f);
+			RenderTools()->DrawRoundRect(&View, vec4(1.0f, 1.0f, 1.0f, 0.75f), 6.0f);
 
 			View.y += 2.0f;
 			UI()->DoLabel(&View, Localize("no players", "server browser message"), View.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
@@ -1194,6 +1085,8 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	const bool CtrlPressed = Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL);
 
 	// handle arrow hotkeys
+	const int LastSelectedFilter = m_aSelectedFilters[BrowserType];
+	const int LastSelectedServer = m_aSelectedServers[BrowserType];
 	if(SelectedFilter > -1)
 	{
 		int NewFilter = SelectedFilter;
@@ -1242,7 +1135,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			if(m_aSelectedServers[BrowserType] != ToBeSelectedServer)
 			{
 				m_aSelectedServers[BrowserType] = ToBeSelectedServer;
-				m_ShowServerDetails = true;
+				m_ShowServerDetails = false; // close server details when scrolling with arrows, as this leads to flicking
 				m_AddressSelection |= ADDR_SELECTION_REVEAL;
 			}
 
@@ -1302,11 +1195,9 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 					}
 				}
 
-				float ItemHeight = HeaderHeight;
-				if(!m_SidebarActive && IsSelected && m_ShowServerDetails)
-				{
-					ItemHeight *= 6.0f;
-				}
+				const bool ShowServerInfo = !m_SidebarActive && m_ShowServerDetails && IsSelected;
+				const float ItemHeight = HeaderHeight * (ShowServerInfo ? 6.0f : 1.0f);
+
 				CUIRect Row;
 				View.HSplitTop(ItemHeight, &Row, &View);
 				s_ScrollRegion.AddRect(Row);
@@ -1316,19 +1207,15 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 					s_ScrollRegion.ScrollHere();
 					m_AddressSelection &= ~ADDR_SELECTION_REVEAL;
 				}
-
-				if(s_ScrollRegion.IsRectClipped(Row))
+				else if(s_ScrollRegion.IsRectClipped(Row))
 				{
 					// only those in the view are rendered and can be selected
 					continue;
 				}
 
-				if(IsSelected)
-				{
-					RenderTools()->DrawUIRect(&Row, vec4(1.0f, 1.0f, 1.0f, 0.5f), CUI::CORNER_ALL, 5.0f);
-				}
-
-				if(int ReturnValue = DoBrowserEntry(pFilter->ID(ServerIndex), Row, pItem, pFilter, IsSelected))
+				// Prevent flickering entry background and text by drawing it as selected for one more frame after the selection has changed
+				const bool WasSelected = LastSelectedFilter >= 0 && LastSelectedServer >= 0 && FilterIndex == LastSelectedFilter && ServerIndex == LastSelectedServer;
+				if(int ReturnValue = DoBrowserEntry(pFilter->ID(ServerIndex), Row, pItem, pFilter, IsSelected || WasSelected, ShowServerInfo))
 				{
 					m_ShowServerDetails = !m_ShowServerDetails || ReturnValue == 2 || m_aSelectedServers[BrowserType] != ServerIndex; // click twice on line => fold server details
 					m_aSelectedFilters[BrowserType] = FilterIndex;
@@ -1464,10 +1351,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		// todo: move this to a helper function
 		static float RenderOffset = 0.0f;
 		if(RenderOffset == 0.0f)
-		{
-			char aChar[2] = "0";
-			RenderOffset = TextRender()->TextWidth(0, 12.0f, aChar, -1, -1.0f);
-		}
+			RenderOffset = TextRender()->TextWidth(0, FontSize, "0", -1, -1.0f);
 
 		float OffsetServer = 0.0f, OffsetPlayer = 0.0f;
 		int Num = ServerBrowser()->NumServers();
@@ -1484,6 +1368,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			OffsetPlayer += RenderOffset;
 		if(NumPlayers < 10)
 			OffsetPlayer += RenderOffset;
+
 		char aBuf[128];
 		Status.VSplitLeft(20.0f, 0, &Status);
 		Status.HSplitTop(ButtonHeight/1.5f, 0, &Status);
@@ -1492,6 +1377,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		Label.y += 2.0f;
 		Label.x += OffsetServer;
 		UI()->DoLabel(&Label, aBuf, 14.0f, CUI::ALIGN_LEFT);
+
 		Status.HSplitTop(SpacingH, 0, &Status);
 		Status.HSplitTop(ButtonHeight, &Label, 0);
 		str_format(aBuf, sizeof(aBuf), Localize("%d players"), NumPlayers);
@@ -1806,12 +1692,16 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 	Label.HMargin(2.0f, &Label);
 	UI()->DoLabel(&Label, Localize("New filter"), FontSize, CUI::ALIGN_LEFT);
 	if(s_aFilterName[0])
-		DoIcon(IMAGE_FRIENDICONS, UI()->MouseInside(&Button) ? SPRITE_FRIEND_PLUS_A : SPRITE_FRIEND_PLUS_B, &Icon);
-	static CButtonContainer s_AddFilter;
-	if(s_aFilterName[0] && UI()->DoButtonLogic(&s_AddFilter, &Button))
 	{
-		m_lFilters.add(CBrowserFilter(CBrowserFilter::FILTER_CUSTOM, s_aFilterName, ServerBrowser()));
-		s_aFilterName[0] = 0;
+		DoIcon(IMAGE_FRIENDICONS, UI()->MouseInside(&Button) ? SPRITE_FRIEND_PLUS_A : SPRITE_FRIEND_PLUS_B, &Icon);
+		static CButtonContainer s_AddFilter;
+		if(UI()->DoButtonLogic(&s_AddFilter, &Button))
+		{
+			m_lFilters.add(CBrowserFilter(CBrowserFilter::FILTER_CUSTOM, s_aFilterName, ServerBrowser()));
+			m_lFilters[m_lFilters.size()-1].Switch();
+			s_aFilterName[0] = 0;
+			Client()->ServerBrowserUpdate();
+		}
 	}
 
 	CBrowserFilter *pFilter = GetSelectedBrowserFilter();
@@ -1832,48 +1722,48 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 	static int s_BrFilterEmpty = 0;
 	if(DoButton_CheckBox(&s_BrFilterEmpty, Localize("Has people playing"), FilterInfo.m_SortHash&IServerBrowser::FILTER_EMPTY, &Button))
-		NewSortHash = FilterInfo.m_SortHash^IServerBrowser::FILTER_EMPTY;
+		NewSortHash ^= IServerBrowser::FILTER_EMPTY;
 
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 	static int s_BrFilterSpectators = 0;
 	if(DoButton_CheckBox(&s_BrFilterSpectators, Localize("Count players only"), FilterInfo.m_SortHash&IServerBrowser::FILTER_SPECTATORS, &Button))
-		NewSortHash = FilterInfo.m_SortHash^IServerBrowser::FILTER_SPECTATORS;
+		NewSortHash ^= IServerBrowser::FILTER_SPECTATORS;
 
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 	static int s_BrFilterFull = 0;
 	if(DoButton_CheckBox(&s_BrFilterFull, Localize("Server not full"), FilterInfo.m_SortHash&IServerBrowser::FILTER_FULL, &Button))
-		NewSortHash = FilterInfo.m_SortHash^IServerBrowser::FILTER_FULL;
+		NewSortHash ^= IServerBrowser::FILTER_FULL;
 
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 	static int s_BrFilterFriends = 0;
 	if(DoButton_CheckBox(&s_BrFilterFriends, Localize("Show friends only"), FilterInfo.m_SortHash&IServerBrowser::FILTER_FRIENDS, &Button))
-		NewSortHash = FilterInfo.m_SortHash^IServerBrowser::FILTER_FRIENDS;
+		NewSortHash ^= IServerBrowser::FILTER_FRIENDS;
 
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 	static int s_BrFilterBots = 0;
 	if(DoButton_CheckBox(&s_BrFilterBots, Localize("Hide bots"), FilterInfo.m_SortHash&IServerBrowser::FILTER_BOTS, &Button))
-		NewSortHash = FilterInfo.m_SortHash^IServerBrowser::FILTER_BOTS;
+		NewSortHash ^= IServerBrowser::FILTER_BOTS;
 
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 	static int s_BrFilterPw = 0;
 	if(DoButton_CheckBox(&s_BrFilterPw, Localize("No password"), FilterInfo.m_SortHash&IServerBrowser::FILTER_PW, &Button))
-		NewSortHash = FilterInfo.m_SortHash^IServerBrowser::FILTER_PW;
+		NewSortHash ^= IServerBrowser::FILTER_PW;
 
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 	static int s_BrFilterCompatversion = 0;
 	if(DoButton_CheckBox(&s_BrFilterCompatversion, Localize("Compatible version"), FilterInfo.m_SortHash&IServerBrowser::FILTER_COMPAT_VERSION, &Button))
-		NewSortHash = FilterInfo.m_SortHash^IServerBrowser::FILTER_COMPAT_VERSION;
+		NewSortHash ^= IServerBrowser::FILTER_COMPAT_VERSION;
 
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 	const bool Locked = pFilter->Custom() == CBrowserFilter::FILTER_STANDARD;
 	static int s_BrFilterPure = 0;
 	if(DoButton_CheckBox(&s_BrFilterPure, Localize("Standard gametype"), FilterInfo.m_SortHash&IServerBrowser::FILTER_PURE, &Button, Locked))
-		NewSortHash = FilterInfo.m_SortHash^IServerBrowser::FILTER_PURE;
+		NewSortHash ^= IServerBrowser::FILTER_PURE;
 
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 	static int s_BrFilterPureMap = 0;
 	if(DoButton_CheckBox(&s_BrFilterPureMap, Localize("Standard map"), FilterInfo.m_SortHash&IServerBrowser::FILTER_PURE_MAP, &Button))
-		NewSortHash = FilterInfo.m_SortHash^IServerBrowser::FILTER_PURE_MAP;
+		NewSortHash ^= IServerBrowser::FILTER_PURE_MAP;
 
 	bool UpdateFilter = false;
 	if(FilterInfo.m_SortHash != NewSortHash)
@@ -1885,10 +1775,8 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 	// game types filter
 	{
 		ServerFilter.HSplitTop(5.0f, 0, &ServerFilter);
-
 		ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 		UI()->DoLabel(&Button, Localize("Game types:"), FontSize, CUI::ALIGN_LEFT);
-
 		ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 		RenderTools()->DrawUIRect(&Button, vec4(0.0, 0.0, 0.0, 0.25f), CUI::CORNER_ALL, 2.0f);
 
@@ -2126,69 +2014,77 @@ void CMenus::RenderServerbrowserInfoTab(CUIRect View)
 
 void CMenus::RenderDetailInfo(CUIRect View, const CServerInfo *pInfo)
 {
-	CUIRect ServerHeader;
 	const float FontSize = 10.0f;
+	const float RowHeight = 15.0f;
+
+	CUIRect ServerHeader;
 	View.HSplitTop(GetListHeaderHeight(), &ServerHeader, &View);
-	RenderTools()->DrawUIRect(&ServerHeader, vec4(1, 1, 1, 0.25f), CUI::CORNER_T, 4.0f);
-	RenderTools()->DrawUIRect(&View, vec4(0, 0, 0, 0.15f), CUI::CORNER_B, 4.0f);
+	RenderTools()->DrawUIRect(&ServerHeader, vec4(1, 1, 1, 0.25f), CUI::CORNER_T, 5.0f);
+	RenderTools()->DrawUIRect(&View, vec4(0, 0, 0, 0.15f), CUI::CORNER_B, 5.0f);
 	ServerHeader.HMargin(2.0f, &ServerHeader);
 	UI()->DoLabel(&ServerHeader, Localize("Server details"), FontSize + 2.0f, CUI::ALIGN_CENTER);
 
-	if(pInfo)
+	if(!pInfo)
+		return;
+
+	CUIRect Row;
+	// Localize("Map:"); Localize("Game type:"); Localize("Version:"); Localize("Difficulty:"); Localize("Casual", "Server difficulty"); Localize("Normal", "Server difficulty"); Localize("Competitive", "Server difficulty");
+	static CLocConstString s_aLabels[] = {
+		"Map:",
+		"Game type:",
+		"Version:",
+		"Difficulty:" };
+	static CLocConstString s_aDifficultyLabels[] = {
+		"Casual",
+		"Normal",
+		"Competitive" };
+	static int s_aDifficultySpriteIds[] = {
+		SPRITE_LEVEL_A_ON,
+		SPRITE_LEVEL_B_ON,
+		SPRITE_LEVEL_C_ON };
+
+	CUIRect LeftColumn, RightColumn;
+	View.VMargin(2.0f, &View);
+	View.VSplitLeft(70.0f, &LeftColumn, &RightColumn);
+
+	for(unsigned int i = 0; i < sizeof(s_aLabels) / sizeof(s_aLabels[0]); i++)
 	{
-		CUIRect Row;
-		// Localize("Map:"); Localize("Game type:"); Localize("Version:"); Localize("Difficulty:"); Localize("Casual", "Server difficulty"); Localize("Normal", "Server difficulty"); Localize("Competitive", "Server difficulty");
-		static CLocConstString s_aLabels[] = {
-			"Map:",
-			"Game type:",
-			"Version:",
-			"Difficulty:" };
-		static CLocConstString s_aDifficultyLabels[] = {
-			"Casual",
-			"Normal",
-			"Competitive" };
-		static int s_aDifficultySpriteIds[] = {
-			SPRITE_LEVEL_A_ON,
-			SPRITE_LEVEL_B_ON,
-			SPRITE_LEVEL_C_ON };
-
-		CUIRect LeftColumn, RightColumn;
-		View.VMargin(2.0f, &View);
-		View.VSplitLeft(70.0f, &LeftColumn, &RightColumn);
-
-		for(unsigned int i = 0; i < sizeof(s_aLabels) / sizeof(s_aLabels[0]); i++)
-		{
-			LeftColumn.HSplitTop(15.0f, &Row, &LeftColumn);
-			UI()->DoLabel(&Row, s_aLabels[i], FontSize, CUI::ALIGN_LEFT, Row.w, false);
-		}
-
-		// map
-		RightColumn.HSplitTop(15.0f, &Row, &RightColumn);
-		UI()->DoLabel(&Row, pInfo->m_aMap, FontSize, CUI::ALIGN_LEFT, Row.w, false);
-
-		// game type
-		RightColumn.HSplitTop(15.0f, &Row, &RightColumn);
-		CUIRect Icon;
-		Row.VSplitLeft(Row.h, &Icon, &Row);
-		Icon.y -= 2.0f;
-		DoGameIcon(pInfo->m_aGameType, &Icon);
-		UI()->DoLabel(&Row, pInfo->m_aGameType, FontSize, CUI::ALIGN_LEFT, Row.w, false);
-
-		// version
-		RightColumn.HSplitTop(15.0f, &Row, &RightColumn);
-		UI()->DoLabel(&Row, pInfo->m_aVersion, FontSize, CUI::ALIGN_LEFT, Row.w, false);
-
-		// difficulty
-		RightColumn.HSplitTop(15.0f, &Row, &RightColumn);
-		Row.VSplitLeft(Row.h, &Icon, &Row);
-		Icon.y -= 2.0f;
-		DoIcon(IMAGE_LEVELICONS, s_aDifficultySpriteIds[pInfo->m_ServerLevel], &Icon);
-		UI()->DoLabel(&Row, s_aDifficultyLabels[pInfo->m_ServerLevel], FontSize, CUI::ALIGN_LEFT, Row.w, false);
+		LeftColumn.HSplitTop(RowHeight, &Row, &LeftColumn);
+		UI()->DoLabel(&Row, s_aLabels[i], FontSize, CUI::ALIGN_LEFT, Row.w, false);
 	}
+
+	// map
+	RightColumn.HSplitTop(RowHeight, &Row, &RightColumn);
+	UI()->DoLabel(&Row, pInfo->m_aMap, FontSize, CUI::ALIGN_LEFT, Row.w, false);
+
+	// game type
+	RightColumn.HSplitTop(RowHeight, &Row, &RightColumn);
+	CUIRect Icon;
+	Row.VSplitLeft(Row.h, &Icon, &Row);
+	Icon.y -= 2.0f;
+	DoGameIcon(pInfo->m_aGameType, &Icon);
+	UI()->DoLabel(&Row, pInfo->m_aGameType, FontSize, CUI::ALIGN_LEFT, Row.w, false);
+
+	// version
+	RightColumn.HSplitTop(RowHeight, &Row, &RightColumn);
+	UI()->DoLabel(&Row, pInfo->m_aVersion, FontSize, CUI::ALIGN_LEFT, Row.w, false);
+
+	// difficulty
+	RightColumn.HSplitTop(RowHeight, &Row, &RightColumn);
+	Row.VSplitLeft(Row.h, &Icon, &Row);
+	Icon.y -= 2.0f;
+	DoIcon(IMAGE_LEVELICONS, s_aDifficultySpriteIds[pInfo->m_ServerLevel], &Icon);
+	UI()->DoLabel(&Row, s_aDifficultyLabels[pInfo->m_ServerLevel], FontSize, CUI::ALIGN_LEFT, Row.w, false);
 }
 
 void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int RowCount, vec4 TextColor, vec4 TextOutlineColor)
 {
+	RenderTools()->DrawUIRect(&View, vec4(0, 0, 0, 0.15f), RowCount > 0 ? CUI::CORNER_B|CUI::CORNER_TL : CUI::CORNER_B, 5.0f);
+	View.Margin(2.0f, &View);
+
+	if(!pInfo)
+		return;
+
 	CBrowserFilter *pFilter = GetSelectedBrowserFilter();
 	CServerFilterInfo FilterInfo;
 	if(pFilter)
@@ -2197,22 +2093,13 @@ void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int 
 	TextRender()->TextColor(TextColor);
 	TextRender()->TextOutlineColor(TextOutlineColor);
 
-	// server scoreboard
-	CTextCursor Cursor;
-	const float FontSize = 8.0f;
-	int ActColumn = 0;
-	RenderTools()->DrawUIRect(&View, vec4(0, 0, 0, 0.15f), CUI::CORNER_B, 4.0f);
-	View.Margin(2.0f, &View);
-
-	if(!pInfo)
-		return;
 	static const CServerInfo *s_pLastInfo = pInfo;
-	bool ResetScroll = s_pLastInfo != pInfo;
+	const bool ResetScroll = s_pLastInfo != pInfo;
 	s_pLastInfo = pInfo;
 
-	CUIRect Scroll;
-
-	float RowWidth = (RowCount == 0) ? View.w : (View.w * 0.25f);
+	const float RowWidth = (RowCount == 0) ? View.w : (View.w * 0.25f);
+	const float FontSize = 8.0f;
+	const vec4 HighlightColor = vec4(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextColor.a);
 	float LineHeight = 20.0f;
 
 	static CScrollRegion s_ScrollRegion;
@@ -2225,7 +2112,7 @@ void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int 
 	ScrollParams.m_ScrollSpeed = 15;
 	s_ScrollRegion.Begin(&View, &ScrollOffset, &ScrollParams);
 	View.y += ScrollOffset.y;
-	if(RowCount != 0)
+	if(RowCount > 0)
 	{
 		const float Width = RowWidth * ((pInfo->m_NumClients+RowCount-1) / RowCount);
 		static float s_ScrollValue = 0.0f;
@@ -2235,6 +2122,7 @@ void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int 
 		}
 		if(Width > View.w)
 		{
+			CUIRect Scroll;
 			View.HSplitBottom(14.0f, &View, &Scroll);
 			Scroll.VMargin(5.0f, &Scroll);
 			s_ScrollValue = DoScrollbarH(&s_ScrollValue, &Scroll, s_ScrollValue);
@@ -2254,22 +2142,18 @@ void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int 
 		CUIRect Name, Clan, Score, Flag, Icon;
 
 		if(RowCount > 0 && Count % RowCount == 0)
-		{
 			View.VSplitLeft(RowWidth, &Row, &View);
-			ActColumn++;
-		}
 
 		Row.HSplitTop(LineHeight, &Name, &Row);
 		s_ScrollRegion.AddRect(Name);
 		if(Count == 0 && ResetScroll)
-		{
 			s_ScrollRegion.ScrollHere(CScrollRegion::SCROLLHERE_KEEP_IN_VIEW);
-		}
 
+		Count++;
 		if(s_ScrollRegion.IsRectClipped(Name))
 			continue;
 
-		RenderTools()->DrawUIRect(&Name, vec4(1.0f, 1.0f, 1.0f, (Count % 2 + 1)*0.05f), CUI::CORNER_ALL, 4.0f);
+		RenderTools()->DrawRoundRect(&Name, vec4(1.0f, 1.0f, 1.0f, (Count % 2 ? 1 : 2)*0.05f), 5.0f);
 
 		// friend
 		if(UI()->DoButtonLogic(&pInfo->m_aClients[i], &Name))
@@ -2289,69 +2173,28 @@ void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int 
 		Name.VSplitLeft(2.0f, 0, &Name);
 		Name.VSplitLeft(25.0f, &Score, &Name);
 		Name.VSplitRight(2*(Name.h-8.0f), &Name, &Flag);
-		Flag.HMargin(4.0f, &Flag);
 		Name.HSplitTop(LineHeight*0.5f, &Name, &Clan);
 
 		// score
 		if(!(pInfo->m_aClients[i].m_PlayerType&CServerInfo::CClient::PLAYERFLAG_SPEC))
 		{
+			Score.y += 4.0f;
 			char aTemp[16];
 			FormatScore(aTemp, sizeof(aTemp), pInfo->m_Flags&IServerBrowser::FLAG_TIMESCORE, &pInfo->m_aClients[i]);
-			TextRender()->SetCursor(&Cursor, Score.x, Score.y + (Score.h - FontSize) / 4.0f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
-			Cursor.m_LineWidth = Score.w;
-			TextRender()->TextEx(&Cursor, aTemp, -1);
+			UI()->DoLabel(&Score, aTemp, FontSize, CUI::ALIGN_LEFT);
 		}
 
 		// name
-		TextRender()->SetCursor(&Cursor, Name.x, Name.y, FontSize, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
-		Cursor.m_LineWidth = Name.w;
-		const char *pName = pInfo->m_aClients[i].m_aName;
-		if(Config()->m_BrFilterString[0])
-		{
-			// highlight the part that matches
-			const char *s = str_find_nocase(pName, Config()->m_BrFilterString);
-			if(s)
-			{
-				TextRender()->TextEx(&Cursor, pName, (int)(s - pName));
-				TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextColor.a);
-				TextRender()->TextEx(&Cursor, s, str_length(Config()->m_BrFilterString));
-				TextRender()->TextColor(TextColor);
-				TextRender()->TextEx(&Cursor, s + str_length(Config()->m_BrFilterString), -1);
-			}
-			else
-				TextRender()->TextEx(&Cursor, pName, -1);
-		}
-		else
-			TextRender()->TextEx(&Cursor, pName, -1);
+		UI()->DoLabelHighlighted(&Name, pInfo->m_aClients[i].m_aName, Config()->m_BrFilterString, FontSize, TextColor, HighlightColor);
 
 		// clan
-		TextRender()->SetCursor(&Cursor, Clan.x, Clan.y, FontSize, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
-		Cursor.m_LineWidth = Clan.w;
-		const char *pClan = pInfo->m_aClients[i].m_aClan;
-		if(Config()->m_BrFilterString[0])
-		{
-			// highlight the part that matches
-			const char *s = str_find_nocase(pClan, Config()->m_BrFilterString);
-			if(s)
-			{
-				TextRender()->TextEx(&Cursor, pClan, (int)(s - pClan));
-				TextRender()->TextColor(TextHighlightColor.r, TextHighlightColor.g, TextHighlightColor.b, TextColor.a);
-				TextRender()->TextEx(&Cursor, s, str_length(Config()->m_BrFilterString));
-				TextRender()->TextColor(TextColor);
-				TextRender()->TextEx(&Cursor, s + str_length(Config()->m_BrFilterString), -1);
-			}
-			else
-				TextRender()->TextEx(&Cursor, pClan, -1);
-		}
-		else
-			TextRender()->TextEx(&Cursor, pClan, -1);
+		UI()->DoLabelHighlighted(&Clan, pInfo->m_aClients[i].m_aClan, Config()->m_BrFilterString, FontSize, TextColor, HighlightColor);
 
 		// flag
+		Flag.HMargin(4.0f, &Flag);
 		Flag.w = Flag.h*2;
 		vec4 FlagColor(1.0f, 1.0f, 1.0f, 0.5f);
 		m_pClient->m_pCountryFlags->Render(pInfo->m_aClients[i].m_Country, &FlagColor, Flag.x, Flag.y, Flag.w, Flag.h);
-
-		++Count;
 	}
 
 	s_ScrollRegion.End();

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -281,10 +281,11 @@ void CMenus::RenderPlayers(CUIRect MainView)
 			MainView.HSplitTop(ButtonHeight, &Row, &MainView);
 			s_ScrollRegion.AddRect(Row);
 
+			Count++;
 			if(s_ScrollRegion.IsRectClipped(Row))
 				continue;
 
-			if(Count++ % 2 == 0)
+			if(Count % 2 == 1)
 				RenderTools()->DrawUIRect(&Row, vec4(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
 			// player info

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -379,28 +379,44 @@ bool CUI::DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float 
 	return true;
 }
 
-void CUI::DoLabel(const CUIRect *r, const char *pText, float Size, EAlignment Align, float LineWidth, bool MultiLine)
+void CUI::DoLabel(const CUIRect *pRect, const char *pText, float FontSize, EAlignment Align, float LineWidth, bool MultiLine)
 {
 	// TODO: FIX ME!!!!
 	//Graphics()->BlendNormal();
+
+	float TextX = pRect->x;
 	switch(Align)
 	{
 	case ALIGN_CENTER:
-	{
-		float tw = TextRender()->TextWidth(0, Size, pText, -1, LineWidth);
-		TextRender()->Text(0, r->x + r->w/2-tw/2, r->y - Size/10, Size, pText, LineWidth, MultiLine);
+		TextX += pRect->w/2.0f - TextRender()->TextWidth(0, FontSize, pText, -1, LineWidth)/2.0f;
 		break;
-	}
 	case ALIGN_LEFT:
-	{
-		TextRender()->Text(0, r->x, r->y - Size/10, Size, pText, LineWidth, MultiLine);
+		// default is left aligned
 		break;
-	}
 	case ALIGN_RIGHT:
-	{
-		float tw = TextRender()->TextWidth(0, Size, pText, -1, LineWidth);
-		TextRender()->Text(0, r->x + r->w-tw, r->y - Size/10, Size, pText, LineWidth, MultiLine);
+		TextX += pRect->w - TextRender()->TextWidth(0, FontSize, pText, -1, LineWidth);
 		break;
 	}
+
+	TextRender()->Text(0, TextX, pRect->y - FontSize/10.0f, FontSize, pText, LineWidth, MultiLine);
+}
+
+void CUI::DoLabelHighlighted(const CUIRect *pRect, const char *pText, const char *pHighlighted, float FontSize, const vec4 &TextColor, const vec4 &HighlightColor)
+{
+	CTextCursor Cursor;
+	TextRender()->SetCursor(&Cursor, pRect->x, pRect->y, FontSize, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
+	Cursor.m_LineWidth = pRect->w;
+
+	TextRender()->TextColor(TextColor);
+	const char *pMatch = pHighlighted && pHighlighted[0] ? str_find_nocase(pText, pHighlighted) : 0;
+	if(pMatch)
+	{
+		TextRender()->TextEx(&Cursor, pText, (int)(pMatch - pText));
+		TextRender()->TextColor(HighlightColor);
+		TextRender()->TextEx(&Cursor, pMatch, str_length(pHighlighted));
+		TextRender()->TextColor(TextColor);
+		TextRender()->TextEx(&Cursor, pMatch + str_length(pHighlighted), -1);
 	}
+	else
+		TextRender()->TextEx(&Cursor, pText, -1);
 }

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -130,8 +130,8 @@ public:
 	int DoButtonLogic(const void *pID, const CUIRect *pRect);
 	bool DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *pY);
 
-	// TODO: Refactor: Remove this?
-	void DoLabel(const CUIRect *pRect, const char *pText, float Size, EAlignment Align, float LineWidth = -1.0f, bool MultiLine = true);
+	void DoLabel(const CUIRect *pRect, const char *pText, float FontSize, EAlignment Align, float LineWidth = -1.0f, bool MultiLine = true);
+	void DoLabelHighlighted(const CUIRect *pRect, const char *pText, const char *pHighlighted, float FontSize, const vec4 &TextColor, const vec4 &HighlightColor);
 };
 
 


### PR DESCRIPTION
- Fix flickering server entry background when scrolling with arrow keys, by keeping the selection state active visually for one more frame after a selection is changed (closes #2696).
  - Scrolling will close the extended server details (if sidebar not active). This is the only solution I found to prevent extensive flickering when scrolling.
- Fix new server browser filter not being updated (closes #2698).
- Fix entries in server browser and ingame player list switching colors and places because clipped items were not being taken into account for that (introduced by #2693).
- Add CUI::DoLabelHighlighted to "highlight the part that matches".
- Fix server entry text not having a consistent base line, by using DoLabel and DoLabelHighlighted consistently.
- Change hover color to be slightly lighter than the selection color.
- Fix the small white pixel border at the bottom of the server details, by removing the additional clipping around RenderDetailScoreboard, which was not required.

Before:
![screenshot_2020-08-31_18-16-48](https://user-images.githubusercontent.com/23437060/91742424-8c618d00-ebb6-11ea-90ab-66bcaa57830e.png)

After:
![screenshot_2020-08-31_18-26-24](https://user-images.githubusercontent.com/23437060/91743242-ced79980-ebb7-11ea-958d-231a6fa26000.png)

Before:
![screenshot_2020-08-31_18-16-43](https://user-images.githubusercontent.com/23437060/91742448-93889b00-ebb6-11ea-963a-b94d90c7e719.png)

After:
![screenshot_2020-08-31_18-26-21](https://user-images.githubusercontent.com/23437060/91743249-d1d28a00-ebb7-11ea-9ded-323d1987b16e.png)