### PR TITLE
Fix button and hovering logic, cleanup and refactoring

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -566,7 +566,7 @@ void CGraphics_Threaded::SetColor(float r, float g, float b, float a)
 	SetColorVertex(Array, 4);
 }
 
-void CGraphics_Threaded::SetColor4(vec4 TopLeft, vec4 TopRight, vec4 BottomLeft, vec4 BottomRight)
+void CGraphics_Threaded::SetColor4(const vec4 &TopLeft, const vec4 &TopRight, const vec4 &BottomLeft, const vec4 &BottomRight)
 {
 	dbg_assert(m_Drawing != 0, "called Graphics()->SetColor without begin");
 	CColorVertex Array[4] = {

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -424,7 +424,7 @@ public:
 
 	virtual void SetColorVertex(const CColorVertex *pArray, int Num);
 	virtual void SetColor(float r, float g, float b, float a);
-	virtual void SetColor4(vec4 TopLeft, vec4 TopRight, vec4 BottomLeft, vec4 BottomRight);
+	virtual void SetColor4(const vec4 &TopLeft, const vec4 &TopRight, const vec4 &BottomLeft, const vec4 &BottomRight);
 
 	void TilesetFallbackSystem(int TextureIndex);
 	virtual void QuadsSetSubset(float TlU, float TlV, float BrU, float BrV, int TextureIndex = -1);

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -172,7 +172,7 @@ public:
 	};
 	virtual void SetColorVertex(const CColorVertex *pArray, int Num) = 0;
 	virtual void SetColor(float r, float g, float b, float a) = 0;
-	virtual void SetColor4(vec4 TopLeft, vec4 TopRight, vec4 BottomLeft, vec4 BottomRight) = 0;
+	virtual void SetColor4(const vec4 &TopLeft, const vec4 &TopRight, const vec4 &BottomLeft, const vec4 &BottomRight) = 0;
 
 	virtual void ReadBackbuffer(unsigned char **ppPixels, int x, int y, int w, int h) = 0;
 	virtual void TakeScreenshot(const char *pFilename) = 0;

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -645,7 +645,7 @@ void CGameConsole::Toggle(int Type)
 		if (m_ConsoleState == CONSOLE_CLOSED || m_ConsoleState == CONSOLE_CLOSING)
 		{
 			Input()->MouseModeAbsolute();
-			m_pClient->m_pMenus->UseMouseButtons(false);
+			UI()->UseMouseButtons(false);
 			m_ConsoleState = CONSOLE_OPENING;
 			// reset controls
 			m_pClient->m_pControls->OnReset();
@@ -653,7 +653,7 @@ void CGameConsole::Toggle(int Type)
 		else
 		{
 			Input()->MouseModeRelative();
-			m_pClient->m_pMenus->UseMouseButtons(true);
+			UI()->UseMouseButtons(true);
 			m_pClient->OnRelease();
 			m_ConsoleState = CONSOLE_CLOSING;
 		}

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -41,7 +41,7 @@ CMenus *CMenus::CUIElementBase::m_pMenus = 0;
 CRenderTools *CMenus::CUIElementBase::m_pRenderTools = 0;
 CUI *CMenus::CUIElementBase::m_pUI = 0;
 IInput *CMenus::CUIElementBase::m_pInput = 0;
-
+IClient *CMenus::CUIElementBase::m_pClient = 0;
 
 CMenus::CMenus()
 {
@@ -70,7 +70,6 @@ CMenus::CMenus()
 	m_MenuActive = true;
 	m_SeekBarActivatedTime = 0;
 	m_SeekBarActive = true;
-	m_UseMouseButtons = true;
 	m_SkinModified = false;
 	m_KeyReaderWasActive = false;
 	m_KeyReaderIsActive = false;
@@ -99,49 +98,41 @@ CMenus::CMenus()
 	m_ActiveListBox = ACTLB_NONE;
 }
 
-float CMenus::ButtonFade(CButtonContainer *pBC, float Seconds, int Checked)
+float CMenus::CButtonContainer::GetFade(bool Checked, float Seconds)
 {
-	if(UI()->HotItem() == pBC->GetID() || Checked)
+	if(m_pUI->HotItem() == GetID() || Checked)
 	{
-		pBC->m_FadeStartTime = Client()->LocalTime();
-		return Seconds;
+		m_FadeStartTime = m_pClient->LocalTime();
+		return 1.0f;
 	}
 
-	return max(0.0f, pBC->m_FadeStartTime -  Client()->LocalTime() + Seconds);
+	return max(0.0f, m_FadeStartTime -  m_pClient->LocalTime() + Seconds)/Seconds;
 }
 
-int CMenus::DoIcon(int ImageId, int SpriteId, const CUIRect *pRect)
+void CMenus::DoIcon(int ImageId, int SpriteId, const CUIRect *pRect, const vec4 *pColor)
 {
 	Graphics()->TextureSet(g_pData->m_aImages[ImageId].m_Id);
 
 	Graphics()->QuadsBegin();
 	RenderTools()->SelectSprite(SpriteId);
-	IGraphics::CQuadItem QuadItem(pRect->x, pRect->y, pRect->w, pRect->h);
-	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	Graphics()->QuadsEnd();
-
-	return 0;
-}
-
-void CMenus::DoIconColor(int ImageId, int SpriteId, const CUIRect* pRect, const vec4& Color)
-{
-	Graphics()->TextureSet(g_pData->m_aImages[ImageId].m_Id);
-
-	Graphics()->QuadsBegin();
-	RenderTools()->SelectSprite(SpriteId);
-	Graphics()->SetColor(Color.r*Color.a, Color.g*Color.a, Color.b*Color.a, Color.a);
+	if(pColor)
+	{
+		Graphics()->SetColor(pColor->r*pColor->a, pColor->g*pColor->a, pColor->b*pColor->a, pColor->a);
+	}
 	IGraphics::CQuadItem QuadItem(pRect->x, pRect->y, pRect->w, pRect->h);
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();
 }
 
-int CMenus::DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, bool Active)
+bool CMenus::DoButton_Toggle(const void *pID, bool Checked, const CUIRect *pRect, bool Active)
 {
 	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_GUIBUTTONS].m_Id);
 	Graphics()->QuadsBegin();
 	if(!Active)
+	{
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.5f);
-	RenderTools()->SelectSprite(Checked?SPRITE_GUIBUTTON_ON:SPRITE_GUIBUTTON_OFF);
+	}
+	RenderTools()->SelectSprite(Checked ? SPRITE_GUIBUTTON_ON : SPRITE_GUIBUTTON_OFF);
 	IGraphics::CQuadItem QuadItem(pRect->x, pRect->y, pRect->w, pRect->h);
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	if(UI()->HotItem() == pID && Active)
@@ -155,15 +146,12 @@ int CMenus::DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, 
 	return Active && UI()->DoButtonLogic(pID, pRect);
 }
 
-int CMenus::DoButton_Menu(CButtonContainer *pBC, const char *pText, int Checked, const CUIRect *pRect, const char *pImageName, int Corners, float r, float FontFactor, vec4 ColorHot, bool TextFade)
+bool CMenus::DoButton_Menu(CButtonContainer *pBC, const char *pText, bool Checked, const CUIRect *pRect, const char *pImageName, int Corners, float Rounding, float FontFactor, vec4 ColorHot, bool TextFade)
 {
-	float Seconds = 0.6f; //  0.6 seconds for fade
-	float Fade = ButtonFade(pBC, Seconds, Checked);
-	float FadeVal = Fade/Seconds;
-	CUIRect Text = *pRect;
+	const float FadeVal = pBC->GetFade(Checked);
 
-	vec4 Color = mix(vec4(0.0f, 0.0f, 0.0f, 0.25f), ColorHot, FadeVal);
-	RenderTools()->DrawUIRect(pRect, Color, Corners, r);
+	CUIRect Text = *pRect;
+	RenderTools()->DrawUIRect(pRect, mix(vec4(0.0f, 0.0f, 0.0f, 0.25f), ColorHot, FadeVal), Corners, Rounding);
 
 	if(pImageName)
 	{
@@ -183,7 +171,7 @@ int CMenus::DoButton_Menu(CButtonContainer *pBC, const char *pText, int Checked,
 			Graphics()->QuadsDrawTL(&QuadItem, 1);
 			Graphics()->QuadsEnd();
 
-			if(Fade > 0.0f)
+			if(FadeVal > 0.0f)
 			{
 				Graphics()->TextureSet(pImage->m_OrgTexture);
 				Graphics()->WrapClamp();
@@ -196,7 +184,7 @@ int CMenus::DoButton_Menu(CButtonContainer *pBC, const char *pText, int Checked,
 		}
 	}
 
-	Text.HMargin(pRect->h>=20.0f?2.0f:1.0f, &Text);
+	Text.HMargin(pRect->h >= 20.0f ? 2.0f : 1.0f, &Text);
 	Text.HMargin((Text.h*FontFactor)/2.0f, &Text);
 	if(TextFade)
 	{
@@ -212,61 +200,40 @@ int CMenus::DoButton_Menu(CButtonContainer *pBC, const char *pText, int Checked,
 	return UI()->DoButtonLogic(pBC->GetID(), pRect);
 }
 
-void CMenus::DoButton_KeySelect(CButtonContainer *pBC, const char *pText, int Checked, const CUIRect *pRect)
+void CMenus::DoButton_KeySelect(CButtonContainer *pBC, const char *pText, const CUIRect *pRect)
 {
-	float Seconds = 0.6f; //  0.6 seconds for fade
-	float Fade = ButtonFade(pBC, Seconds, Checked);
-	float FadeVal = Fade/Seconds;
+	const float FadeVal = pBC->GetFade();
 
 	RenderTools()->DrawUIRect(pRect, vec4(0.0f+FadeVal, 0.0f+FadeVal, 0.0f+FadeVal, 0.25f+FadeVal*0.5f), CUI::CORNER_ALL, 5.0f);
-	CUIRect Temp;
-	pRect->HMargin(1.0f, &Temp);
+
+	CUIRect Label;
+	pRect->HMargin(1.0f, &Label);
 	TextRender()->TextColor(1.0f-FadeVal, 1.0f-FadeVal, 1.0f-FadeVal, 1.0f);
 	TextRender()->TextOutlineColor(0.0f+FadeVal, 0.0f+FadeVal, 0.0f+FadeVal, 0.25f);
-	UI()->DoLabel(&Temp, pText, Temp.h*ms_FontmodHeight, CUI::ALIGN_CENTER);
+	UI()->DoLabel(&Label, pText, Label.h*ms_FontmodHeight, CUI::ALIGN_CENTER);
 	TextRender()->TextColor(CUI::ms_DefaultTextColor);
 	TextRender()->TextOutlineColor(CUI::ms_DefaultTextOutlineColor);
 }
 
-int CMenus::DoButton_MenuTab(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Corners)
+bool CMenus::DoButton_MenuTabTop(CButtonContainer *pBC, const char *pText, bool Checked, const CUIRect *pRect, float Alpha, float FontAlpha, int Corners, float Rounding, float FontFactor)
 {
-	if(Checked)
-		RenderTools()->DrawUIRect(pRect, vec4(1.0f, 1.0f, 1.0f, 0.25f), Corners, 10.0f);
-	else
-	{
-		RenderTools()->DrawUIRect(pRect, vec4(0.0f, 0.0f, 0.0f, 0.25f), Corners, 10.0f);
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.7f);
-	}
+	const float ActualAlpha = UI()->MouseHovered(pRect) ? 1.0f : Alpha;
+	const float FadeVal = pBC->GetFade(Checked)*FontAlpha;
 
-	CUIRect Temp;
-	pRect->HMargin(pRect->h>=20.0f?2.0f:1.0f, &Temp);
-	UI()->DoLabel(&Temp, pText, Temp.h*ms_FontmodHeight, CUI::ALIGN_CENTER);
+	RenderTools()->DrawUIRect(pRect, vec4(0.0f+FadeVal, 0.0f+FadeVal, 0.0f+FadeVal, Config()->m_ClMenuAlpha/100.0f*ActualAlpha+FadeVal*0.5f), Corners, Rounding);
 
-	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
-	return UI()->DoButtonLogic(pID, pRect);
-}
-
-int CMenus::DoButton_MenuTabTop(CButtonContainer *pBC, const char *pText, int Checked, const CUIRect *pRect, float Alpha, float FontAlpha, int Corners, float r, float FontFactor)
-{
-	if(UI()->MouseInside(pRect))
-		Alpha = 1.0f;
-	float Seconds = 0.6f; //  0.6 seconds for fade
-	float Fade = ButtonFade(pBC, Seconds, Checked);
-	float FadeVal = (Fade/Seconds)*FontAlpha;
-
-	RenderTools()->DrawUIRect(pRect, vec4(0.0f+FadeVal, 0.0f+FadeVal, 0.0f+FadeVal, Config()->m_ClMenuAlpha/100.0f*Alpha+FadeVal*0.5f), Corners, r);
-	CUIRect Temp;
-	pRect->HMargin(pRect->h>=20.0f?2.0f:1.0f, &Temp);
-	Temp.HMargin((Temp.h*FontFactor)/2.0f, &Temp);
+	CUIRect Label;
+	pRect->HMargin(pRect->h >= 20.0f ? 2.0f : 1.0f, &Label);
+	Label.HMargin((Label.h*FontFactor)/2.0f, &Label);
 	TextRender()->TextColor(1.0f-FadeVal, 1.0f-FadeVal, 1.0f-FadeVal, FontAlpha);
 	TextRender()->TextOutlineColor(0.0f+FadeVal, 0.0f+FadeVal, 0.0f+FadeVal, 0.25f*FontAlpha);
-	UI()->DoLabel(&Temp, pText, Temp.h*ms_FontmodHeight, CUI::ALIGN_CENTER);
+	UI()->DoLabel(&Label, pText, Label.h*ms_FontmodHeight, CUI::ALIGN_CENTER);
 	TextRender()->TextColor(CUI::ms_DefaultTextColor);
 	TextRender()->TextOutlineColor(CUI::ms_DefaultTextOutlineColor);
 	return UI()->DoButtonLogic(pBC->GetID(), pRect);
 }
 
-int CMenus::DoButton_GridHeader(const void *pID, const char *pText, int Checked, CUI::EAlignment Align, const CUIRect *pRect)
+bool CMenus::DoButton_GridHeader(const void *pID, const char *pText, bool Checked, CUI::EAlignment Align, const CUIRect *pRect)
 {
 	if(Checked)
 	{
@@ -281,7 +248,7 @@ int CMenus::DoButton_GridHeader(const void *pID, const char *pText, int Checked,
 
 	CUIRect Label;
 	pRect->VMargin(2.0f, &Label);
-	Label.y+=2.0f;
+	Label.y += 2.0f;
 	UI()->DoLabel(&Label, pText, pRect->h*ms_FontmodHeight*0.8f, Align);
 
 	if(Checked)
@@ -293,18 +260,23 @@ int CMenus::DoButton_GridHeader(const void *pID, const char *pText, int Checked,
 	return UI()->DoButtonLogic(pID, pRect);
 }
 
-int CMenus::DoButton_CheckBox_Common(const void *pID, const char *pText, const char *pBoxText, const CUIRect *pRect, bool Checked, bool Locked)
+bool CMenus::DoButton_CheckBox(const void *pID, const char *pText, bool Checked, const CUIRect *pRect, bool Locked)
 {
+	if(Locked)
+	{
+		TextRender()->TextColor(0.5f, 0.5f, 0.5f, 1.0f);
+	}
+
 	RenderTools()->DrawUIRect(pRect, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
-	CUIRect c = *pRect;
-	CUIRect t = *pRect;
-	c.w = c.h;
-	t.x += c.w;
-	t.w -= c.w;
-	t.VSplitLeft(5.0f, 0, &t);
+	CUIRect Checkbox = *pRect;
+	CUIRect Label = *pRect;
+	Checkbox.w = Checkbox.h;
+	Label.x += Checkbox.w;
+	Label.w -= Checkbox.w;
+	Label.VSplitLeft(5.0f, 0, &Label);
 
-	c.Margin(2.0f, &c);
+	Checkbox.Margin(2.0f, &Checkbox);
 	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_MENUICONS].m_Id);
 	Graphics()->QuadsBegin();
 	if(Locked)
@@ -315,52 +287,45 @@ int CMenus::DoButton_CheckBox_Common(const void *pID, const char *pText, const c
 	if(UI()->HotItem() == pID)
 	{
 		RenderTools()->SelectSprite(SPRITE_MENU_CHECKBOX_HOVER);
-		IGraphics::CQuadItem QuadItem(c.x, c.y, c.w, c.h);
+		IGraphics::CQuadItem QuadItem(Checkbox.x, Checkbox.y, Checkbox.w, Checkbox.h);
 		Graphics()->QuadsDrawTL(&QuadItem, 1);
 	}
 	RenderTools()->SelectSprite(Checked ? SPRITE_MENU_CHECKBOX_ACTIVE : SPRITE_MENU_CHECKBOX_INACTIVE);
-	IGraphics::CQuadItem QuadItem(c.x, c.y, c.w, c.h);
+	IGraphics::CQuadItem QuadItem(Checkbox.x, Checkbox.y, Checkbox.w, Checkbox.h);
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();
 
-	t.y += 1.0f; // lame fix
-	UI()->DoLabel(&c, pBoxText, pRect->h*ms_FontmodHeight*0.6f, CUI::ALIGN_CENTER);
-	UI()->DoLabel(&t, pText, pRect->h*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
-	return UI()->DoButtonLogic(pID, pRect);
-}
+	Label.y += 1.0f; // lame fix
+	UI()->DoLabel(&Label, pText, pRect->h*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 
-int CMenus::DoButton_CheckBox(const void *pID, const char *pText, int Checked, const CUIRect *pRect, bool Locked)
-{
 	if(Locked)
 	{
-		TextRender()->TextColor(0.5f, 0.5f, 0.5f, 1.0f);
-		DoButton_CheckBox_Common(pID, pText, "", pRect, Checked, Locked);
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 		return false;
 	}
-	return DoButton_CheckBox_Common(pID, pText, "", pRect, Checked, Locked);
+	return UI()->DoButtonLogic(pID, pRect);
 }
 
-int CMenus::DoButton_CheckBox_Number(const void *pID, const char *pText, int SelectedNumber, const CUIRect *pRect)
+bool CMenus::DoButton_SpriteID(CButtonContainer *pBC, int ImageID, int SpriteID, bool Checked, const CUIRect *pRect, int Corners, float Rounding, bool Fade)
 {
-	char aBuf[16];
-	str_format(aBuf, sizeof(aBuf), "%d", SelectedNumber);
-	return DoButton_CheckBox_Common(pID, pText, aBuf, pRect);
-}
-
-int CMenus::DoButton_SpriteID(CButtonContainer *pBC, int ImageID, int SpriteID, bool Checked, const CUIRect *pRect, int Corners, float r, bool Fade)
-{
-	float Seconds = 0.6f; //  0.6 seconds for fade
-	float FadeVal = Fade ? ButtonFade(pBC, Seconds, Checked) / Seconds : 0.0f;
-
-	RenderTools()->DrawUIRect(pRect, vec4(0.0f + FadeVal, 0.0f + FadeVal, 0.0f + FadeVal, 0.25f + FadeVal * 0.5f), Corners, r);
+	const float FadeVal = Fade ? pBC->GetFade(Checked) : 0.0f;
 
 	CUIRect Icon = *pRect;
-	if(Icon.w > Icon.h)
-		Icon.VMargin((Icon.w - Icon.h) / 2, &Icon);
-	else if(Icon.w < Icon.h)
-		Icon.HMargin((Icon.h - Icon.w) / 2, &Icon);
-	Icon.Margin(2.0f, &Icon);
+
+	if(FadeVal > 0.0f || !pBC->IsCleanBackground())
+	{
+		RenderTools()->DrawUIRect(pRect, vec4(0.0f + FadeVal, 0.0f + FadeVal, 0.0f + FadeVal, 0.25f + FadeVal * 0.5f), Corners, Rounding);
+	}
+
+	if(!pBC->IsCleanBackground())
+	{
+		if(Icon.w > Icon.h)
+			Icon.VMargin((Icon.w - Icon.h) / 2, &Icon);
+		else if(Icon.w < Icon.h)
+			Icon.HMargin((Icon.h - Icon.w) / 2, &Icon);
+		Icon.Margin(2.0f, &Icon);
+	}
+
 	Graphics()->TextureSet(g_pData->m_aImages[ImageID].m_Id);
 	Graphics()->QuadsBegin();
 	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -372,58 +337,9 @@ int CMenus::DoButton_SpriteID(CButtonContainer *pBC, int ImageID, int SpriteID, 
 	return UI()->DoButtonLogic(pBC->GetID(), pRect);
 }
 
-int CMenus::DoButton_SpriteClean(int ImageID, int SpriteID, const CUIRect *pRect)
-{
-	bool Inside = UI()->MouseInside(pRect);
-
-	Graphics()->TextureSet(g_pData->m_aImages[ImageID].m_Id);
-	Graphics()->QuadsBegin();
-	Graphics()->SetColor(1.0f, 1.0f, 1.0f, Inside ? 1.0f : 0.6f);
-	RenderTools()->SelectSprite(SpriteID);
-	IGraphics::CQuadItem QuadItem(pRect->x, pRect->y, pRect->w, pRect->h);
-	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	Graphics()->QuadsEnd();
-
-	int ReturnValue = 0;
-	if(Inside && Input()->KeyPress(KEY_MOUSE_1))
-		ReturnValue = 1;
-
-	return ReturnValue;
-}
-
-int CMenus::DoButton_SpriteCleanID(const void *pID, int ImageID, int SpriteID, const CUIRect *pRect, bool Blend)
-{
-	bool Inside = UI()->MouseInside(pRect);
-
-	Graphics()->TextureSet(g_pData->m_aImages[ImageID].m_Id);
-	Graphics()->QuadsBegin();
-	Graphics()->SetColor(1.0f, 1.0f, 1.0f, !Blend || Inside ? 1.0f : 0.6f);
-	RenderTools()->SelectSprite(SpriteID);
-	IGraphics::CQuadItem QuadItem(pRect->x, pRect->y, pRect->w, pRect->h);
-	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	Graphics()->QuadsEnd();
-
-	return UI()->DoButtonLogic(pID, pRect);
-}
-
-int CMenus::DoButton_MouseOver(int ImageID, int SpriteID, const CUIRect *pRect)
-{
-	bool Inside = UI()->MouseInside(pRect);
-
-	Graphics()->TextureSet(g_pData->m_aImages[ImageID].m_Id);
-	Graphics()->QuadsBegin();
-	Graphics()->SetColor(1.0f, 1.0f, 1.0f, Inside ? 1.0f : 0.6f);
-	RenderTools()->SelectSprite(SpriteID);
-	IGraphics::CQuadItem QuadItem(pRect->x, pRect->y, pRect->w, pRect->h);
-	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	Graphics()->QuadsEnd();
-
-	return Inside;
-}
-
 bool CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden, int Corners)
 {
-	bool Inside = UI()->MouseInside(pRect);
+	bool Inside = UI()->MouseHovered(pRect);
 	bool Changed = false;
 	bool UpdateOffset = false;
 	static int s_AtIndex = 0;
@@ -525,8 +441,7 @@ bool CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned Str
 	else
 		Color = vec4(0.0f, 0.0f, 0.0f, 0.25f);
 	RenderTools()->DrawUIRect(&Textbox, Color, Corners, 5.0f);
-	Textbox.VMargin(2.0f, &Textbox);
-	Textbox.HMargin(2.0f, &Textbox);
+	Textbox.Margin(2.0f, &Textbox);
 
 	const char *pDisplayStr = pStr;
 	char aStars[128];
@@ -577,13 +492,14 @@ bool CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned Str
 		// set cursor active
 		m_CursorActive = true;
 
-		float w = TextRender()->TextWidth(0, FontSize, pDisplayStr, s_AtIndex, -1.0f);
-		Textbox = *pRect;
-		Textbox.VSplitLeft(2.0f, 0, &Textbox);
-		Textbox.x += (w-*pOffset-TextRender()->TextWidth(0, FontSize, "|", -1, -1.0f)/2);
-
 		if((2*time_get()/time_freq()) % 2)	// make it blink
+		{
+			float TextWidth = TextRender()->TextWidth(0, FontSize, pDisplayStr, s_AtIndex, -1.0f);
+			Textbox = *pRect;
+			Textbox.VSplitLeft(2.0f, 0, &Textbox);
+			Textbox.x += TextWidth - *pOffset - TextRender()->TextWidth(0, FontSize, "|", -1, -1.0f)/2;
 			UI()->DoLabel(&Textbox, "|", FontSize, CUI::ALIGN_LEFT);
+		}
 	}
 	UI()->ClipDisable();
 
@@ -646,7 +562,7 @@ void CMenus::DoScrollbarOption(void *pID, int *pOption, const CUIRect *pRect, co
 void CMenus::DoScrollbarOptionLabeled(void *pID, int *pOption, const CUIRect *pRect, const char *pStr, const char* aLabels[], int Num, IScrollbarScale *pScale)
 {
 	int Value = clamp(*pOption, 0, Num - 1);
-	int Max = Num - 1;
+	const int Max = Num - 1;
 
 	char aBuf[128];
 	str_format(aBuf, sizeof(aBuf), "%s: %s", pStr, aLabels[Value]);
@@ -668,18 +584,15 @@ void CMenus::DoScrollbarOptionLabeled(void *pID, int *pOption, const CUIRect *pR
 	*pOption = clamp(Value, 0, Max);
 }
 
-float CMenus::DoDropdownMenu(void *pID, const CUIRect *pRect, const char *pStr, float HeaderHeight, FDropdownCallback pfnCallback)
+float CMenus::DoIndependentDropdownMenu(void *pID, const CUIRect *pRect, const char *pStr, float HeaderHeight, FDropdownCallback pfnCallback, bool *pActive)
 {
 	CUIRect View = *pRect;
 	CUIRect Header, Label;
 
-	bool Active = pID == m_pActiveDropdown;
-	int Corners = Active ? CUI::CORNER_T : CUI::CORNER_ALL;
-
 	View.HSplitTop(HeaderHeight, &Header, &View);
 
 	// background
-	RenderTools()->DrawUIRect(&Header, vec4(0.0f, 0.0f, 0.0f, 0.25f), Corners, 5.0f);
+	RenderTools()->DrawUIRect(&Header, vec4(0.0f, 0.0f, 0.0f, 0.25f), *pActive ? CUI::CORNER_T : CUI::CORNER_ALL, 5.0f);
 
 	// render icon
 	CUIRect Button;
@@ -687,66 +600,11 @@ float CMenus::DoDropdownMenu(void *pID, const CUIRect *pRect, const char *pStr, 
 	Button.Margin(2.0f, &Button);
 	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_MENUICONS].m_Id);
 	Graphics()->QuadsBegin();
-	if(UI()->MouseInside(&Header))
+	if(UI()->MouseHovered(&Header))
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 	else
 		Graphics()->SetColor(0.6f, 0.6f, 0.6f, 1.0f);
-	if(Active)
-		RenderTools()->SelectSprite(SPRITE_MENU_EXPANDED);
-	else
-		RenderTools()->SelectSprite(SPRITE_MENU_COLLAPSED);
-	IGraphics::CQuadItem QuadItem(Button.x, Button.y, Button.w, Button.h);
-	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-	Graphics()->QuadsEnd();
-
-	// label
-	Label = Header;
-	Label.y += 2.0f;
-	UI()->DoLabel(&Label, pStr, Header.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
-
-	if(UI()->DoButtonLogic(pID, &Header))
-	{
-		if(Active)
-			m_pActiveDropdown = 0;
-		else
-			m_pActiveDropdown = (int*)pID;
-	}
-
-	// render content of expanded menu
-	if(Active)
-		return HeaderHeight + (this->*pfnCallback)(View);
-
-	return HeaderHeight;
-}
-
-float CMenus::DoIndependentDropdownMenu(void *pID, const CUIRect *pRect, const char *pStr, float HeaderHeight, FDropdownCallback pfnCallback, bool* pActive)
-{
-	CUIRect View = *pRect;
-	CUIRect Header, Label;
-
-	bool Active = *pActive;
-	int Corners = Active ? CUI::CORNER_T : CUI::CORNER_ALL;
-
-	View.HSplitTop(HeaderHeight, &Header, &View);
-
-	// background
-	RenderTools()->DrawUIRect(&Header, vec4(0.0f, 0.0f, 0.0f, 0.25f), Corners, 5.0f);
-
-	// render icon
-	CUIRect Button;
-	Header.VSplitLeft(Header.h, &Button, 0);
-	Button.Margin(2.0f, &Button);
-	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_MENUICONS].m_Id);
-	Graphics()->QuadsBegin();
-	if(UI()->MouseInside(&Header))
-		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-	else
-		Graphics()->SetColor(0.6f, 0.6f, 0.6f, 1.0f);
-	if(Active)
-		RenderTools()->SelectSprite(SPRITE_MENU_EXPANDED);
-	else
-		RenderTools()->SelectSprite(SPRITE_MENU_COLLAPSED);
+	RenderTools()->SelectSprite(*pActive ? SPRITE_MENU_EXPANDED : SPRITE_MENU_COLLAPSED);
 	IGraphics::CQuadItem QuadItem(Button.x, Button.y, Button.w, Button.h);
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -761,7 +619,7 @@ float CMenus::DoIndependentDropdownMenu(void *pID, const CUIRect *pRect, const c
 		*pActive ^= 1;
 
 	// render content of expanded menu
-	if(Active)
+	if(*pActive)
 		return HeaderHeight + (this->*pfnCallback)(View);
 
 	return HeaderHeight;
@@ -798,8 +656,8 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 
 	// logic
 	static float s_OffsetY;
-	const bool InsideHandle = UI()->MouseInside(&Handle);
-	const bool InsideRail = UI()->MouseInside(&Rail);
+	const bool InsideHandle = UI()->MouseHovered(&Handle);
+	const bool InsideRail = UI()->MouseHovered(&Rail);
 	float ReturnValue = Current;
 	bool Grabbed = false; // whether to apply the offset
 
@@ -867,8 +725,8 @@ float CMenus::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current)
 
 	// logic
 	static float s_OffsetX;
-	const bool InsideHandle = UI()->MouseInside(&Handle);
-	const bool InsideRail = UI()->MouseInside(&Rail);
+	const bool InsideHandle = UI()->MouseHovered(&Handle);
+	const bool InsideRail = UI()->MouseHovered(&Rail);
 	float ReturnValue = Current;
 	bool Grabbed = false; // whether to apply the offset
 
@@ -953,7 +811,7 @@ int CMenus::DoKeyReader(CButtonContainer *pBC, const CUIRect *pRect, int Key, in
 	static const void *pGrabbedID = 0;
 	static bool MouseReleased = true;
 	static int ButtonUsed = 0;
-	bool Inside = UI()->MouseInside(pRect) && UI()->MouseInsideClip();
+	const bool Hovered = UI()->MouseHovered(pRect);
 	int NewKey = Key;
 	*NewModifier = Modifier;
 
@@ -978,7 +836,7 @@ int CMenus::DoKeyReader(CButtonContainer *pBC, const CUIRect *pRect, int Key, in
 
 		if(ButtonUsed == 1 && !UI()->MouseButton(1))
 		{
-			if(Inside)
+			if(Hovered)
 				NewKey = 0;
 			UI()->SetActiveItem(0);
 		}
@@ -1003,24 +861,24 @@ int CMenus::DoKeyReader(CButtonContainer *pBC, const CUIRect *pRect, int Key, in
 		}
 	}
 
-	if(Inside)
+	if(Hovered)
 		UI()->SetHotItem(pBC->GetID());
 
 	// draw
 	if(UI()->CheckActiveItem(pBC->GetID()) && ButtonUsed == 0)
 	{
-		DoButton_KeySelect(pBC, "???", 0, pRect);
+		DoButton_KeySelect(pBC, "???", pRect);
 		m_KeyReaderIsActive = true;
 	}
 	else
 	{
 		if(Key == 0)
-			DoButton_KeySelect(pBC, "", 0, pRect);
+			DoButton_KeySelect(pBC, "", pRect);
 		else
 		{
 			char aBuf[64];
 			str_format(aBuf, sizeof(aBuf), "%s%s", CBinds::GetModifierName(*NewModifier), Input()->KeyName(Key));
-			DoButton_KeySelect(pBC, aBuf, 0, pRect);
+			DoButton_KeySelect(pBC, aBuf, pRect);
 		}
 	}
 	return NewKey;
@@ -1088,9 +946,11 @@ void CMenus::RenderMenubar(CUIRect Rect)
 		Right.VSplitRight(Spacing, &Right, 0); // little space
 		Right.VSplitRight(ButtonWidth/2.0f, &Right, &Button);
 		static CButtonContainer s_ServerBrowserButton;
-		if(DoButton_SpriteID(&s_ServerBrowserButton, IMAGE_BROWSER, UI()->MouseInside(&Button) || m_GamePage == PAGE_INTERNET || m_GamePage == PAGE_LAN ? SPRITE_BROWSER_B : SPRITE_BROWSER_A,
+		if(DoButton_SpriteID(&s_ServerBrowserButton, IMAGE_BROWSER, UI()->MouseHovered(&Button) || m_GamePage == PAGE_INTERNET || m_GamePage == PAGE_LAN ? SPRITE_BROWSER_B : SPRITE_BROWSER_A,
 			m_GamePage == PAGE_INTERNET || m_GamePage == PAGE_LAN, &Button) || CheckHotKey(KEY_B))
+		{
 			NewPage = ServerBrowser()->GetType() == IServerBrowser::TYPE_INTERNET ? PAGE_INTERNET : PAGE_LAN;
+		}
 
 		Rect.HSplitTop(Spacing, 0, &Rect);
 		Rect.HSplitTop(25.0f, &Box, &Rect);
@@ -1642,16 +1502,14 @@ int CMenus::Render()
 				static CButtonContainer s_QuitButton;
 
 				// draw red-blending button
-				vec4 Color = mix(vec4(0.f, 0.f, 0.f, 0.25f), vec4(1.f/0xff*0xf9, 1.f/0xff*0x2b, 1.f/0xff*0x2b, 0.75f), ButtonFade(&s_QuitButton, 0.6f, 0)/0.6f);
+				vec4 Color = mix(vec4(0.f, 0.f, 0.f, 0.25f), vec4(1.f/0xff*0xf9, 1.f/0xff*0x2b, 1.f/0xff*0x2b, 0.75f), s_QuitButton.GetFade());
 				RenderTools()->DrawUIRect(&Button, Color, CUI::CORNER_BL, 5.0f);
 
 				// draw non-blending X
 				CUIRect XText = Button;
-				// XText.HMargin(Button.h>=20.0f?2.0f:1.0f, &XText);
 
 				UI()->DoLabel(&XText, "\xE2\x9C\x95", XText.h*ms_FontmodHeight, CUI::ALIGN_CENTER);
 				if(UI()->DoButtonLogic(s_QuitButton.GetID(), &Button))
-				// if(DoButton_SpriteCleanID(&s_QuitButton, IMAGE_FRIENDICONS, SPRITE_FRIEND_X_A, &Button, false))
 					m_Popup = POPUP_QUIT;
 
 				// settings button
@@ -2351,19 +2209,10 @@ void CMenus::OnRender()
 	}
 
 	// update the ui
-	CUIRect *pScreen = UI()->Screen();
-	float mx = (m_MousePos.x/(float)Graphics()->ScreenWidth())*pScreen->w;
-	float my = (m_MousePos.y/(float)Graphics()->ScreenHeight())*pScreen->h;
-
-	int Buttons = 0;
-	if(m_UseMouseButtons)
-	{
-		if(Input()->KeyIsPressed(KEY_MOUSE_1)) Buttons |= 1;
-		if(Input()->KeyIsPressed(KEY_MOUSE_2)) Buttons |= 2;
-		if(Input()->KeyIsPressed(KEY_MOUSE_3)) Buttons |= 4;
-	}
-
-	UI()->Update(mx,my,mx*3.0f,my*3.0f,Buttons);
+	const CUIRect *pScreen = UI()->Screen();
+	float MouseX = (m_MousePos.x/(float)Graphics()->ScreenWidth())*pScreen->w;
+	float MouseY = (m_MousePos.y/(float)Graphics()->ScreenHeight())*pScreen->h;
+	UI()->Update(MouseX, MouseY, MouseX*3.0f, MouseY*3.0f);
 
 	// render
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
@@ -2374,7 +2223,7 @@ void CMenus::OnRender()
 	Graphics()->WrapClamp();
 	Graphics()->QuadsBegin();
 	Graphics()->SetColor(1,1,1,1);
-	IGraphics::CQuadItem QuadItem(mx, my, 24, 24);
+	IGraphics::CQuadItem QuadItem(MouseX, MouseY, 24, 24);
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();
 	Graphics()->WrapNormal();
@@ -2382,8 +2231,7 @@ void CMenus::OnRender()
 	// render debug information
 	if(Config()->m_Debug)
 	{
-		CUIRect Screen = *UI()->Screen();
-		Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
+		Graphics()->MapScreen(pScreen->x, pScreen->y, pScreen->w, pScreen->h);
 
 		char aBuf[64];
 		str_format(aBuf, sizeof(aBuf), "%p %p %p", UI()->HotItem(), UI()->GetActiveItem(), UI()->LastActiveItem());
@@ -2415,8 +2263,8 @@ bool CMenus::IsBackgroundNeeded() const
 
 void CMenus::RenderBackground(float Time)
 {
-	float ScreenWidth = 300*Graphics()->ScreenAspect();
 	float ScreenHeight = 300;
+	float ScreenWidth = ScreenHeight*Graphics()->ScreenAspect();
 	Graphics()->MapScreen(0, 0, ScreenWidth, ScreenHeight);
 
 	// render the tiles

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -84,54 +84,6 @@ public:
 class CMenus : public CComponent
 {
 public:
-	class CButtonContainer
-	{
-	public:
-		float m_FadeStartTime;
-
-		const void *GetID() const { return &m_FadeStartTime; }
-	};
-
-private:
-	typedef float (CMenus::*FDropdownCallback)(CUIRect View);
-
-	float ButtonFade(CButtonContainer *pBC, float Seconds, int Checked=0);
-
-	int DoButton_SpriteID(CButtonContainer *pBC, int ImageID, int SpriteID, bool Checked, const CUIRect *pRect, int Corners=CUI::CORNER_ALL, float r=5.0f, bool Fade=true);
-	int DoButton_SpriteClean(int ImageID, int SpriteID, const CUIRect *pRect);
-	int DoButton_SpriteCleanID(const void *pID, int ImageID, int SpriteID, const CUIRect *pRect, bool Blend=true);
-	int DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, bool Active);
-	int DoButton_Menu(CButtonContainer *pBC, const char *pText, int Checked, const CUIRect *pRect, const char *pImageName=0, int Corners=CUI::CORNER_ALL, float r=5.0f, float FontFactor=0.0f, vec4 ColorHot=vec4(1.0f, 1.0f, 1.0f, 0.75f), bool TextFade=true);
-	int DoButton_MenuTab(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Corners);
-	int DoButton_MenuTabTop(CButtonContainer *pBC, const char *pText, int Checked, const CUIRect *pRect, float Alpha=1.0f, float FontAlpha=1.0f, int Corners=CUI::CORNER_ALL, float r=5.0f, float FontFactor=0.0f);
-	int DoButton_Customize(CButtonContainer *pBC, IGraphics::CTextureHandle Texture, int SpriteID, const CUIRect *pRect, float ImageRatio);
-
-	int DoButton_CheckBox_Common(const void *pID, const char *pText, const char *pBoxText, const CUIRect *pRect, bool Checked=false, bool Locked=false);
-	int DoButton_CheckBox(const void *pID, const char *pText, int Checked, const CUIRect *pRect, bool Locked=false);
-	int DoButton_CheckBox_Number(const void *pID, const char *pText, int SelectedNumber, const CUIRect *pRect);
-
-	int DoButton_MouseOver(int ImageID, int SpriteID, const CUIRect *pRect);
-
-	int DoIcon(int ImageId, int SpriteId, const CUIRect *pRect);
-	void DoIconColor(int ImageId, int SpriteId, const CUIRect *pRect, const vec4& Color);
-	int DoButton_GridHeader(const void *pID, const char *pText, int Checked, CUI::EAlignment Align, const CUIRect *pRect);
-
-	bool DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden=false, int Corners=CUI::CORNER_ALL);
-	void DoEditBoxOption(void *pID, char *pOption, int OptionLength, const CUIRect *pRect, const char *pStr, float VSplitVal, float *pOffset, bool Hidden=false);
-	void DoScrollbarOption(void *pID, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, IScrollbarScale *pScale = &LinearScrollbarScale, bool Infinite=false);
-	void DoScrollbarOptionLabeled(void *pID, int *pOption, const CUIRect *pRect, const char *pStr, const char* aLabels[], int Num, IScrollbarScale *pScale = &LinearScrollbarScale);
-	float DoDropdownMenu(void *pID, const CUIRect *pRect, const char *pStr, float HeaderHeight, FDropdownCallback pfnCallback);
-	float DoIndependentDropdownMenu(void *pID, const CUIRect *pRect, const char *pStr, float HeaderHeight, FDropdownCallback pfnCallback, bool* pActive);
-	void DoInfoBox(const CUIRect *pRect, const char *pLable, const char *pValue);
-
-	float DoScrollbarV(const void *pID, const CUIRect *pRect, float Current);
-	float DoScrollbarH(const void *pID, const CUIRect *pRect, float Current);
-	void DoJoystickBar(const CUIRect *pRect, float Current, float Tolerance, bool Active);
-	void DoButton_KeySelect(CButtonContainer *pBC, const char *pText, int Checked, const CUIRect *pRect);
-	int DoKeyReader(CButtonContainer *pPC, const CUIRect *pRect, int Key, int Modifier, int* NewModifier);
-	void UiDoGetButtons(int Start, int Stop, CUIRect View, float ButtonHeight, float Spacing);
-
-
 	class CUIElementBase
 	{
 	protected:
@@ -139,10 +91,48 @@ private:
 		static CRenderTools *m_pRenderTools;
 		static CUI *m_pUI;
 		static IInput *m_pInput;
+		static IClient *m_pClient;
 
 	public:
-		static void Init(CMenus *pMenus) { m_pMenus = pMenus; m_pRenderTools = pMenus->RenderTools(); m_pUI = pMenus->UI(); m_pInput = pMenus->Input(); };
+		static void Init(CMenus *pMenus) { m_pMenus = pMenus; m_pRenderTools = pMenus->RenderTools(); m_pUI = pMenus->UI(); m_pInput = pMenus->Input(); m_pClient = pMenus->Client(); };
 	};
+
+	class CButtonContainer : public CUIElementBase
+	{
+		bool m_CleanBackground;
+		float m_FadeStartTime;
+	public:
+		CButtonContainer(bool CleanBackground = false) { m_CleanBackground = CleanBackground; }
+		const void *GetID() const { return &m_FadeStartTime; }
+		float GetFade(bool Checked = false, float Seconds = 0.6f);
+		bool IsCleanBackground() const { return m_CleanBackground; }
+	};
+
+private:
+	typedef float (CMenus::*FDropdownCallback)(CUIRect View);
+
+	bool DoButton_SpriteID(CButtonContainer *pBC, int ImageID, int SpriteID, bool Checked, const CUIRect *pRect, int Corners = CUI::CORNER_ALL, float Rounding = 5.0f, bool Fade = true);
+	bool DoButton_Toggle(const void *pID, bool Checked, const CUIRect *pRect, bool Active);
+	bool DoButton_Menu(CButtonContainer *pBC, const char *pText, bool Checked, const CUIRect *pRect, const char *pImageName = 0, int Corners = CUI::CORNER_ALL, float Rounding = 5.0f, float FontFactor = 0.0f, vec4 ColorHot = vec4(1.0f, 1.0f, 1.0f, 0.75f), bool TextFade = true);
+	bool DoButton_MenuTabTop(CButtonContainer *pBC, const char *pText, bool Checked, const CUIRect *pRect, float Alpha = 1.0f, float FontAlpha = 1.0f, int Corners = CUI::CORNER_ALL, float Rounding = 5.0f, float FontFactor = 0.0f);
+
+	bool DoButton_CheckBox(const void *pID, const char *pText, bool Checked, const CUIRect *pRect, bool Locked = false);
+
+	void DoIcon(int ImageId, int SpriteId, const CUIRect *pRect, const vec4 *pColor = 0);
+	bool DoButton_GridHeader(const void *pID, const char *pText, bool Checked, CUI::EAlignment Align, const CUIRect *pRect);
+
+	bool DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden = false, int Corners = CUI::CORNER_ALL);
+	void DoEditBoxOption(void *pID, char *pOption, int OptionLength, const CUIRect *pRect, const char *pStr, float VSplitVal, float *pOffset, bool Hidden = false);
+	void DoScrollbarOption(void *pID, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, IScrollbarScale *pScale = &LinearScrollbarScale, bool Infinite = false);
+	void DoScrollbarOptionLabeled(void *pID, int *pOption, const CUIRect *pRect, const char *pStr, const char *apLabels[], int Num, IScrollbarScale *pScale = &LinearScrollbarScale);
+	float DoIndependentDropdownMenu(void *pID, const CUIRect *pRect, const char *pStr, float HeaderHeight, FDropdownCallback pfnCallback, bool *pActive);
+	void DoInfoBox(const CUIRect *pRect, const char *pLable, const char *pValue);
+
+	float DoScrollbarV(const void *pID, const CUIRect *pRect, float Current);
+	float DoScrollbarH(const void *pID, const CUIRect *pRect, float Current);
+	void DoJoystickBar(const CUIRect *pRect, float Current, float Tolerance, bool Active);
+	void DoButton_KeySelect(CButtonContainer *pBC, const char *pText, const CUIRect *pRect);
+	int DoKeyReader(CButtonContainer *pPC, const CUIRect *pRect, int Key, int Modifier, int *pNewModifier);
 
 	// Scroll region : found in menus_scrollregion.cpp
 	struct CScrollRegionParams
@@ -329,7 +319,6 @@ private:
 	int m_MenuPage;
 	int m_MenuPageOld;
 	bool m_MenuActive;
-	bool m_UseMouseButtons;
 	vec2 m_MousePos;
 	vec2 m_PrevMousePos;
 	bool m_CursorActive;
@@ -617,7 +606,9 @@ private:
 
 		// buttons var
 		int m_SwitchButton;
-		int m_aButtonID[3];
+		CButtonContainer m_DeleteButtonContainer;
+		CButtonContainer m_UpButtonContainer;
+		CButtonContainer m_DownButtonContainer;
 
 		CBrowserFilter() {}
 		CBrowserFilter(int Custom, const char* pName, IServerBrowser *pServerBrowser);
@@ -853,6 +844,7 @@ private:
 	float RenderSettingsControlsScoreboard(CUIRect View);
 	float RenderSettingsControlsStats(CUIRect View);
 	float RenderSettingsControlsMisc(CUIRect View);
+	void DoSettingsControlsButtons(int Start, int Stop, CUIRect View, float ButtonHeight, float Spacing);
 
 	void DoJoystickAxisPicker(CUIRect View);
 
@@ -883,8 +875,6 @@ public:
 		int m_TimeLeft;
 	};
 	void GetSwitchTeamInfo(CSwitchTeamInfo *pInfo);
-
-	void UseMouseButtons(bool Use) { m_UseMouseButtons = Use; }
 
 	static CMenusKeyBinder m_Binder;
 

--- a/src/game/client/components/menus_callback.cpp
+++ b/src/game/client/components/menus_callback.cpp
@@ -65,7 +65,7 @@ static CKeyInfo gs_aKeys[] =
 
 const int g_KeyCount = sizeof(gs_aKeys) / sizeof(CKeyInfo);
 
-void CMenus::UiDoGetButtons(int Start, int Stop, CUIRect View, float ButtonHeight, float Spacing)
+void CMenus::DoSettingsControlsButtons(int Start, int Stop, CUIRect View, float ButtonHeight, float Spacing)
 {
 	for (int i = Start; i < Stop; i++)
 	{
@@ -247,7 +247,7 @@ float CMenus::RenderSettingsControlsMovement(CUIRect View)
 	View.HSplitTop(BackgroundHeight, &View, 0);
 	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
 
-	UiDoGetButtons(0, 5, View, ButtonHeight, Spacing);
+	DoSettingsControlsButtons(0, 5, View, ButtonHeight, Spacing);
 
 	return BackgroundHeight;
 }
@@ -264,7 +264,7 @@ float CMenus::RenderSettingsControlsWeapon(CUIRect View)
 	View.HSplitTop(BackgroundHeight, &View, 0);
 	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
 
-	UiDoGetButtons(5, 12, View, ButtonHeight, Spacing);
+	DoSettingsControlsButtons(5, 12, View, ButtonHeight, Spacing);
 
 	return BackgroundHeight;
 }
@@ -281,7 +281,7 @@ float CMenus::RenderSettingsControlsVoting(CUIRect View)
 	View.HSplitTop(BackgroundHeight, &View, 0);
 	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
 
-	UiDoGetButtons(12, 14, View, ButtonHeight, Spacing);
+	DoSettingsControlsButtons(12, 14, View, ButtonHeight, Spacing);
 
 	return BackgroundHeight;
 }
@@ -298,7 +298,7 @@ float CMenus::RenderSettingsControlsChat(CUIRect View)
 	View.HSplitTop(BackgroundHeight, &View, 0);
 	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
 
-	UiDoGetButtons(14, 18, View, ButtonHeight, Spacing);
+	DoSettingsControlsButtons(14, 18, View, ButtonHeight, Spacing);
 
 	return BackgroundHeight;
 }
@@ -339,7 +339,7 @@ float CMenus::RenderSettingsControlsScoreboard(CUIRect View)
 	View.HSplitTop(BackgroundHeight, &View, 0);
 	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
 
-	UiDoGetButtons(StartOption, StartOption+NumOptions, View, ButtonHeight, Spacing);
+	DoSettingsControlsButtons(StartOption, StartOption+NumOptions, View, ButtonHeight, Spacing);
 
 	View.HSplitTop(ButtonHeight*2+Spacing*3, 0, &View);
 	View.VSplitLeft(View.w/3, 0, &View);
@@ -364,7 +364,7 @@ float CMenus::RenderSettingsControlsMisc(CUIRect View)
 	View.HSplitTop(BackgroundHeight, &View, 0);
 	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
 
-	UiDoGetButtons(StartOption, StartOption+NumOptions, View, ButtonHeight, Spacing);
+	DoSettingsControlsButtons(StartOption, StartOption+NumOptions, View, ButtonHeight, Spacing);
 
 	return BackgroundHeight;
 }

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -125,8 +125,6 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		UI()->DoLabel(&SeekBar, aBuffer, SeekBar.h*0.70f, CUI::ALIGN_CENTER);
 
 		// do the logic
-		bool Inside = UI()->MouseInside(&SeekBar);
-
 		if(UI()->CheckActiveItem(&s_PrevAmount))
 		{
 			if(!UI()->MouseButton(0))
@@ -157,7 +155,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			}
 		}
 
-		if(Inside)
+		if(UI()->MouseHovered(&SeekBar))
 			UI()->SetHotItem(&s_PrevAmount);
 	}
 
@@ -549,7 +547,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 					IconColor = vec4(0.5, 1, 0.5, 1);
 			}
 
-			DoIconColor(IMAGE_FILEICONS, DemoItem.m_IsDir?SPRITE_FILE_FOLDER:SPRITE_FILE_DEMO1, &FileIcon, IconColor);
+			DoIcon(IMAGE_FILEICONS, DemoItem.m_IsDir ? SPRITE_FILE_FOLDER : SPRITE_FILE_DEMO1, &FileIcon, &IconColor);
 
 			for(int c = 0; c < NumCols; c++)
 			{

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -780,8 +780,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 			// clear button
 			{
 				static CButtonContainer s_ClearButton;
-				float Fade = ButtonFade(&s_ClearButton, 0.6f);
-				RenderTools()->DrawUIRect(&ClearButton, vec4(1.0f, 1.0f, 1.0f, 0.33f+(Fade/0.6f)*0.165f), CUI::CORNER_R, 3.0f);
+				RenderTools()->DrawUIRect(&ClearButton, vec4(1.0f, 1.0f, 1.0f, 0.33f+s_ClearButton.GetFade()*0.165f), CUI::CORNER_R, 3.0f);
 				Label = ClearButton;
 				Label.y += 2.0f;
 				UI()->DoLabel(&Label, "x", Label.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);

--- a/src/game/client/components/menus_popups.cpp
+++ b/src/game/client/components/menus_popups.cpp
@@ -53,15 +53,14 @@ void CMenus::DoPopupMenu()
 {
 	if(m_PopupActive)
 	{
-		bool Inside = UI()->MouseInside(&s_Popups.m_Rect);
 		UI()->SetHotItem(&s_Popups.m_pId);
 
 		if(UI()->CheckActiveItem(&s_Popups.m_pId))
 		{
 			if(!UI()->MouseButton(0))
 			{
-				if(!Inside)
-				m_PopupActive = false;
+				if(!UI()->MouseHovered(&s_Popups.m_Rect))
+					m_PopupActive = false;
 				UI()->SetActiveItem(0);
 			}
 		}

--- a/src/game/client/components/menus_scrollregion.cpp
+++ b/src/game/client/components/menus_scrollregion.cpp
@@ -67,10 +67,10 @@ void CMenus::CScrollRegion::End()
 	CUIRect RegionRect = m_ClipRect;
 	RegionRect.w += m_Params.m_ScrollbarWidth;
 
-	const bool isPageScroll = m_pInput->KeyIsPressed(KEY_LALT) || m_pInput->KeyIsPressed(KEY_RALT);
-	if(m_pUI->MouseInside(&RegionRect))
-	{	
-		float ScrollUnit = isPageScroll ? m_ClipRect.h : m_Params.m_ScrollUnit;
+	const bool IsPageScroll = m_pInput->KeyIsPressed(KEY_LALT) || m_pInput->KeyIsPressed(KEY_RALT);
+	if(m_pUI->MouseHovered(&RegionRect))
+	{
+		const float ScrollUnit = IsPageScroll ? m_ClipRect.h : m_Params.m_ScrollUnit;
 		if(m_pInput->KeyPress(KEY_MOUSE_WHEEL_UP))
 			m_ScrollY -= ScrollUnit;
 		else if(m_pInput->KeyPress(KEY_MOUSE_WHEEL_DOWN))
@@ -98,8 +98,8 @@ void CMenus::CScrollRegion::End()
 	bool Hovered = false;
 	bool Grabbed = false;
 	const void* pID = &m_ScrollY;
-	const bool InsideSlider = m_pUI->MouseInside(&Slider);
-	const bool InsideRail = m_pUI->MouseInside(&m_RailRect);
+	const bool InsideSlider = m_pUI->MouseHovered(&Slider);
+	const bool InsideRail = m_pUI->MouseHovered(&m_RailRect);
 
 	if(m_pUI->CheckActiveItem(pID) && m_pUI->MouseButton(0))
 	{

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -63,23 +63,6 @@ bool CMenusKeyBinder::OnInput(IInput::CEvent Event)
 	return false;
 }
 
-int CMenus::DoButton_Customize(CButtonContainer *pBC, IGraphics::CTextureHandle Texture, int SpriteID, const CUIRect *pRect, float ImageRatio)
-{
-	float Seconds = 0.6f; //  0.6 seconds for fade
-	float Fade = ButtonFade(pBC, Seconds);
-
-	RenderTools()->DrawUIRect(pRect, vec4(1.0f, 1.0f, 1.0f, 0.5f+(Fade/Seconds)*0.25f), CUI::CORNER_ALL, 10.0f);
-	Graphics()->TextureSet(Texture);
-	Graphics()->QuadsBegin();
-	RenderTools()->SelectSprite(SpriteID);
-	float Height = pRect->w/ImageRatio;
-	IGraphics::CQuadItem QuadItem(pRect->x, pRect->y+(pRect->h-Height)/2, pRect->w, Height);
-	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	Graphics()->QuadsEnd();
-
-	return UI()->DoButtonLogic(pBC->GetID(), pRect);
-}
-
 void CMenus::RenderHSLPicker(CUIRect MainView)
 {
 	CUIRect Label, Button, Picker;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -340,7 +340,7 @@ void CGameClient::OnInit()
 	m_pGraphics = Kernel()->RequestInterface<IGraphics>();
 
 	// propagate pointers
-	m_UI.Init(Config(), Graphics(), TextRender());
+	m_UI.Init(Config(), Graphics(), Input(), TextRender());
 	m_RenderTools.Init(Config(), Graphics(), UI());
 
 	int64 Start = time_get();

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3075,8 +3075,8 @@ void CEditor::AddFileDialogEntry(int Index, CUIRect *pView)
 void CEditor::RenderFileDialog()
 {
 	// GUI coordsys
-	Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
 	CUIRect View = *UI()->Screen();
+	Graphics()->MapScreen(View.x, View.y, View.w, View.h);
 	CUIRect Preview;
 	float Width = View.w, Height = View.h;
 
@@ -4138,7 +4138,7 @@ void CEditor::Render()
 	// basic start
 	Graphics()->Clear(1.0f, 0.0f, 1.0f);
 	CUIRect View = *UI()->Screen();
-	Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
+	Graphics()->MapScreen(View.x, View.y, View.w, View.h);
 
 	float Width = View.w;
 	float Height = View.h;
@@ -4503,7 +4503,7 @@ void CEditor::Init()
 	m_pTextRender = Kernel()->RequestInterface<ITextRender>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 	m_RenderTools.Init(m_pConfig, m_pGraphics, &m_UI);
-	m_UI.Init(m_pConfig, m_pGraphics, m_pTextRender);
+	m_UI.Init(m_pConfig, m_pGraphics, m_pInput, m_pTextRender);
 	m_Map.m_pEditor = this;
 
 	m_CheckerTexture = Graphics()->LoadTexture("editor/checker.png", IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, 0);
@@ -4646,7 +4646,6 @@ void CEditor::UpdateAndRender()
 
 	// handle cursor movement
 	{
-		float mx, my, Mwx, Mwy, Mdx, Mdy;
 		float rx = 0.0f, ry = 0.0f;
 		int CursorType = Input()->CursorRelative(&rx, &ry);
 		UI()->ConvertCursorMove(&rx, &ry, CursorType);
@@ -4664,19 +4663,19 @@ void CEditor::UpdateAndRender()
 		s_MouseY = clamp(s_MouseY, 0.0f, (float)Graphics()->ScreenHeight());
 
 		// update the ui
-		mx = (s_MouseX/(float)Graphics()->ScreenWidth())*UI()->Screen()->w;
-		my = (s_MouseY/(float)Graphics()->ScreenHeight())*UI()->Screen()->h;
-		Mdx = (m_MouseDeltaX/(float)Graphics()->ScreenWidth())*UI()->Screen()->w;
-		Mdy = (m_MouseDeltaY/(float)Graphics()->ScreenHeight())*UI()->Screen()->h;
-		Mwx = 0;
-		Mwy = 0;
+		float mx = (s_MouseX/(float)Graphics()->ScreenWidth())*UI()->Screen()->w;
+		float my = (s_MouseY/(float)Graphics()->ScreenHeight())*UI()->Screen()->h;
+		float Mdx = (m_MouseDeltaX/(float)Graphics()->ScreenWidth())*UI()->Screen()->w;
+		float Mdy = (m_MouseDeltaY/(float)Graphics()->ScreenHeight())*UI()->Screen()->h;
+		float Mwx = 0;
+		float Mwy = 0;
 
 		// fix correct world x and y
-		CLayerGroup *g = GetSelectedGroup();
-		if(g)
+		CLayerGroup *pSelectedGroup = GetSelectedGroup();
+		if(pSelectedGroup)
 		{
 			float aPoints[4];
-			g->Mapping(aPoints);
+			pSelectedGroup->Mapping(aPoints);
 
 			float WorldWidth = aPoints[2]-aPoints[0];
 			float WorldHeight = aPoints[3]-aPoints[1];
@@ -4687,12 +4686,7 @@ void CEditor::UpdateAndRender()
 			m_MouseDeltaWy = Mdy*(WorldHeight / UI()->Screen()->h);
 		}
 
-		int Buttons = 0;
-		if(Input()->KeyIsPressed(KEY_MOUSE_1)) Buttons |= 1;
-		if(Input()->KeyIsPressed(KEY_MOUSE_2)) Buttons |= 2;
-		if(Input()->KeyIsPressed(KEY_MOUSE_3)) Buttons |= 4;
-
-		UI()->Update(mx,my,Mwx,Mwy,Buttons);
+		UI()->Update(mx, my, Mwx, Mwy);
 	}
 
 	// toggle gui


### PR DESCRIPTION
- Change CUI::DoButtonLogic to only use left mouse button.
  - I don't know why right mouse button was enabled for buttons, but it doesn't feel right and this would free up the right mouse button to be used for other things in the future, like contextual menus/infos.
- Represent all the Checked-Values using bool instead of int.
- Consolidate mouse button handling from Gameclient and Editor in CUI.
- Make CButtonContainer inherit CUIElementBase and move and simplify the ButtonFade handling.
- Consolidate button methods. Remove unused, mostly duplicated methods.
- Remove DoButton_SpriteClean, which was not using the button logic, and replace it with usage of the other methods.
  - Add highlighting to the buttons to make hover visible.
  - Fixes the problematic buttons named in #2716. Now all buttons are triggered by releasing the left mouse button, whereas before those buttons were triggered by pressing already.
- Add CUI::MouseHovered to check MouseInside and MouseInsideClip and use it everywhere in the client so items are not highlighted when hovering them outside of the clip area (closes #2716).