### PR TITLE
Fix a few prediction issues

### DIFF
--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -195,39 +195,15 @@ void CItems::RenderFlag(const CNetObj_Flag *pPrev, const CNetObj_Flag *pCurrent,
 			(pCurrent->m_Team == TEAM_BLUE && pPrevGameDataFlag->m_FlagCarrierBlue != pCurGameDataFlag->m_FlagCarrierBlue)))
 			Pos = vec2(pCurrent->m_X, pCurrent->m_Y);
 
-		// use predicted carrier position if possible
-		if(pCurrent->m_Team == TEAM_RED)
-		{
-			if(pCurGameDataFlag->m_FlagCarrierRed >= 0)
-			{
-				// `FlagCarrier >= 0` means that there is a character carrying the flag
-				if(m_pClient->ShouldUsePredicted() &&
-					m_pClient->ShouldUsePredictedChar(pCurGameDataFlag->m_FlagCarrierRed))
-				{
-					Pos = m_pClient->PredictedCharPos(pCurGameDataFlag->m_FlagCarrierRed);
-				}
-				else
-				{
-					Pos = m_pClient->UnpredictedCharPos(pCurGameDataFlag->m_FlagCarrierRed);
-				}
-			}
-		}
-		else if(pCurrent->m_Team == TEAM_BLUE)
-		{
-			if(pCurGameDataFlag->m_FlagCarrierBlue >= 0)
-			{
-				// `FlagCarrier >= 0` means that there is a character carrying the flag
-				if(m_pClient->ShouldUsePredicted() &&
-					m_pClient->ShouldUsePredictedChar(pCurGameDataFlag->m_FlagCarrierBlue))
-				{
-					Pos = m_pClient->PredictedCharPos(pCurGameDataFlag->m_FlagCarrierBlue);
-				}
-				else
-				{
-					Pos = m_pClient->UnpredictedCharPos(pCurGameDataFlag->m_FlagCarrierBlue);
-				}
-			}
-		}
+		int FlagCarrier = -1;
+		if(pCurrent->m_Team == TEAM_RED && pCurGameDataFlag->m_FlagCarrierRed >= 0)
+			FlagCarrier = pCurGameDataFlag->m_FlagCarrierRed;
+		else if(pCurrent->m_Team == TEAM_BLUE && pCurGameDataFlag->m_FlagCarrierBlue >= 0)
+			FlagCarrier = pCurGameDataFlag->m_FlagCarrierBlue;
+
+		// make sure to use predicted position
+		if(FlagCarrier >= 0 && FlagCarrier < MAX_CLIENTS && m_pClient->ShouldUsePredicted() && m_pClient->ShouldUsePredictedChar(FlagCarrier))
+			Pos = m_pClient->GetCharPos(FlagCarrier, true);
 	}
 
 	IGraphics::CQuadItem QuadItem(Pos.x, Pos.y-Size*0.75f, Size, Size*2);

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -13,66 +13,57 @@
 void CNamePlates::RenderNameplate(
 	const CNetObj_Character *pPrevChar,
 	const CNetObj_Character *pPlayerChar,
-	const CNetObj_PlayerInfo *pPlayerInfo,
 	int ClientID
-	)
+	) const
 {
-	vec2 Position;
-	if(m_pClient->ShouldUsePredicted() &&
-		m_pClient->ShouldUsePredictedChar(ClientID))
-	{
-		Position = m_pClient->PredictedCharPos(ClientID);
-	}
-	else
-	{
-		Position = m_pClient->UnpredictedCharPos(ClientID);
-	}
+	const CGameClient::CClientData *pClientData = &m_pClient->m_aClients[ClientID];
+
+	bool Predicted = m_pClient->ShouldUsePredicted() && m_pClient->ShouldUsePredictedChar(ClientID);
+	vec2 Position = m_pClient->GetCharPos(ClientID, Predicted);
 
 	float FontSize = 18.0f + 20.0f * Config()->m_ClNameplatesSize / 100.0f;
 	// render name plate
-	if(m_pClient->m_LocalClientID != ClientID)
+
+	float a = 1;
+	if(Config()->m_ClNameplatesAlways == 0)
+		a = clamp(1-powf(distance(m_pClient->m_pControls->m_TargetPos, Position)/200.0f,16.0f), 0.0f, 1.0f);
+
+
+	char aName[64];
+	str_format(aName, sizeof(aName), "%s", Config()->m_ClShowsocial ? pClientData->m_aName: "");
+
+	CTextCursor Cursor;
+	float tw = TextRender()->TextWidth(0, FontSize, aName, -1, -1.0f) + RenderTools()->GetClientIdRectSize(FontSize);
+	TextRender()->SetCursor(&Cursor, Position.x-tw/2.0f, Position.y-FontSize-38.0f, FontSize, TEXTFLAG_RENDER);
+
+	TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.5f*a);
+	TextRender()->TextColor(1.0f, 1.0f, 1.0f, a);
+	if(Config()->m_ClNameplatesTeamcolors && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS)
 	{
-		float a = 1;
-		if(Config()->m_ClNameplatesAlways == 0)
-			a = clamp(1-powf(distance(m_pClient->m_pControls->m_TargetPos, Position)/200.0f,16.0f), 0.0f, 1.0f);
-
-
-		char aName[64];
-		str_format(aName, sizeof(aName), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[ClientID].m_aName: "");
-
-		CTextCursor Cursor;
-		float tw = TextRender()->TextWidth(0, FontSize, aName, -1, -1.0f) + RenderTools()->GetClientIdRectSize(FontSize);
-		TextRender()->SetCursor(&Cursor, Position.x-tw/2.0f, Position.y-FontSize-38.0f, FontSize, TEXTFLAG_RENDER);
-
-		TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.5f*a);
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, a);
-		if(Config()->m_ClNameplatesTeamcolors && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS)
-		{
-			if(m_pClient->m_aClients[ClientID].m_Team == TEAM_RED)
-				TextRender()->TextColor(1.0f, 0.5f, 0.5f, a);
-			else if(m_pClient->m_aClients[ClientID].m_Team == TEAM_BLUE)
-				TextRender()->TextColor(0.7f, 0.7f, 1.0f, a);
-		}
-
-		const vec4 IdTextColor(0.1f, 0.1f, 0.1f, a);
-		vec4 BgIdColor(1.0f, 1.0f, 1.0f, a * 0.5f);
-		if(Config()->m_ClNameplatesTeamcolors && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS)
-		{
-			if(m_pClient->m_aClients[ClientID].m_Team == TEAM_RED)
-				BgIdColor = vec4(1.0f, 0.5f, 0.5f, a * 0.5f);
-			else if(m_pClient->m_aClients[ClientID].m_Team == TEAM_BLUE)
-				BgIdColor = vec4(0.7f, 0.7f, 1.0f, a * 0.5f);
-		}
-
-		if(a > 0.001f)
-		{
-			RenderTools()->DrawClientID(TextRender(), &Cursor, ClientID, BgIdColor, IdTextColor);
-			TextRender()->TextEx(&Cursor, aName, -1);
-		}
-
-		TextRender()->TextColor(CUI::ms_DefaultTextColor);
-		TextRender()->TextOutlineColor(CUI::ms_DefaultTextOutlineColor);
+		if(pClientData->m_Team == TEAM_RED)
+			TextRender()->TextColor(1.0f, 0.5f, 0.5f, a);
+		else if(pClientData->m_Team == TEAM_BLUE)
+			TextRender()->TextColor(0.7f, 0.7f, 1.0f, a);
 	}
+
+	const vec4 IdTextColor(0.1f, 0.1f, 0.1f, a);
+	vec4 BgIdColor(1.0f, 1.0f, 1.0f, a * 0.5f);
+	if(Config()->m_ClNameplatesTeamcolors && m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS)
+	{
+		if(pClientData->m_Team == TEAM_RED)
+			BgIdColor = vec4(1.0f, 0.5f, 0.5f, a * 0.5f);
+		else if(pClientData->m_Team == TEAM_BLUE)
+			BgIdColor = vec4(0.7f, 0.7f, 1.0f, a * 0.5f);
+	}
+
+	if(a > 0.001f)
+	{
+		RenderTools()->DrawClientID(TextRender(), &Cursor, ClientID, BgIdColor, IdTextColor);
+		TextRender()->TextEx(&Cursor, aName, -1);
+	}
+
+	TextRender()->TextColor(CUI::ms_DefaultTextColor);
+	TextRender()->TextOutlineColor(CUI::ms_DefaultTextOutlineColor);
 }
 
 void CNamePlates::OnRender()
@@ -83,17 +74,11 @@ void CNamePlates::OnRender()
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		// only render active characters
-		if(!m_pClient->m_Snap.m_aCharacters[i].m_Active)
-			continue;
-
-		const void *pInfo = Client()->SnapFindItem(IClient::SNAP_CURRENT, NETOBJTYPE_PLAYERINFO, i);
-
-		if(pInfo)
+		if(m_pClient->m_aClients[i].m_Active && m_pClient->m_Snap.m_aCharacters[i].m_Active && m_pClient->m_LocalClientID != i)
 		{
 			RenderNameplate(
 				&m_pClient->m_Snap.m_aCharacters[i].m_Prev,
 				&m_pClient->m_Snap.m_aCharacters[i].m_Cur,
-				(const CNetObj_PlayerInfo *)pInfo,
 				i);
 		}
 	}

--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -9,9 +9,8 @@ class CNamePlates : public CComponent
 	void RenderNameplate(
 		const CNetObj_Character *pPrevChar,
 		const CNetObj_Character *pPlayerChar,
-		const CNetObj_PlayerInfo *pPlayerInfo,
 		int ClientID
-	);
+	) const;
 
 public:
 	virtual void OnRender();

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -79,17 +79,17 @@ void CPlayers::RenderHook(
 		vec2 Pos = Position;
 		vec2 HookPos;
 
-		if(pPlayerChar->m_HookedPlayer != -1 && m_pClient->m_Snap.m_aCharacters[pPlayerChar->m_HookedPlayer].m_Active)
+		if(Player.m_HookedPlayer != -1 && m_pClient->m_Snap.m_aCharacters[Player.m_HookedPlayer].m_Active)
 		{
 			// `HookedPlayer != -1` means that a player is being hooked
 			if(m_pClient->ShouldUsePredicted() &&
-				m_pClient->ShouldUsePredictedChar(pPlayerChar->m_HookedPlayer))
+				m_pClient->ShouldUsePredictedChar(Player.m_HookedPlayer))
 			{
-				HookPos = m_pClient->PredictedCharPos(pPlayerChar->m_HookedPlayer);
+				HookPos = m_pClient->PredictedCharPos(Player.m_HookedPlayer);
 			}
 			else
 			{
-				HookPos = m_pClient->UnpredictedCharPos(pPlayerChar->m_HookedPlayer);
+				HookPos = m_pClient->UnpredictedCharPos(Player.m_HookedPlayer);
 			}
 		}
 		else

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -79,7 +79,7 @@ void CPlayers::RenderHook(
 		vec2 Pos = Position;
 		vec2 HookPos;
 
-		if(pPlayerChar->m_HookedPlayer != -1)
+		if(pPlayerChar->m_HookedPlayer != -1 && m_pClient->m_Snap.m_aCharacters[pPlayerChar->m_HookedPlayer].m_Active)
 		{
 			// `HookedPlayer != -1` means that a player is being hooked
 			if(m_pClient->ShouldUsePredicted() &&

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -40,34 +40,25 @@ inline float AngularApproach(float Src, float Dst, float Amount)
 void CPlayers::RenderHook(
 	const CNetObj_Character *pPrevChar,
 	const CNetObj_Character *pPlayerChar,
-	const CNetObj_PlayerInfo *pPrevInfo,
-	const CNetObj_PlayerInfo *pPlayerInfo,
+	const CTeeRenderInfo *pRenderInfo,
 	int ClientID
-	)
+	) const
 {
-	CNetObj_Character Prev;
-	CNetObj_Character Player;
-	Prev = *pPrevChar;
-	Player = *pPlayerChar;
-
-	CTeeRenderInfo RenderInfo = m_aRenderInfo[ClientID];
+	CNetObj_Character Prev = *pPrevChar;
+	CNetObj_Character Player = *pPlayerChar;
+	CTeeRenderInfo RenderInfo = *pRenderInfo;
 
 	float IntraTick = Client()->IntraGameTick();
 
 	// set size
 	RenderInfo.m_Size = 64.0f;
 
-	if(m_pClient->ShouldUsePredicted() &&
-		m_pClient->ShouldUsePredictedChar(ClientID))
+	if(m_pClient->ShouldUsePredicted() && m_pClient->ShouldUsePredictedChar(ClientID))
 	{
 		m_pClient->UsePredictedChar(&Prev, &Player, &IntraTick, ClientID);
 	}
 
-	vec2 Position = mix(
-		vec2(Prev.m_X, Prev.m_Y),
-		vec2(Player.m_X, Player.m_Y),
-		IntraTick
-	);
+	vec2 Position = mix(vec2(Prev.m_X, Prev.m_Y), vec2(Player.m_X, Player.m_Y), IntraTick);
 
 	// draw hook
 	if(Prev.m_HookState>0 && Player.m_HookState>0)
@@ -82,24 +73,13 @@ void CPlayers::RenderHook(
 		if(Player.m_HookedPlayer != -1 && m_pClient->m_Snap.m_aCharacters[Player.m_HookedPlayer].m_Active)
 		{
 			// `HookedPlayer != -1` means that a player is being hooked
-			if(m_pClient->ShouldUsePredicted() &&
-				m_pClient->ShouldUsePredictedChar(Player.m_HookedPlayer))
-			{
-				HookPos = m_pClient->PredictedCharPos(Player.m_HookedPlayer);
-			}
-			else
-			{
-				HookPos = m_pClient->UnpredictedCharPos(Player.m_HookedPlayer);
-			}
+			bool Predicted = m_pClient->ShouldUsePredicted() && m_pClient->ShouldUsePredictedChar(Player.m_HookedPlayer);
+			HookPos = m_pClient->GetCharPos(Player.m_HookedPlayer, Predicted);
 		}
 		else
 		{
-			// The hook is in the air or on a hookable tile
-			HookPos = mix(
-				vec2(Prev.m_HookX, Prev.m_HookY),
-				vec2(Player.m_HookX, Player.m_HookY),
-				IntraTick
-			);
+			// The hook is in the air, on a hookable tile or the hooked player is out of range
+			HookPos = mix(vec2(Prev.m_HookX, Prev.m_HookY), vec2(Player.m_HookX, Player.m_HookY), IntraTick);
 		}
 
 		float d = distance(Pos, HookPos);
@@ -133,18 +113,16 @@ void CPlayers::RenderHook(
 void CPlayers::RenderPlayer(
 	const CNetObj_Character *pPrevChar,
 	const CNetObj_Character *pPlayerChar,
-	const CNetObj_PlayerInfo *pPrevInfo,
 	const CNetObj_PlayerInfo *pPlayerInfo,
+	const CTeeRenderInfo *pRenderInfo,
 	int ClientID
-	)
+	) const
 {
-	CNetObj_Character Prev;
-	CNetObj_Character Player;
-	Prev = *pPrevChar;
-	Player = *pPlayerChar;
+	CNetObj_Character Prev = *pPrevChar;
+	CNetObj_Character Player = *pPlayerChar;
+	CTeeRenderInfo RenderInfo = *pRenderInfo;
 
-	CNetObj_PlayerInfo pInfo = *pPlayerInfo;
-	CTeeRenderInfo RenderInfo = m_aRenderInfo[ClientID];
+	const CGameClient::CClientData *pClientData = &m_pClient->m_aClients[ClientID];
 
 	// set size
 	RenderInfo.m_Size = 64.0f;
@@ -187,8 +165,7 @@ void CPlayers::RenderPlayer(
 		g_GameClient.m_aClients[info.cid].angle = angle;*/
 	}
 
-	if(m_pClient->ShouldUsePredicted() &&
-		m_pClient->ShouldUsePredictedChar(ClientID))
+	if(m_pClient->ShouldUsePredicted() && m_pClient->ShouldUsePredictedChar(ClientID))
 	{
 		m_pClient->UsePredictedChar(&Prev, &Player, &IntraTick, ClientID);
 	}
@@ -420,7 +397,7 @@ void CPlayers::RenderPlayer(
 
 	RenderTools()->RenderTee(&State, &RenderInfo, Player.m_Emote, Direction, Position);
 
-	if(pInfo.m_PlayerFlags&PLAYERFLAG_CHATTING)
+	if(pPlayerInfo->m_PlayerFlags&PLAYERFLAG_CHATTING)
 	{
 		Graphics()->TextureSet(g_pData->m_aImages[IMAGE_EMOTICONS].m_Id);
 		Graphics()->QuadsBegin();
@@ -430,13 +407,13 @@ void CPlayers::RenderPlayer(
 		Graphics()->QuadsEnd();
 	}
 
-	if (m_pClient->m_aClients[ClientID].m_EmoticonStart != -1 && m_pClient->m_aClients[ClientID].m_EmoticonStart + 2 * Client()->GameTickSpeed() > Client()->GameTick())
+	if(pClientData->m_EmoticonStart != -1 && pClientData->m_EmoticonStart + 2 * Client()->GameTickSpeed() > Client()->GameTick())
 	{
 		Graphics()->TextureSet(g_pData->m_aImages[IMAGE_EMOTICONS].m_Id);
 		Graphics()->QuadsBegin();
 
-		int SinceStart = Client()->GameTick() - m_pClient->m_aClients[ClientID].m_EmoticonStart;
-		int FromEnd = m_pClient->m_aClients[ClientID].m_EmoticonStart + 2 * Client()->GameTickSpeed() - Client()->GameTick();
+		int SinceStart = Client()->GameTick() - pClientData->m_EmoticonStart;
+		int FromEnd = pClientData->m_EmoticonStart + 2 * Client()->GameTickSpeed() - Client()->GameTick();
 
 		float a = 1;
 
@@ -457,7 +434,7 @@ void CPlayers::RenderPlayer(
 
 		Graphics()->SetColor(1.0f * a, 1.0f * a, 1.0f * a, a);
 		// client_datas::emoticon is an offset from the first emoticon
-		RenderTools()->SelectSprite(SPRITE_OOP + m_pClient->m_aClients[ClientID].m_Emoticon);
+		RenderTools()->SelectSprite(SPRITE_OOP + pClientData->m_Emoticon);
 		IGraphics::CQuadItem QuadItem(Position.x, Position.y - 23 - 32*h, 64, 64*h);
 		Graphics()->QuadsDraw(&QuadItem, 1);
 		Graphics()->QuadsEnd();
@@ -469,11 +446,19 @@ void CPlayers::OnRender()
 	if(Client()->State() < IClient::STATE_ONLINE)
 		return;
 
+	static const CNetObj_PlayerInfo *s_apInfo[MAX_CLIENTS];
+	static CTeeRenderInfo s_aRenderInfo[MAX_CLIENTS];
+
 	// update RenderInfo for ninja
 	bool IsTeamplay = (m_pClient->m_GameInfo.m_GameFlags&GAMEFLAG_TEAMS) != 0;
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
-		m_aRenderInfo[i] = m_pClient->m_aClients[i].m_RenderInfo;
+		if(!m_pClient->m_Snap.m_aCharacters[i].m_Active)
+			continue;
+
+		s_apInfo[i] = (const CNetObj_PlayerInfo *)Client()->SnapFindItem(IClient::SNAP_CURRENT, NETOBJTYPE_PLAYERINFO, i);
+		s_aRenderInfo[i] = m_pClient->m_aClients[i].m_RenderInfo;
+
 		if(m_pClient->m_Snap.m_aCharacters[i].m_Cur.m_Weapon == WEAPON_NINJA)
 		{
 			// change the skin for the player to the ninja
@@ -485,19 +470,19 @@ void CPlayers::OnRender()
 				{
 					if(IsTeamplay)
 					{
-						m_aRenderInfo[i].m_aTextures[p] = pNinja->m_apParts[p]->m_ColorTexture;
+						s_aRenderInfo[i].m_aTextures[p] = pNinja->m_apParts[p]->m_ColorTexture;
 						int ColorVal = m_pClient->m_pSkins->GetTeamColor(true, pNinja->m_aPartColors[p], m_pClient->m_aClients[i].m_Team, p);
-						m_aRenderInfo[i].m_aColors[p] = m_pClient->m_pSkins->GetColorV4(ColorVal, p==SKINPART_MARKING);
+						s_aRenderInfo[i].m_aColors[p] = m_pClient->m_pSkins->GetColorV4(ColorVal, p==SKINPART_MARKING);
 					}
 					else if(pNinja->m_aUseCustomColors[p])
 					{
-						m_aRenderInfo[i].m_aTextures[p] = pNinja->m_apParts[p]->m_ColorTexture;
-						m_aRenderInfo[i].m_aColors[p] = m_pClient->m_pSkins->GetColorV4(pNinja->m_aPartColors[p], p==SKINPART_MARKING);
+						s_aRenderInfo[i].m_aTextures[p] = pNinja->m_apParts[p]->m_ColorTexture;
+						s_aRenderInfo[i].m_aColors[p] = m_pClient->m_pSkins->GetColorV4(pNinja->m_aPartColors[p], p==SKINPART_MARKING);
 					}
 					else
 					{
-						m_aRenderInfo[i].m_aTextures[p] = pNinja->m_apParts[p]->m_OrgTexture;
-						m_aRenderInfo[i].m_aColors[p] = vec4(1.0f, 1.0f, 1.0f, 1.0f);
+						s_aRenderInfo[i].m_aTextures[p] = pNinja->m_apParts[p]->m_OrgTexture;
+						s_aRenderInfo[i].m_aColors[p] = vec4(1.0f, 1.0f, 1.0f, 1.0f);
 					}
 				}
 			}
@@ -510,38 +495,35 @@ void CPlayers::OnRender()
 		for(int i = 0; i < MAX_CLIENTS; i++)
 		{
 			// only render active characters
-			if(!m_pClient->m_Snap.m_aCharacters[i].m_Active)
+			if(!m_pClient->m_Snap.m_aCharacters[i].m_Active || !s_apInfo[i])
 				continue;
 
-			const void *pPrevInfo = Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_PLAYERINFO, i);
-			const void *pInfo = Client()->SnapFindItem(IClient::SNAP_CURRENT, NETOBJTYPE_PLAYERINFO, i);
+			//
+			bool Local = m_pClient->m_LocalClientID == i;
+			if((p % 2) == 0 && Local) continue;
+			if((p % 2) == 1 && !Local) continue;
 
-			if(pPrevInfo && pInfo)
+			CNetObj_Character *pPrevChar = &m_pClient->m_Snap.m_aCharacters[i].m_Prev;
+			CNetObj_Character *pCurChar = &m_pClient->m_Snap.m_aCharacters[i].m_Cur;
+
+			if(p<2)
 			{
-				//
-				bool Local = m_pClient->m_LocalClientID == i;
-				if((p % 2) == 0 && Local) continue;
-				if((p % 2) == 1 && !Local) continue;
-
-				CNetObj_Character PrevChar = m_pClient->m_Snap.m_aCharacters[i].m_Prev;
-				CNetObj_Character CurChar = m_pClient->m_Snap.m_aCharacters[i].m_Cur;
-
-				if(p<2)
-					RenderHook(
-							&PrevChar,
-							&CurChar,
-							(const CNetObj_PlayerInfo *)pPrevInfo,
-							(const CNetObj_PlayerInfo *)pInfo,
-							i
-						);
-				else
-					RenderPlayer(
-							&PrevChar,
-							&CurChar,
-							(const CNetObj_PlayerInfo *)pPrevInfo,
-							(const CNetObj_PlayerInfo *)pInfo,
-							i
-						);
+				RenderHook(
+						pPrevChar,
+						pCurChar,
+						&s_aRenderInfo[i],
+						i
+					);
+			}
+			else
+			{
+				RenderPlayer(
+						pPrevChar,
+						pCurChar,
+						s_apInfo[i],
+						&s_aRenderInfo[i],
+						i
+					);
 			}
 		}
 	}

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -6,21 +6,19 @@
 
 class CPlayers : public CComponent
 {
-	CTeeRenderInfo m_aRenderInfo[MAX_CLIENTS];
 	void RenderPlayer(
 		const CNetObj_Character *pPrevChar,
 		const CNetObj_Character *pPlayerChar,
-		const CNetObj_PlayerInfo *pPrevInfo,
 		const CNetObj_PlayerInfo *pPlayerInfo,
+		const CTeeRenderInfo *pRenderInfo,
 		int ClientID
-	);
+	) const;
 	void RenderHook(
 		const CNetObj_Character *pPrevChar,
 		const CNetObj_Character *pPlayerChar,
-		const CNetObj_PlayerInfo *pPrevInfo,
-		const CNetObj_PlayerInfo *pPlayerInfo,
+		const CTeeRenderInfo *pRenderInfo,
 		int ClientID
-	);
+	) const;
 
 public:
 	virtual void OnRender();

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -116,42 +116,25 @@ public:
 
 	vec2 m_LocalCharacterPos;
 
-	// predicted players
+	// Whether we should use/render predicted entities. Depends on client
+	// and game state.
+	bool ShouldUsePredicted() const;
 
-	CCharacterCore m_aPredictedPrevChars[MAX_CLIENTS];
-	CCharacterCore m_aPredictedChars[MAX_CLIENTS];
+	// Whether we should use/render predictions for a specific `ClientID`.
+	// Should check `ShouldUsePredicted` before checking this.
+	bool ShouldUsePredictedChar(int ClientID) const;
 
-	bool ShouldUsePredicted();
-		// Whether we should use/render predicted entities. Depends on client
-		// and game state.
-private:
-	bool ShouldUsePredictedLocalChar();
-		// Whether we should use/render the predicted local character. Depends
-		// on config and snap state. Should check `ShouldUsePredicted` before
-		// checking this.
-	bool ShouldUsePredictedNonLocalChars();
-		// Whether we should use/render predicted entities for non-local
-		// characters. Depends on config. Should check `ShouldUsePredicted`
-		// before checking this.
-public:
-	bool ShouldUsePredictedChar(int ClientID);
-		// Whether we should use/render predictions for a specific `ClientID`.
-		// Should check `ShouldUsePredicted` before checking this.
-
+	// Replaces `pPrevChar`, `pPlayerChar`, and `IntraTick` with their predicted
+	// counterparts for `ClientID`. Should check `ShouldUsePredictedChar`
+	// before using this.
 	void UsePredictedChar(
 		CNetObj_Character *pPrevChar,
 		CNetObj_Character *pPlayerChar,
 		float *IntraTick,
 		int ClientID
-	);
-		// Replaces `pPrevChar`, `pPlayerChar`, and `IntraTick` with their predicted
-		// counterparts for `ClientID`. Should check `ShouldUsePredictedChar`
-		// before using this.
+	) const;
 
-	vec2 PredictedCharPos(int ClientID);
-		// Return the interpolated, predicted position for `ClientID`
-	vec2 UnpredictedCharPos(int ClientID);
-		// Return the interpolated, unpredicted position for `ClientID`
+	vec2 GetCharPos(int ClientID, bool Predicted = false) const;
 
 	// ---
 
@@ -225,6 +208,7 @@ public:
 		int m_Emoticon;
 		int m_EmoticonStart;
 		CCharacterCore m_Predicted;
+		CCharacterCore m_PrevPredicted;
 
 		CTeeRenderInfo m_SkinInfo; // this is what the server reports
 		CTeeRenderInfo m_RenderInfo; // this is what we use

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -404,7 +404,7 @@ void CCharacterCore::Move()
 	m_Pos = NewPos;
 }
 
-void CCharacterCore::Write(CNetObj_CharacterCore *pObjCore)
+void CCharacterCore::Write(CNetObj_CharacterCore *pObjCore) const
 {
 	pObjCore->m_X = round_to_int(m_Pos.x);
 	pObjCore->m_Y = round_to_int(m_Pos.y);

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -179,7 +179,7 @@ public:
 	void ResetDragVelocity();
 
 	void Read(const CNetObj_CharacterCore *pObjCore);
-	void Write(CNetObj_CharacterCore *pObjCore);
+	void Write(CNetObj_CharacterCore *pObjCore) const;
 	void Quantize();
 };
 

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -6,7 +6,7 @@
 
 
 // client
-MACRO_CONFIG_INT(ClPredict, cl_predict, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Predict client movements")
+MACRO_CONFIG_INT(ClPredict, cl_predict, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Use prediction for objects in the game world")
 MACRO_CONFIG_INT(ClPredictPlayers, cl_predict_players, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Predict movements of other players")
 MACRO_CONFIG_INT(ClPredictProjectiles, cl_predict_projectiles, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Predict position of projectiles")
 MACRO_CONFIG_INT(ClNameplates, cl_nameplates, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show name plates")


### PR DESCRIPTION
This fixes two issues:

- #2650 is using the actual position of a player as the hook destination. If the character is not visible, this leads to hooks to random coordinates.
- The hook rendering code mixes predicted and unpredicted values. This causes the hook to not always be at the center of the hooked tee. According to the unpredicted `pPlayerChar->m_HookedPlayer` the hook is still flying, so it uses `Player.m_HookX` and `Player.m_HookY`. These values are predicted, so the hook might already be attached and pulling the other tee back, so it is not exactly at the center.

Some other changes:

- Reduced the number of snap-item queries in the player rendering code
- Made `cl_predict` a global switch to turn on/off the prediction