### PR TITLE
CScrollRegion: m_ScrollY now ties to content height instead of slider height

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1957,7 +1957,7 @@ int CMenus::Render()
 				s_ActSelection = FilterInfo.m_Country;
 			static CListBox s_ListBox;
 			int OldSelected = -1;
-			s_ListBox.DoStart(40.0f, m_pClient->m_pCountryFlags->Num(), 12, OldSelected, &Box, false);
+			s_ListBox.DoStart(40.0f, m_pClient->m_pCountryFlags->Num(), 12, 1, OldSelected, &Box, false);
 
 			for(int i = 0; i < m_pClient->m_pCountryFlags->Num(); ++i)
 			{

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -160,8 +160,7 @@ private:
 		int m_Flags;
 
 		enum {
-			FLAG_CONTENT_STATIC_WIDTH = 0x1,
-			FLAG_NO_SMOOTH_SCROLLING = 0x2,
+			FLAG_CONTENT_STATIC_WIDTH = 0x1
 		};
 
 		CScrollRegionParams()

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -214,7 +214,7 @@ private:
 		CUIRect m_ClipRect;
 		CUIRect m_RailRect;
 		CUIRect m_LastAddedRect; // saved for ScrollHere()
-		vec2 m_MouseGrabStart;
+		vec2 m_SliderGrabPos; // where did user grab the slider
 		vec2 m_ContentScrollOff;
 		CScrollRegionParams m_Params;
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -150,7 +150,7 @@ private:
 		float m_ScrollbarWidth;
 		float m_ScrollbarMargin;
 		float m_SliderMinHeight;
-		float m_ScrollSpeed;
+		float m_ScrollUnit;
 		vec4 m_ClipBgColor;
 		vec4 m_ScrollbarBgColor;
 		vec4 m_RailBgColor;
@@ -160,7 +160,8 @@ private:
 		int m_Flags;
 
 		enum {
-			FLAG_CONTENT_STATIC_WIDTH = 0x1
+			FLAG_CONTENT_STATIC_WIDTH = 0x1,
+			FLAG_NO_SMOOTH_SCROLLING = 0x2,
 		};
 
 		CScrollRegionParams()
@@ -168,7 +169,7 @@ private:
 			m_ScrollbarWidth = 20;
 			m_ScrollbarMargin = 5;
 			m_SliderMinHeight = 25;
-			m_ScrollSpeed = 5;
+			m_ScrollUnit = 10;
 			m_ClipBgColor = vec4(0.0f, 0.0f, 0.0f, 0.25f);
 			m_ScrollbarBgColor = vec4(0.0f, 0.0f, 0.0f, 0.25f);
 			m_RailBgColor = vec4(1.0f, 1.0f, 1.0f, 0.25f);
@@ -226,7 +227,7 @@ private:
 		};
 
 		CScrollRegion();
-		void Begin(CUIRect* pClipRect, vec2* pOutOffset, const CScrollRegionParams* pParams = 0);
+		void Begin(CUIRect* pClipRect, vec2* pOutOffset, CScrollRegionParams* pParams = 0);
 		void End();
 		void AddRect(CUIRect Rect);
 		void ScrollHere(int Option = CScrollRegion::SCROLLHERE_KEEP_IN_VIEW);
@@ -273,7 +274,7 @@ private:
 		void DoHeader(const CUIRect *pRect, const char *pTitle, float HeaderHeight = 20.0f, float Spacing = 2.0f);
 		bool DoFilter(float FilterHeight = 20.0f, float Spacing = 2.0f);
 		void DoFooter(const char *pBottomText, float FooterHeight = 20.0f); // call before DoStart to create a footer
-		void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int SelectedIndex,
+		void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex,
 					const CUIRect *pRect = 0, bool Background = true, bool *pActive = 0);
 		CListboxItem DoNextItem(const void *pID, bool Selected = false, bool *pActive = 0);
 		int DoEnd();

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1151,7 +1151,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	ScrollParams.m_ClipBgColor = vec4(0,0,0,0);
 	ScrollParams.m_Flags = CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH;
 	ScrollParams.m_SliderMinHeight = 5;
-	ScrollParams.m_ScrollSpeed = 5;
+	ScrollParams.m_ScrollUnit = 60.0f; // 3 rows per scroll
 	View.w += ScrollParams.m_ScrollbarWidth;
 	s_ScrollRegion.Begin(&View, &ScrollOffset, &ScrollParams);
 	View.y += ScrollOffset.y;
@@ -1511,7 +1511,7 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 	ScrollParams.m_ScrollbarBgColor = vec4(0,0,0,0);
 	ScrollParams.m_ScrollbarWidth = 14;
 	ScrollParams.m_ScrollbarMargin = 5;
-	ScrollParams.m_ScrollSpeed = 15;
+	ScrollParams.m_ScrollUnit = 40.0f; // various sized content, 40 units per scroll;
 	s_ScrollRegion.Begin(&View, &ScrollOffset, &ScrollParams);
 	View.y += ScrollOffset.y;
 
@@ -2113,7 +2113,7 @@ void CMenus::RenderDetailScoreboard(CUIRect View, const CServerInfo *pInfo, int 
 	ScrollParams.m_ScrollbarBgColor = vec4(0,0,0,0);
 	ScrollParams.m_ScrollbarWidth = 5;
 	ScrollParams.m_ScrollbarMargin = 1;
-	ScrollParams.m_ScrollSpeed = 15;
+	ScrollParams.m_ScrollUnit = 40.0f; // 2 players per scroll
 	s_ScrollRegion.Begin(&View, &ScrollOffset, &ScrollParams);
 	View.y += ScrollOffset.y;
 	if(RowCount > 0)

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1511,7 +1511,7 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 	ScrollParams.m_ScrollbarBgColor = vec4(0,0,0,0);
 	ScrollParams.m_ScrollbarWidth = 14;
 	ScrollParams.m_ScrollbarMargin = 5;
-	ScrollParams.m_ScrollUnit = 40.0f; // various sized content, 40 units per scroll;
+	ScrollParams.m_ScrollUnit = 40.0f; // various sized content, 40 units per scroll
 	s_ScrollRegion.Begin(&View, &ScrollOffset, &ScrollParams);
 	View.y += ScrollOffset.y;
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -525,7 +525,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	static CListBox s_ListBox;
 	s_ListBox.DoHeader(&ListBox, Localize("Recorded"), GetListHeaderHeight());
 
-	s_ListBox.DoStart(20.0f, m_lDemos.size(), 1, m_DemolistSelectedIndex);
+	s_ListBox.DoStart(20.0f, m_lDemos.size(), 1, 3, m_DemolistSelectedIndex);
 	for(sorted_array<CDemoItem>::range r = m_lDemos.all(); !r.empty(); r.pop_front())
 	{
 		CListboxItem Item = s_ListBox.DoNextItem(&r.front(), (&r.front() - m_lDemos.base_ptr()) == m_DemolistSelectedIndex);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -235,7 +235,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 	CScrollRegionParams ScrollParams;
 	ScrollParams.m_ClipBgColor = vec4(0,0,0,0);
 	ScrollParams.m_ScrollbarBgColor = vec4(0,0,0,0);
-	ScrollParams.m_ScrollSpeed = 15;
+	ScrollParams.m_ScrollUnit = ButtonHeight * 3; // 3 players per scroll
 	if(s_ScrollRegion.IsScrollbarShown())
 		Row.VSplitRight(ScrollParams.m_ScrollbarWidth, &Row, 0);
 
@@ -508,7 +508,7 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 	static CListBox s_ListBox;
 	CUIRect List = MainView;
 	s_ListBox.DoHeader(&List, Localize("Option"), GetListHeaderHeight());
-	s_ListBox.DoStart(20.0f, m_pClient->m_pVoting->m_NumVoteOptions, 1, m_CallvoteSelectedOption, 0, true);
+	s_ListBox.DoStart(20.0f, m_pClient->m_pVoting->m_NumVoteOptions, 1, 3, m_CallvoteSelectedOption, 0, true);
 
 	for(CVoteOptionClient *pOption = m_pClient->m_pVoting->m_pFirst; pOption; pOption = pOption->m_pNext)
 	{
@@ -556,7 +556,7 @@ void CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 	static CListBox s_ListBox;
 	CUIRect List = MainView;
 	s_ListBox.DoHeader(&List, Localize("Player"), GetListHeaderHeight());
-	s_ListBox.DoStart(20.0f, NumOptions, 1, Selected, 0, true);
+	s_ListBox.DoStart(20.0f, NumOptions, 1, 3, Selected, 0, true);
 
 	for(int i = 0; i < NumOptions; i++)
 	{

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -74,8 +74,8 @@ void CMenus::CListBox::DoFooter(const char *pBottomText, float FooterHeight)
 	m_FooterHeight = FooterHeight;
 }
 
-void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int SelectedIndex,
-							  const CUIRect *pRect, bool Background, bool *pActive)
+void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, 
+							int SelectedIndex, const CUIRect *pRect, bool Background, bool *pActive)
 {
 	CUIRect View;
 	if(pRect)
@@ -120,7 +120,9 @@ void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, i
 
 	// setup the scrollbar
 	m_ScrollOffset = vec2(0, 0);
-	m_ScrollRegion.Begin(&m_ListBoxView, &m_ScrollOffset);
+	CScrollRegionParams ScrollParams;
+	ScrollParams.m_ScrollUnit = m_ListBoxRowHeight * RowsPerScroll;
+	m_ScrollRegion.Begin(&m_ListBoxView, &m_ScrollOffset, &ScrollParams);
 	m_ListBoxView.y += m_ScrollOffset.y;
 }
 

--- a/src/game/client/components/menus_scrollregion.cpp
+++ b/src/game/client/components/menus_scrollregion.cpp
@@ -93,9 +93,6 @@ void CMenus::CScrollRegion::End()
 	}
 
 	m_ScrollY = clamp(m_ScrollY, 0.0f, MaxScroll);
-
-
-
 	Slider.y += m_ScrollY/MaxScroll * MaxSlider;
 
 	bool Hovered = false;

--- a/src/game/client/components/menus_scrollregion.cpp
+++ b/src/game/client/components/menus_scrollregion.cpp
@@ -101,36 +101,34 @@ void CMenus::CScrollRegion::End()
 	const bool InsideSlider = m_pUI->MouseInside(&Slider);
 	const bool InsideRail = m_pUI->MouseInside(&m_RailRect);
 
-	if(InsideSlider)
+	if(m_pUI->CheckActiveItem(pID) && m_pUI->MouseButton(0))
+	{
+		float MouseY = m_pUI->MouseY();
+		m_ScrollY += (MouseY - (Slider.y + m_SliderGrabPos.y)) / MaxSlider * MaxScroll;
+		m_SliderGrabPos.y = clamp(m_SliderGrabPos.y, 0.0f, SliderHeight);
+		Grabbed = true;
+	}
+	else if(InsideSlider)
 	{
 		m_pUI->SetHotItem(pID);
 
 		if(!m_pUI->CheckActiveItem(pID) && m_pUI->MouseButtonClicked(0))
 		{
 			m_pUI->SetActiveItem(pID);
-			m_MouseGrabStart.y = m_pUI->MouseY();
+			m_SliderGrabPos.y = m_pUI->MouseY() - Slider.y;
 		}
 		Hovered = true;
 	}
 	else if(InsideRail && m_pUI->MouseButtonClicked(0))
 	{
-		m_ScrollY += m_pUI->MouseY() - (Slider.y+Slider.h/2);
+		m_ScrollY += (m_pUI->MouseY() - (Slider.y+Slider.h/2)) / MaxSlider * MaxScroll;
 		m_pUI->SetActiveItem(pID);
-		m_MouseGrabStart.y = m_pUI->MouseY();
+		m_SliderGrabPos.y = Slider.h/2;
 		Hovered = true;
 	}
 	else if(m_pUI->CheckActiveItem(pID) && !m_pUI->MouseButton(0))
 	{
 		m_pUI->SetActiveItem(0);
-	}
-
-	// move slider
-	if(m_pUI->CheckActiveItem(pID) && m_pUI->MouseButton(0))
-	{
-		float MouseY = m_pUI->MouseY();
-		m_ScrollY += (MouseY - m_MouseGrabStart.y) / MaxSlider * MaxScroll;
-		m_MouseGrabStart.y = MouseY;
-		Grabbed = true;
 	}
 
 	m_ScrollY = clamp(m_ScrollY, 0.0f, MaxScroll);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -357,7 +357,7 @@ void CMenus::RenderSkinSelection(CUIRect MainView)
 	int OldSelected = -1;
 	s_ListBox.DoHeader(&MainView, Localize("Skins"), GetListHeaderHeight());
 	m_RefreshSkinSelector = s_ListBox.DoFilter();
-	s_ListBox.DoStart(50.0f, s_paSkinList.size(), 10, OldSelected);
+	s_ListBox.DoStart(50.0f, s_paSkinList.size(), 10, 1, OldSelected);
 
 	for(int i = 0; i < s_paSkinList.size(); ++i)
 	{
@@ -436,7 +436,7 @@ void CMenus::RenderSkinPartSelection(CUIRect MainView)
 	static int OldSelected = -1;
 	s_ListBox.DoHeader(&MainView, Localize(CSkins::ms_apSkinPartNames[m_TeePartSelected]), GetListHeaderHeight());
 	s_InitSkinPartList = s_ListBox.DoFilter();
-	s_ListBox.DoStart(50.0f, s_paList[m_TeePartSelected].size(), 5, OldSelected);
+	s_ListBox.DoStart(50.0f, s_paList[m_TeePartSelected].size(), 5, 1, OldSelected);
 
 	for(int i = 0; i < s_paList[m_TeePartSelected].size(); ++i)
 	{
@@ -712,7 +712,7 @@ void CMenus::RenderLanguageSelection(CUIRect MainView, bool Header)
 	if(Header)
 		s_ListBox.DoHeader(&MainView, Localize("Language"), GetListHeaderHeight());
 	bool IsActive = m_ActiveListBox == ACTLB_LANG;
-	s_ListBox.DoStart(20.0f, s_Languages.size(), 1, s_SelectedLanguage, Header?0:&MainView, Header, &IsActive);
+	s_ListBox.DoStart(20.0f, s_Languages.size(), 1, 3, s_SelectedLanguage, Header?0:&MainView, Header, &IsActive);
 
 	for(sorted_array<CLanguage>::range r = s_Languages.all(); !r.empty(); r.pop_front())
 	{
@@ -780,7 +780,7 @@ void CMenus::RenderThemeSelection(CUIRect MainView, bool Header)
 		s_ListBox.DoHeader(&MainView, Localize("Theme"), GetListHeaderHeight());
 
 	bool IsActive = m_ActiveListBox == ACTLB_THEME;
-	s_ListBox.DoStart(20.0f, m_lThemes.size(), 1, SelectedTheme, Header?0:&MainView, Header, &IsActive);
+	s_ListBox.DoStart(20.0f, m_lThemes.size(), 1, 3, SelectedTheme, Header?0:&MainView, Header, &IsActive);
 
 	for(sorted_array<CTheme>::range r = m_lThemes.all(); !r.empty(); r.pop_front())
 	{
@@ -1129,7 +1129,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	static CListBox s_ListBox;
 	int OldSelected = -1;
 	s_ListBox.DoHeader(&MainView, Localize("Country"), GetListHeaderHeight());
-	s_ListBox.DoStart(40.0f, m_pClient->m_pCountryFlags->Num(), 18, OldSelected);
+	s_ListBox.DoStart(40.0f, m_pClient->m_pCountryFlags->Num(), 18, 1, OldSelected);
 
 	for(int i = 0; i < m_pClient->m_pCountryFlags->Num(); ++i)
 	{
@@ -1470,6 +1470,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 	vec2 ScrollOffset(0, 0);
 	CScrollRegionParams ScrollParams;
 	ScrollParams.m_ClipBgColor = vec4(0,0,0,0);
+	ScrollParams.m_ScrollUnit = 40.0f; // inconsistent margin, 2 category header per scroll
 	s_ScrollRegion.Begin(&MainView, &ScrollOffset, &ScrollParams);
 	MainView.y += ScrollOffset.y;
 
@@ -1599,7 +1600,7 @@ bool CMenus::DoResolutionList(CUIRect* pRect, CListBox* pListBox,
 	int OldSelected = -1;
 	char aBuf[32];
 
-	pListBox->DoStart(20.0f, lModes.size(), 1, OldSelected, pRect);
+	pListBox->DoStart(20.0f, lModes.size(), 1, 3, OldSelected, pRect);
 
 	for(int i = 0; i < lModes.size(); ++i)
 	{

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1674,14 +1674,7 @@ bool CGameClient::ShouldUsePredicted()
 	// - When we are spectating
 	return
 		Client()->State() != IClient::STATE_DEMOPLAYBACK &&
-		!(
-			m_Snap.m_pGameData &&
-			m_Snap.m_pGameData->m_GameStateFlags & (
-				GAMESTATEFLAG_PAUSED |
-				GAMESTATEFLAG_ROUNDOVER |
-				GAMESTATEFLAG_GAMEOVER
-			)
-		) &&
+		!(IsWorldPaused()) &&
 		!(m_Snap.m_SpecInfo.m_Active);
 }
 


### PR DESCRIPTION
closes #2709 

Make scroll region consistent by making its scroll position tie to the height of the content instead of the height of slider.
(Basically, I've changed it from `x units of slider movement` to `x units of content movement` per scroll)

`m_ScrollSpeed` has been renamed to `m_ScrollUnit` to indicate its new purpose.

All scroll speed of scroll regions including the ones in listbox has been readjusted as well with the following rules:

- For rows height of 20 units, scroll speed is 3 rows per scroll. (which is the default behaviour in windows)
- For rows height of > 40 units, scroll speed is 1 row per scroll.
- For content that has inconsistent item heights (controls list and friend list), scroll speed is set in each case but kept in the range of [40, 60] units per scroll.

Mouse wheel also scrolls a page when either ALT key is held down, which can be handy when scrolling large server list.