### PR TITLE
Fix hotkeys and scrolling being enabled when console is open

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -645,7 +645,7 @@ void CGameConsole::Toggle(int Type)
 		if (m_ConsoleState == CONSOLE_CLOSED || m_ConsoleState == CONSOLE_CLOSING)
 		{
 			Input()->MouseModeAbsolute();
-			UI()->UseMouseButtons(false);
+			UI()->SetEnabled(false);
 			m_ConsoleState = CONSOLE_OPENING;
 			// reset controls
 			m_pClient->m_pControls->OnReset();
@@ -653,7 +653,7 @@ void CGameConsole::Toggle(int Type)
 		else
 		{
 			Input()->MouseModeRelative();
-			UI()->UseMouseButtons(true);
+			UI()->SetEnabled(true);
 			m_pClient->OnRelease();
 			m_ConsoleState = CONSOLE_CLOSING;
 		}

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -355,7 +355,7 @@ void CMapLayers::OnRender()
 			// skip rendering if detail layers is not wanted
 			if(!(pLayer->m_Flags&LAYERFLAG_DETAIL && !Config()->m_GfxHighDetail && !IsGameLayer && (Client()->State() == IClient::STATE_ONLINE || Client()->State() == IClient::STATE_DEMOPLAYBACK)))
 			{
-				if(pLayer->m_Type == LAYERTYPE_TILES && Input()->KeyIsPressed(KEY_LCTRL) && Input()->KeyIsPressed(KEY_LSHIFT) && Input()->KeyPress(KEY_KP_0))
+				if(pLayer->m_Type == LAYERTYPE_TILES && Input()->KeyIsPressed(KEY_LCTRL) && Input()->KeyIsPressed(KEY_LSHIFT) && UI()->KeyPress(KEY_KP_0))
 				{
 					CMapItemLayerTilemap *pTMap = (CMapItemLayerTilemap *)pLayer;
 					CTile *pTiles = (CTile *)pLayers->Map()->GetData(pTMap->m_Data);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -397,7 +397,7 @@ bool CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned Str
 			UI()->ClearLastActiveItem();
 		}
 
-		if(UI()->LastActiveItem() == pID && !m_pClient->m_pGameConsole->IsConsoleActive())
+		if(UI()->LastActiveItem() == pID && UI()->Enabled())
 		{
 			for(int i = 0; i < Input()->NumEvents(); i++)
 			{
@@ -2098,7 +2098,7 @@ bool CMenus::OnInput(IInput::CEvent e)
 			// special for popups
 			if(e.m_Key == KEY_RETURN || e.m_Key == KEY_KP_ENTER)
 				m_EnterPressed = true;
-			else if(e.m_Key == KEY_TAB && !Input()->KeyPress(KEY_LALT) && !Input()->KeyPress(KEY_RALT))
+			else if(e.m_Key == KEY_TAB && !Input()->KeyIsPressed(KEY_LALT) && !Input()->KeyIsPressed(KEY_RALT))
 				m_TabPressed = true;
 			else if(e.m_Key == KEY_DELETE)
 				m_DeletePressed = true;
@@ -2251,9 +2251,11 @@ void CMenus::OnRender()
 
 bool CMenus::CheckHotKey(int Key) const
 {
-	return !m_KeyReaderIsActive && !m_KeyReaderWasActive && !m_PrevCursorActive && !m_PopupActive &&
-		!Input()->KeyIsPressed(KEY_LSHIFT) && !Input()->KeyIsPressed(KEY_RSHIFT) && !Input()->KeyIsPressed(KEY_LCTRL) && !Input()->KeyIsPressed(KEY_RCTRL) && !Input()->KeyIsPressed(KEY_LALT) && // no modifier
-		Input()->KeyIsPressed(Key) && !m_pClient->m_pGameConsole->IsConsoleActive();
+	return !m_KeyReaderIsActive && !m_KeyReaderWasActive && !m_PrevCursorActive && !m_PopupActive
+		&& !Input()->KeyIsPressed(KEY_LSHIFT) && !Input()->KeyIsPressed(KEY_RSHIFT)
+		&& !Input()->KeyIsPressed(KEY_LCTRL) && !Input()->KeyIsPressed(KEY_RCTRL)
+		&& !Input()->KeyIsPressed(KEY_LALT)
+		&& UI()->KeyIsPressed(Key);
 }
 
 bool CMenus::IsBackgroundNeeded() const

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -2245,7 +2245,7 @@ void CMenus::RenderServerbrowserBottomBox(CUIRect MainView)
 	MainView.HSplitTop(25.0f, &MainView, 0);
 	MainView.VSplitLeft(ButtonWidth, &Button, &MainView);
 	static CButtonContainer s_RefreshButton;
-	if(DoButton_Menu(&s_RefreshButton, Localize("Refresh"), 0, &Button) || (Input()->KeyPress(KEY_R) && (Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL))))
+	if(DoButton_Menu(&s_RefreshButton, Localize("Refresh"), 0, &Button) || (UI()->KeyPress(KEY_R) && (Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL))))
 	{
 		if(m_MenuPage == PAGE_INTERNET)
 			ServerBrowser()->Refresh(IServerBrowser::REFRESHFLAG_INTERNET);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -53,7 +53,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 
 	CUIRect SeekBar, ButtonBar, NameBar;
 
-	const bool CtrlDown = Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL);
+	const bool CtrlDown = UI()->KeyIsPressed(KEY_LCTRL) || UI()->KeyIsPressed(KEY_RCTRL);
 	static bool s_LastCtrlDown = CtrlDown;
 
 	int CurrentTick = pInfo->m_CurrentTick - pInfo->m_FirstTick;
@@ -167,11 +167,11 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		PositionToSeek = 0.0f;
 	}
 
-	bool IncreaseDemoSpeed = Input()->KeyPress(KEY_MOUSE_WHEEL_UP) || Input()->KeyPress(KEY_PLUS) || Input()->KeyPress(KEY_KP_PLUS);
-	bool DecreaseDemoSpeed = Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN) || Input()->KeyPress(KEY_MINUS) || Input()->KeyPress(KEY_KP_MINUS);
+	bool IncreaseDemoSpeed = UI()->KeyPress(KEY_MOUSE_WHEEL_UP) || UI()->KeyPress(KEY_PLUS) || UI()->KeyPress(KEY_KP_PLUS);
+	bool DecreaseDemoSpeed = UI()->KeyPress(KEY_MOUSE_WHEEL_DOWN) || UI()->KeyPress(KEY_MINUS) || UI()->KeyPress(KEY_KP_MINUS);
 
 	// add spacebar for toggling Play/Pause
-	if(Input()->KeyPress(KEY_SPACE))
+	if(UI()->KeyPress(KEY_SPACE))
 	{
 		if(!pInfo->m_Paused)
 			DemoPlayer()->Pause();
@@ -181,8 +181,8 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 
 	// skip forward/backward using left/right arrow keys
 	const bool ShiftDown = Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT);
-	const bool SkipBackwards = Input()->KeyPress(KEY_LEFT);
-	const bool SkipForwards = Input()->KeyPress(KEY_RIGHT);
+	const bool SkipBackwards = UI()->KeyPress(KEY_LEFT);
+	const bool SkipForwards = UI()->KeyPress(KEY_RIGHT);
 	if(SkipBackwards || SkipForwards)
 	{
 		int DesiredTick = 0;
@@ -655,7 +655,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 
 	BottomView.VSplitLeft(ButtonWidth, &Button, &BottomView);
 	static CButtonContainer s_RefreshButton;
-	if(DoButton_Menu(&s_RefreshButton, Localize("Refresh"), 0, &Button) || (Input()->KeyPress(KEY_R) && (Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL))))
+	if(DoButton_Menu(&s_RefreshButton, Localize("Refresh"), 0, &Button) || (UI()->KeyPress(KEY_R) && (Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL))))
 	{
 		DemolistPopulate();
 		DemolistOnUpdate(false);

--- a/src/game/client/components/menus_popups.cpp
+++ b/src/game/client/components/menus_popups.cpp
@@ -83,7 +83,7 @@ void CMenus::DoPopupMenu()
 		if(s_Popups.m_pfnFunc(this, r))
 			m_PopupActive = false;
 
-		if(Input()->KeyPress(KEY_ESCAPE))
+		if(UI()->KeyPress(KEY_ESCAPE))
 			m_PopupActive = false;
 	}
 }

--- a/src/game/client/components/menus_scrollregion.cpp
+++ b/src/game/client/components/menus_scrollregion.cpp
@@ -76,13 +76,13 @@ void CMenus::CScrollRegion::End()
 	if(m_pUI->MouseHovered(&RegionRect))
 	{
 		const float ScrollUnit = IsPageScroll ? m_ClipRect.h : m_Params.m_ScrollUnit;
-		if(m_pInput->KeyPress(KEY_MOUSE_WHEEL_UP))
+		if(m_pUI->KeyPress(KEY_MOUSE_WHEEL_UP))
 		{
 			m_AnimTime = AnimationDuration;
 			m_AnimInitScrollY = m_ScrollY;
 			m_AnimTargetScrollY -= ScrollUnit;
 		}
-		else if(m_pInput->KeyPress(KEY_MOUSE_WHEEL_DOWN))
+		else if(m_pUI->KeyPress(KEY_MOUSE_WHEEL_DOWN))
 		{
 			m_AnimTime = AnimationDuration;
 			m_AnimInitScrollY = m_ScrollY;

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -32,7 +32,7 @@ CUI::CUI()
 	m_MouseWorldY = 0;
 	m_MouseButtons = 0;
 	m_LastMouseButtons = 0;
-	m_UseMouseButtons = true;
+	m_Enabled = true;
 
 	m_Screen.x = 0;
 	m_Screen.y = 0;
@@ -43,7 +43,7 @@ CUI::CUI()
 void CUI::Update(float MouseX, float MouseY, float MouseWorldX, float MouseWorldY)
 {
 	unsigned MouseButtons = 0;
-	if(m_UseMouseButtons)
+	if(Enabled())
 	{
 		if(Input()->KeyIsPressed(KEY_MOUSE_1)) MouseButtons |= 1;
 		if(Input()->KeyIsPressed(KEY_MOUSE_2)) MouseButtons |= 2;
@@ -60,6 +60,16 @@ void CUI::Update(float MouseX, float MouseY, float MouseWorldX, float MouseWorld
 	if(m_pActiveItem)
 		m_pHotItem = m_pActiveItem;
 	m_pBecommingHotItem = 0;
+}
+
+bool CUI::KeyPress(int Key) const
+{
+	return Enabled() && Input()->KeyPress(Key);
+}
+
+bool CUI::KeyIsPressed(int Key) const
+{
+	return Enabled() && Input()->KeyIsPressed(Key);
 }
 
 void CUI::ConvertCursorMove(float *pX, float *pY, int CursorType) const

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -29,16 +29,18 @@ class CUI
 		MAX_CLIP_NESTING_DEPTH = 16
 	};
 
+	bool m_Enabled;
+
 	const void *m_pHotItem;
 	const void *m_pActiveItem;
 	const void *m_pLastActiveItem;
 	const void *m_pBecommingHotItem;
 	bool m_ActiveItemValid;
+
 	float m_MouseX, m_MouseY; // in gui space
 	float m_MouseWorldX, m_MouseWorldY; // in world space
 	unsigned m_MouseButtons;
 	unsigned m_LastMouseButtons;
-	bool m_UseMouseButtons;
 
 	CUIRect m_Screen;
 
@@ -99,6 +101,8 @@ public:
 		ALIGN_RIGHT,
 	};
 
+	void SetEnabled(bool Enabled) { m_Enabled = Enabled; }
+	bool Enabled() const { return m_Enabled; }
 	void Update(float MouseX, float MouseY, float MouseWorldX, float MouseWorldY);
 
 	float MouseX() const { return m_MouseX; }
@@ -107,7 +111,6 @@ public:
 	float MouseWorldY() const { return m_MouseWorldY; }
 	bool MouseButton(int Index) const { return (m_MouseButtons>>Index)&1; }
 	bool MouseButtonClicked(int Index) const { return MouseButton(Index) && !((m_LastMouseButtons>>Index)&1) ; }
-	void UseMouseButtons(bool UseMouseButtons) { m_UseMouseButtons = UseMouseButtons; }
 
 	void SetHotItem(const void *pID) { m_pBecommingHotItem = pID; }
 	void SetActiveItem(const void *pID) { m_ActiveItemValid = true; m_pActiveItem = pID; if (pID) m_pLastActiveItem = pID; }
@@ -125,6 +128,9 @@ public:
 	bool MouseInsideClip() const { return !IsClipped() || MouseInside(ClipArea()); };
 	bool MouseHovered(const CUIRect *pRect) const { return MouseInside(pRect) && MouseInsideClip(); };
 	void ConvertCursorMove(float *pX, float *pY, int CursorType) const;
+
+	bool KeyPress(int Key) const;
+	bool KeyIsPressed(int Key) const;
 
 	const CUIRect *Screen();
 	float PixelSize();


### PR DESCRIPTION
Generalize the mouse-enabled state to full UI-enabled state and add proxy methods KeyPress and KeyIsPressed to check the enabled state, to avoid scrolling and other menu hotkeys being active while the local/remote console is open.