### PR TITLE
Fix localization string search

### DIFF
--- a/src/game/client/localization.cpp
+++ b/src/game/client/localization.cpp
@@ -126,7 +126,7 @@ const char *CLocalizationDatabase::FindString(unsigned Hash, unsigned ContextHas
 {
 	CString String;
 	String.m_Hash = Hash;
-	String.m_ContextHash = 0; // this is ignored for the search anyway
+	String.m_ContextHash = ContextHash;
 	sorted_array<CString>::range r = ::find_binary(m_Strings.all(), String);
 	if(r.empty())
 		return 0;

--- a/src/game/client/localization.h
+++ b/src/game/client/localization.h
@@ -17,8 +17,8 @@ class CLocalizationDatabase
 		string m_Replacement;
 
 		bool operator <(const CString &Other) const { return m_Hash < Other.m_Hash || (m_Hash == Other.m_Hash && m_ContextHash < Other.m_ContextHash); }
-		bool operator <=(const CString &Other) const { return m_Hash <= Other.m_Hash; }
-		bool operator ==(const CString &Other) const { return m_Hash == Other.m_Hash; }
+		bool operator <=(const CString &Other) const { return m_Hash < Other.m_Hash || (m_Hash == Other.m_Hash && m_ContextHash <= Other.m_ContextHash); }
+		bool operator ==(const CString &Other) const { return m_Hash == Other.m_Hash && m_ContextHash == Other.m_ContextHash; }
 	};
 
 	sorted_array<CString> m_Strings;


### PR DESCRIPTION
Translation string search was haphazard when using context. (depends on which one of the same hashes is hit by the binary search)
Changed CString operator to represent a proper dual key sorted_array and include context hash when searching.