### PR TITLE
Change all scrollbars to require clicking, to avoid multiple scrollbars being activated at once (closes #2700)

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -797,7 +797,7 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 	pRect->VMargin(5.0f, &Rail);
 
 	// logic
-	static float OffsetY;
+	static float s_OffsetY;
 	const bool InsideHandle = UI()->MouseInside(&Handle);
 	const bool InsideRail = UI()->MouseInside(&Rail);
 	float ReturnValue = Current;
@@ -805,36 +805,37 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 
 	if(UI()->CheckActiveItem(pID))
 	{
-		if(!UI()->MouseButton(0))
+		if(UI()->MouseButton(0))
+			Grabbed = true;
+		else
 			UI()->SetActiveItem(0);
-
-		Grabbed = true;
 	}
 	else if(UI()->HotItem() == pID)
 	{
 		if(UI()->MouseButton(0))
 		{
 			UI()->SetActiveItem(pID);
-			OffsetY = UI()->MouseY()-Handle.y;
+			s_OffsetY = UI()->MouseY()-Handle.y;
 		}
 	}
-	else if(UI()->MouseButton(0) && !InsideHandle && InsideRail)
+	else if(UI()->MouseButtonClicked(0) && !InsideHandle && InsideRail)
 	{
-		bool Up = UI()->MouseY() < Handle.y + Handle.h/2;
-		OffsetY = UI()->MouseY() - Handle.y + 8 * (Up ? 1 : -1);
+		s_OffsetY = Handle.h * 0.5f;
+		UI()->SetActiveItem(pID);
 		Grabbed = true;
+	}
+	else if(InsideHandle)
+	{
+		UI()->SetHotItem(pID);
 	}
 
 	if(Grabbed)
 	{
 		const float Min = pRect->y;
 		const float Max = pRect->h-Handle.h;
-		const float Cur = UI()->MouseY()-OffsetY;
+		const float Cur = UI()->MouseY()-s_OffsetY;
 		ReturnValue = clamp((Cur-Min)/Max, 0.0f, 1.0f);
 	}
-
-	if(InsideHandle)
-		UI()->SetHotItem(pID);
 
 	// render
 	RenderTools()->DrawUIRect(&Rail, vec4(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, Rail.w/2.0f);
@@ -863,7 +864,7 @@ float CMenus::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current)
 	pRect->HMargin(5.0f, &Rail);
 
 	// logic
-	static float OffsetX;
+	static float s_OffsetX;
 	const bool InsideHandle = UI()->MouseInside(&Handle);
 	const bool InsideRail = UI()->MouseInside(&Rail);
 	float ReturnValue = Current;
@@ -871,35 +872,37 @@ float CMenus::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current)
 
 	if(UI()->CheckActiveItem(pID))
 	{
-		if(!UI()->MouseButton(0))
+		if(UI()->MouseButton(0))
+			Grabbed = true;
+		else
 			UI()->SetActiveItem(0);
-		Grabbed = true;
 	}
 	else if(UI()->HotItem() == pID)
 	{
 		if(UI()->MouseButton(0))
 		{
 			UI()->SetActiveItem(pID);
-			OffsetX = UI()->MouseX()-Handle.x;
+			s_OffsetX = UI()->MouseX()-Handle.x;
 		}
 	}
 	else if(UI()->MouseButtonClicked(0) && !InsideHandle && InsideRail)
 	{
-		OffsetX = Handle.w * 0.5f;
+		s_OffsetX = Handle.w * 0.5f;
 		UI()->SetActiveItem(pID);
 		Grabbed = true;
+	}
+	else if(InsideHandle)
+	{
+		UI()->SetHotItem(pID);
 	}
 
 	if(Grabbed)
 	{
 		const float Min = pRect->x;
 		const float Max = pRect->w-Handle.w;
-		const float Cur = UI()->MouseX()-OffsetX;
+		const float Cur = UI()->MouseX()-s_OffsetX;
 		ReturnValue = clamp((Cur-Min)/Max, 0.0f, 1.0f);
 	}
-
-	if(InsideHandle)
-		UI()->SetHotItem(pID);
 
 	// render
 	RenderTools()->DrawUIRect(&Rail, vec4(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, Rail.h/2.0f);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -814,8 +814,9 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 	{
 		if(UI()->MouseButton(0))
 		{
-			UI()->SetActiveItem(pID);
 			s_OffsetY = UI()->MouseY()-Handle.y;
+			UI()->SetActiveItem(pID);
+			Grabbed = true;
 		}
 	}
 	else if(UI()->MouseButtonClicked(0) && !InsideHandle && InsideRail)
@@ -824,7 +825,8 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 		UI()->SetActiveItem(pID);
 		Grabbed = true;
 	}
-	else if(InsideHandle)
+
+	if(InsideHandle)
 	{
 		UI()->SetHotItem(pID);
 	}
@@ -838,7 +840,7 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 	}
 
 	// render
-	RenderTools()->DrawUIRect(&Rail, vec4(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, Rail.w/2.0f);
+	RenderTools()->DrawRoundRect(&Rail, vec4(1.0f, 1.0f, 1.0f, 0.25f), Rail.w/2.0f);
 
 	vec4 Color;
 	if(Grabbed)
@@ -847,7 +849,7 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 		Color = vec4(1.0f, 1.0f, 1.0f, 1.0f);
 	else
 		Color = vec4(0.8f, 0.8f, 0.8f, 1.0f);
-	RenderTools()->DrawUIRect(&Handle, Color, CUI::CORNER_ALL, Handle.w/2.0f);
+	RenderTools()->DrawRoundRect(&Handle, Color, Handle.w/2.0f);
 
 	return ReturnValue;
 }
@@ -881,8 +883,9 @@ float CMenus::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current)
 	{
 		if(UI()->MouseButton(0))
 		{
-			UI()->SetActiveItem(pID);
 			s_OffsetX = UI()->MouseX()-Handle.x;
+			UI()->SetActiveItem(pID);
+			Grabbed = true;
 		}
 	}
 	else if(UI()->MouseButtonClicked(0) && !InsideHandle && InsideRail)
@@ -891,7 +894,8 @@ float CMenus::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current)
 		UI()->SetActiveItem(pID);
 		Grabbed = true;
 	}
-	else if(InsideHandle)
+
+	if(InsideHandle)
 	{
 		UI()->SetHotItem(pID);
 	}
@@ -905,7 +909,7 @@ float CMenus::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current)
 	}
 
 	// render
-	RenderTools()->DrawUIRect(&Rail, vec4(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, Rail.h/2.0f);
+	RenderTools()->DrawRoundRect(&Rail, vec4(1.0f, 1.0f, 1.0f, 0.25f), Rail.h/2.0f);
 
 	vec4 Color;
 	if(Grabbed)
@@ -914,7 +918,7 @@ float CMenus::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current)
 		Color = vec4(1.0f, 1.0f, 1.0f, 1.0f);
 	else
 		Color = vec4(0.8f, 0.8f, 0.8f, 1.0f);
-	RenderTools()->DrawUIRect(&Handle, Color, CUI::CORNER_ALL, Handle.h/2.0f);
+	RenderTools()->DrawRoundRect(&Handle, Color, Handle.h/2.0f);
 
 	return ReturnValue;
 }

--- a/src/game/client/components/menus_scrollregion.cpp
+++ b/src/game/client/components/menus_scrollregion.cpp
@@ -108,35 +108,37 @@ void CMenus::CScrollRegion::End()
 
 		Hovered = true;
 	}
-	else if(InsideRail && m_pUI->MouseButton(0))
+	else if(InsideRail && m_pUI->MouseButtonClicked(0))
 	{
-		const float SliderDistance = m_pUI->MouseY() - (Slider.y+Slider.h/2);
-		m_ScrollY += sign(SliderDistance) * log(abs(SliderDistance)); // slow down to reasonable scroll speed; keep sign with logarithm
+		m_ScrollY += m_pUI->MouseY() - (Slider.y+Slider.h/2);
+		m_pUI->SetActiveItem(pID);
+		m_MouseGrabStart.y = m_pUI->MouseY();
 		Hovered = true;
 	}
-
-	if(m_pUI->CheckActiveItem(pID) && !m_pUI->MouseButton(0))
+	else if(m_pUI->CheckActiveItem(pID) && !m_pUI->MouseButton(0))
+	{
 		m_pUI->SetActiveItem(0);
+	}
 
 	// move slider
 	if(m_pUI->CheckActiveItem(pID) && m_pUI->MouseButton(0))
 	{
-		float my = m_pUI->MouseY();
-		m_ScrollY += my - m_MouseGrabStart.y;
-		m_MouseGrabStart.y = my;
-
+		float MouseY = m_pUI->MouseY();
+		m_ScrollY += MouseY - m_MouseGrabStart.y;
+		m_MouseGrabStart.y = MouseY;
 		Grabbed = true;
 	}
 
 	m_ScrollY = clamp(m_ScrollY, 0.0f, MaxScroll);
 	m_ContentScrollOff.y = -m_ScrollY/MaxScroll * (m_ContentH - m_ClipRect.h);
 
-	vec4 SliderColor = m_Params.m_SliderColor;
+	vec4 SliderColor;
 	if(Grabbed)
 		SliderColor = m_Params.m_SliderColorGrabbed;
 	else if(Hovered)
 		SliderColor = m_Params.m_SliderColorHover;
-
+	else
+		SliderColor = m_Params.m_SliderColor;
 	m_pRenderTools->DrawRoundRect(&Slider, SliderColor, Slider.w/2.0f);
 }
 


### PR DESCRIPTION
Change vertical scrollbar in menus and in scrollregion to function like the horizontal one. That is, _clicking_ on the rail scrolls to that position immediately and activates scrolling while the mouse button is held, which avoids multiple scrollbars being activated at once.

Closes #2700.