### PR TITLE
Fix demo player freezing on seeking and other minor issues

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -75,15 +75,18 @@ void CChat::OnReset()
 	m_CurrentLineWidth = -1.0f;
 
 	// init chat commands (must be in alphabetical order)
-	m_CommandManager.ClearCommands();
-	m_CommandManager.AddCommand("all", "Switch to all chat", "?r[message]", &Com_All, this);
-	m_CommandManager.AddCommand("friend", "Add player as friend", "s[name]", &Com_Befriend, this);
-	m_CommandManager.AddCommand("m", "Mute a player", "s[name]", &Com_Mute, this);
-	m_CommandManager.AddCommand("mute", "Mute a player", "s[name]", &Com_Mute, this);
-	m_CommandManager.AddCommand("r", "Reply to a whisper", "?r[message]", &Com_Reply, this);
-	m_CommandManager.AddCommand("team", "Switch to team chat", "?r[message]", &Com_Team, this);
-	m_CommandManager.AddCommand("w", "Whisper another player", "r[name]", &Com_Whisper, this);
-	m_CommandManager.AddCommand("whisper", "Whisper another player", "r[name]", &Com_Whisper, this);
+	if(Client()->State() < IClient::STATE_ONLINE)
+	{
+		m_CommandManager.ClearCommands();
+		m_CommandManager.AddCommand("all", "Switch to all chat", "?r[message]", &Com_All, this);
+		m_CommandManager.AddCommand("friend", "Add player as friend", "s[name]", &Com_Befriend, this);
+		m_CommandManager.AddCommand("m", "Mute a player", "s[name]", &Com_Mute, this);
+		m_CommandManager.AddCommand("mute", "Mute a player", "s[name]", &Com_Mute, this);
+		m_CommandManager.AddCommand("r", "Reply to a whisper", "?r[message]", &Com_Reply, this);
+		m_CommandManager.AddCommand("team", "Switch to team chat", "?r[message]", &Com_Team, this);
+		m_CommandManager.AddCommand("w", "Whisper another player", "r[name]", &Com_Whisper, this);
+		m_CommandManager.AddCommand("whisper", "Whisper another player", "r[name]", &Com_Whisper, this);
+	}
 }
 
 void CChat::OnMapLoad()

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -162,7 +162,6 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	// rewind when reaching the end
 	if(CurrentTick == TotalTicks)
 	{
-		m_pClient->OnReset();
 		DemoPlayer()->Pause();
 		PositionToSeek = 0.0f;
 	}
@@ -276,7 +275,6 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		static CButtonContainer s_ResetButton;
 		if(DoButton_SpriteID(&s_ResetButton, IMAGE_DEMOBUTTONS, SPRITE_DEMOBUTTON_STOP, false, &Button, CUI::CORNER_ALL))
 		{
-			m_pClient->OnReset();
 			DemoPlayer()->Pause();
 			PositionToSeek = 0.0f;
 		}

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -147,19 +147,21 @@ void CSounds::ClearQueue()
 
 void CSounds::Enqueue(int Channel, int SetId)
 {
-	// add sound to the queue
-	if(m_QueuePos < QUEUE_SIZE)
-	{
-		if(Channel == CHN_MUSIC || !Config()->m_ClEditor)
-		{
-			m_aQueue[m_QueuePos].m_Channel = Channel;
-			m_aQueue[m_QueuePos++].m_SetId = SetId;
-		}
-	}
+	if(m_pClient->m_SuppressEvents)
+		return;
+	if(m_QueuePos >= QUEUE_SIZE)
+		return;
+	if(Channel != CHN_MUSIC && Config()->m_ClEditor)
+		return;
+
+	m_aQueue[m_QueuePos].m_Channel = Channel;
+	m_aQueue[m_QueuePos++].m_SetId = SetId;
 }
 
 void CSounds::Play(int Chn, int SetId, float Vol)
 {
+	if(m_pClient->m_SuppressEvents)
+		return;
 	if(Chn == CHN_MUSIC && !Config()->m_SndMusic)
 		return;
 
@@ -176,9 +178,11 @@ void CSounds::Play(int Chn, int SetId, float Vol)
 
 void CSounds::PlayAt(int Chn, int SetId, float Vol, vec2 Pos)
 {
+	if(m_pClient->m_SuppressEvents)
+		return;
 	if(Chn == CHN_MUSIC && !Config()->m_SndMusic)
 		return;
-	
+
 	ISound::CSampleHandle SampleId = GetSampleId(SetId);
 	if(!SampleId.IsValid())
 		return;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -471,28 +471,34 @@ void CGameClient::OnConnected()
 
 void CGameClient::OnReset()
 {
-	// clear out the invalid pointers
-	m_LastNewPredictedTick = -1;
-	mem_zero(&m_Snap, sizeof(m_Snap));
+	if(Client()->State() < IClient::STATE_ONLINE)
+	{
+		// clear out the invalid pointers
+		m_LastNewPredictedTick = -1;
+		mem_zero(&m_Snap, sizeof(m_Snap));
 
-	for(int i = 0; i < MAX_CLIENTS; i++)
-		m_aClients[i].Reset(this, i);
+		for(int ClientID = 0; ClientID < MAX_CLIENTS; ClientID++)
+			m_aClients[ClientID].Reset(this, ClientID);
+	}
 
 	for(int i = 0; i < m_All.m_Num; i++)
 		m_All.m_paComponents[i]->OnReset();
 
-	m_LocalClientID = -1;
-	m_TeamCooldownTick = 0;
-	m_TeamChangeTime = 0.0f;
-	m_LastSkinChangeTime = Client()->LocalTime();
-	mem_zero(&m_GameInfo, sizeof(m_GameInfo));
-	m_DemoSpecMode = SPEC_FREEVIEW;
-	m_DemoSpecID = -1;
-	m_Tuning = CTuningParams();
-	m_MuteServerBroadcast = false;
-	m_LastGameStartTick = -1;
-	m_LastFlagCarrierRed = FLAG_MISSING;
-	m_LastFlagCarrierBlue = FLAG_MISSING;
+	if(Client()->State() < IClient::STATE_ONLINE)
+	{
+		m_LocalClientID = -1;
+		m_TeamCooldownTick = 0;
+		m_TeamChangeTime = 0.0f;
+		m_LastSkinChangeTime = Client()->LocalTime();
+		mem_zero(&m_GameInfo, sizeof(m_GameInfo));
+		m_DemoSpecMode = SPEC_FREEVIEW;
+		m_DemoSpecID = -1;
+		m_Tuning = CTuningParams();
+		m_MuteServerBroadcast = false;
+		m_LastGameStartTick = -1;
+		m_LastFlagCarrierRed = FLAG_MISSING;
+		m_LastFlagCarrierBlue = FLAG_MISSING;
+	}
 }
 
 void CGameClient::UpdatePositions()
@@ -698,13 +704,9 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 			switch(GameMsgID)
 			{
 			case GAMEMSG_CTF_DROP:
-				if(m_SuppressEvents)
-					return;
 				m_pSounds->Enqueue(CSounds::CHN_GLOBAL, SOUND_CTF_DROP);
 				break;
 			case GAMEMSG_CTF_RETURN:
-				if(m_SuppressEvents)
-					return;
 				m_pSounds->Enqueue(CSounds::CHN_GLOBAL, SOUND_CTF_RETURN);
 				break;
 			case GAMEMSG_TEAM_ALL:
@@ -732,8 +734,6 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 				}
 				break;
 			case GAMEMSG_CTF_GRAB:
-				if(m_SuppressEvents)
-					return;
 				if(m_LocalClientID != -1 && (m_aClients[m_LocalClientID].m_Team != aParaI[0] || (m_Snap.m_SpecInfo.m_Active &&
 								((m_Snap.m_SpecInfo.m_SpectatorID != -1 && m_aClients[m_Snap.m_SpecInfo.m_SpectatorID].m_Team != aParaI[0]) ||
 								(m_Snap.m_SpecInfo.m_SpecMode == SPEC_FLAGRED && aParaI[0] != TEAM_RED) ||


### PR DESCRIPTION
- Only reset game client properties when going offline, fixing client freezes when seeking (closes #2737).
- Only reset chat command manager when going offline.
- Remove two redundant calls to OnReset in demo player, as seeking will also call OnReset.
- Make sure _all_ sounds are suppressed while seeking (m_SuppressEvents).