### PR TITLE
Various Improvements of Demo Browser

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -233,17 +233,17 @@ bool CMenus::DoButton_MenuTabTop(CButtonContainer *pBC, const char *pText, bool 
 	return UI()->DoButtonLogic(pBC->GetID(), pRect);
 }
 
-bool CMenus::DoButton_GridHeader(const void *pID, const char *pText, bool Checked, CUI::EAlignment Align, const CUIRect *pRect)
+bool CMenus::DoButton_GridHeader(const void *pID, const char *pText, bool Checked, CUI::EAlignment Align, const CUIRect *pRect, int Corners)
 {
 	if(Checked)
 	{
-		RenderTools()->DrawUIRect(pRect, vec4(0.9f, 0.9f, 0.9f, 0.5f), CUI::CORNER_ALL, 5.0f);
+		RenderTools()->DrawUIRect(pRect, vec4(0.9f, 0.9f, 0.9f, 0.5f), Corners, 5.0f);
 		TextRender()->TextColor(CUI::ms_HighlightTextColor);
 		TextRender()->TextOutlineColor(CUI::ms_HighlightTextOutlineColor);
 	}
 	else if(UI()->HotItem() == pID)
 	{
-		RenderTools()->DrawUIRect(pRect, vec4(1.0f, 1.0f, 1.0f, 0.5f), CUI::CORNER_ALL, 5.0f);
+		RenderTools()->DrawUIRect(pRect, vec4(1.0f, 1.0f, 1.0f, 0.5f), Corners, 5.0f);
 	}
 
 	CUIRect Label;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -119,7 +119,7 @@ private:
 	bool DoButton_CheckBox(const void *pID, const char *pText, bool Checked, const CUIRect *pRect, bool Locked = false);
 
 	void DoIcon(int ImageId, int SpriteId, const CUIRect *pRect, const vec4 *pColor = 0);
-	bool DoButton_GridHeader(const void *pID, const char *pText, bool Checked, CUI::EAlignment Align, const CUIRect *pRect);
+	bool DoButton_GridHeader(const void *pID, const char *pText, bool Checked, CUI::EAlignment Align, const CUIRect *pRect, int Corners = CUI::CORNER_ALL);
 
 	bool DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden = false, int Corners = CUI::CORNER_ALL);
 	void DoEditBoxOption(void *pID, char *pOption, int OptionLength, const CUIRect *pRect, const char *pStr, float VSplitVal, float *pOffset, bool Hidden = false);
@@ -267,6 +267,7 @@ private:
 		CListBox();
 
 		void DoHeader(const CUIRect *pRect, const char *pTitle, float HeaderHeight = 20.0f, float Spacing = 2.0f);
+		void DoSubHeader(float HeaderHeight = 20.0f, float Spacing = 2.0f);
 		bool DoFilter(float FilterHeight = 20.0f, float Spacing = 2.0f);
 		void DoFooter(const char *pBottomText, float FooterHeight = 20.0f); // call before DoStart to create a footer
 		void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex,
@@ -275,6 +276,7 @@ private:
 		int DoEnd();
 		bool FilterMatches(const char *pNeedle) const;
 		bool WasItemActivated() const { return m_ListBoxItemActivated; };
+		float GetScrollBarWidth() const { return m_ScrollRegion.IsScrollbarShown() ? 20 : 0; } // defined in menus_scrollregion.cpp
 	};
 
 
@@ -689,8 +691,7 @@ private:
 		COL_BROWSER_PING,
 		NUM_BROWSER_COLS,
 
-		COL_DEMO_ICON=0,
-		COL_DEMO_NAME,
+		COL_DEMO_NAME = 0,
 		COL_DEMO_LENGTH,
 		COL_DEMO_DATE,
 		NUM_DEMO_COLS,

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -568,29 +568,23 @@ void CMenus::RenderDemoList(CUIRect MainView)
 					Button.x += FileIcon.w + 10.0f;
 					UI()->DoLabel(&Button, DemoItem.m_aName, Item.m_Rect.h*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
 				}
-				else if(ID == COL_DEMO_LENGTH && !r.front().m_IsDir && r.front().m_InfosLoaded)
+				else if(ID == COL_DEMO_LENGTH && !DemoItem.m_IsDir && DemoItem.m_InfosLoaded && DemoItem.m_Valid)
 				{
-					if (DemoItem.m_Valid)
-					{
-						int Length = DemoItem.Length();
-						char aLength[32];
-						str_format(aLength, sizeof(aLength), "%d:%02d", Length/60, Length%60);
-						Button.VMargin(4.0f, &Button);
-						if(!Item.m_Selected)
-							TextRender()->TextColor(CUI::ms_TransparentTextColor);
-						UI()->DoLabel(&Button, aLength, Item.m_Rect.h*ms_FontmodHeight*0.8f, CUI::ALIGN_RIGHT);
-					}
+					int Length = DemoItem.Length();
+					char aLength[32];
+					str_format(aLength, sizeof(aLength), "%d:%02d", Length/60, Length%60);
+					Button.VMargin(4.0f, &Button);
+					if(!Item.m_Selected)
+						TextRender()->TextColor(CUI::ms_TransparentTextColor);
+					UI()->DoLabel(&Button, aLength, Item.m_Rect.h*ms_FontmodHeight*0.8f, CUI::ALIGN_RIGHT);
 				}
-				else if(ID == COL_DEMO_DATE)
+				else if(ID == COL_DEMO_DATE && !DemoItem.m_IsDir)
 				{
-					if(!DemoItem.m_IsDir)
-					{
-						char aDate[64];
-						str_timestamp_ex(DemoItem.m_Date, aDate, sizeof(aDate), FORMAT_SPACE);
-						if(!Item.m_Selected)
-							TextRender()->TextColor(CUI::ms_TransparentTextColor);
-						UI()->DoLabel(&Button, aDate, Item.m_Rect.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
-					}
+					char aDate[64];
+					str_timestamp_ex(DemoItem.m_Date, aDate, sizeof(aDate), FORMAT_SPACE);
+					if(!Item.m_Selected)
+						TextRender()->TextColor(CUI::ms_TransparentTextColor);
+					UI()->DoLabel(&Button, aDate, Item.m_Rect.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 				}
 				TextRender()->TextColor(CUI::ms_DefaultTextColor);
 				if(Item.m_Selected)

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -21,10 +21,9 @@
 #include "menus.h"
 
 CMenus::CColumn CMenus::ms_aDemoCols[] = {
-	{COL_DEMO_ICON,		-1, " ", -1, 0, 0, {0}, {0}, CUI::ALIGN_CENTER},
 	{COL_DEMO_NAME,		CMenus::SORT_DEMONAME, Localize("Name"), 0, 100.0f, 0, {0}, {0}, CUI::ALIGN_CENTER},
-	{COL_DEMO_LENGTH,	CMenus::SORT_LENGTH, Localize("Length"), 1, 100.0f, 0, {0}, {0}, CUI::ALIGN_CENTER},
-	{COL_DEMO_DATE,		CMenus::SORT_DATE, Localize("Date"), 1, 160.0f, 0, {0}, {0}, CUI::ALIGN_CENTER},
+	{COL_DEMO_LENGTH,	CMenus::SORT_LENGTH, Localize("Length"), 1, 80.0f, 0, {0}, {0}, CUI::ALIGN_CENTER},
+	{COL_DEMO_DATE,		CMenus::SORT_DATE, Localize("Date"), 1, 170.0f, 0, {0}, {0}, CUI::ALIGN_CENTER},
 };
 
 void CMenus::RenderDemoPlayer(CUIRect MainView)
@@ -455,10 +454,14 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	CUIRect ListBox, Button, FileIcon;
 	MainView.HSplitTop(MainView.h - BackgroundHeight - 2 * HMargin, &ListBox, &MainView);
 
-	// demo list
+	// demo list header
+	static CListBox s_ListBox;
+	s_ListBox.DoHeader(&ListBox, Localize("Recorded"), GetListHeaderHeight());
 
+	// demo list column headers
 	CUIRect Headers;
-	ListBox.HSplitTop(GetListHeaderHeight(), &Headers, &ListBox);
+	ListBox.HMargin(GetListHeaderHeight() + 2.0f, &Headers);
+	Headers.h = GetListHeaderHeight();
 
 	RenderTools()->DrawUIRect(&Headers, vec4(0.0f,0,0,0.15f), 0, 0);
 
@@ -491,15 +494,14 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	{
 		if(ms_aDemoCols[i].m_Direction == 0)
 			ms_aDemoCols[i].m_Rect = Headers;
+		if(i == NumCols - 1)
+			ms_aDemoCols[i].m_Rect.w -= s_ListBox.GetScrollBarWidth();
 	}
 
 	// do headers
 	for(int i = 0; i < NumCols; i++)
 	{
-		if(i == COL_DEMO_ICON)
-			continue;
-
-		if(DoButton_GridHeader(ms_aDemoCols[i].m_Caption, ms_aDemoCols[i].m_Caption, Config()->m_BrDemoSort == ms_aDemoCols[i].m_Sort, ms_aDemoCols[i].m_Align, &ms_aDemoCols[i].m_Rect))
+		if(DoButton_GridHeader(ms_aDemoCols[i].m_Caption, ms_aDemoCols[i].m_Caption, Config()->m_BrDemoSort == ms_aDemoCols[i].m_Sort, ms_aDemoCols[i].m_Align, &ms_aDemoCols[i].m_Rect, CUI::CORNER_T))
 		{
 			if(ms_aDemoCols[i].m_Sort != -1)
 			{
@@ -518,8 +520,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		}
 	}
 
-	static CListBox s_ListBox;
-	s_ListBox.DoHeader(&ListBox, Localize("Recorded"), GetListHeaderHeight());
+	s_ListBox.DoSubHeader(GetListHeaderHeight(), 0.0f);
 
 	s_ListBox.DoStart(20.0f, m_lDemos.size(), 1, 3, m_DemolistSelectedIndex);
 	for(sorted_array<CDemoItem>::range r = m_lDemos.all(); !r.empty(); r.pop_front())
@@ -569,13 +570,16 @@ void CMenus::RenderDemoList(CUIRect MainView)
 				}
 				else if(ID == COL_DEMO_LENGTH && !r.front().m_IsDir && r.front().m_InfosLoaded)
 				{
-					int Length = r.front().Length();
-					char aLength[32];
-					str_format(aLength, sizeof(aLength), "%d:%02d", Length/60, Length%60);
-					Button.VMargin(4.0f, &Button);
-					if(!Item.m_Selected)
-						TextRender()->TextColor(CUI::ms_TransparentTextColor);
-					UI()->DoLabel(&Button, aLength, Item.m_Rect.h*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
+					if (DemoItem.m_Valid)
+					{
+						int Length = DemoItem.Length();
+						char aLength[32];
+						str_format(aLength, sizeof(aLength), "%d:%02d", Length/60, Length%60);
+						Button.VMargin(4.0f, &Button);
+						if(!Item.m_Selected)
+							TextRender()->TextColor(CUI::ms_TransparentTextColor);
+						UI()->DoLabel(&Button, aLength, Item.m_Rect.h*ms_FontmodHeight*0.8f, CUI::ALIGN_RIGHT);
+					}
 				}
 				else if(ID == COL_DEMO_DATE)
 				{
@@ -585,7 +589,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 						str_timestamp_ex(DemoItem.m_Date, aDate, sizeof(aDate), FORMAT_SPACE);
 						if(!Item.m_Selected)
 							TextRender()->TextColor(CUI::ms_TransparentTextColor);
-						UI()->DoLabel(&Button, aDate, Item.m_Rect.h*ms_FontmodHeight*0.8f, CUI::ALIGN_LEFT);
+						UI()->DoLabel(&Button, aDate, Item.m_Rect.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 					}
 				}
 				TextRender()->TextColor(CUI::ms_DefaultTextColor);
@@ -599,16 +603,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 
 	MainView.HSplitTop(HMargin, 0, &MainView);
 	static int s_DemoDetailsDropdown = 0;
-	if(!m_DemolistSelectedIsDir && m_DemolistSelectedIndex >= 0 && m_lDemos[m_DemolistSelectedIndex].m_Valid)
-		DoIndependentDropdownMenu(&s_DemoDetailsDropdown, &MainView, aFooterLabel, ButtonHeight, &CMenus::RenderDemoDetails, &s_DemoDetailsActive);
-	else
-	{
-		CUIRect Header;
-		MainView.HSplitTop(ButtonHeight, &Header, &MainView);
-		RenderTools()->DrawUIRect(&Header, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
-		Header.y += 2.0f;
-		UI()->DoLabel(&Header, aFooterLabel, ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
-	}
+	DoIndependentDropdownMenu(&s_DemoDetailsDropdown, &MainView, aFooterLabel, ButtonHeight, &CMenus::RenderDemoDetails, &s_DemoDetailsActive);
 
 	// demo buttons
 	int NumButtons = m_DemolistSelectedIsDir ? 3 : 5;
@@ -732,7 +727,7 @@ void CMenus::PopupConfirmDeleteDemo()
 float CMenus::RenderDemoDetails(CUIRect View)
 {
 	// render demo info
-	if(!m_DemolistSelectedIsDir && m_DemolistSelectedIndex >= 0 && m_lDemos[m_DemolistSelectedIndex].m_Valid)
+	if(!m_DemolistSelectedIsDir && m_DemolistSelectedIndex >= 0 && m_lDemos[m_DemolistSelectedIndex].m_Valid && m_lDemos[m_DemolistSelectedIndex].m_InfosLoaded)
 	{
 		CUIRect Button;
 

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -40,6 +40,13 @@ void CMenus::CListBox::DoHeader(const CUIRect *pRect, const char *pTitle,
 	m_ListBoxView = View;
 }
 
+void CMenus::CListBox::DoSubHeader(float HeaderHeight, float Spacing)
+{
+	CUIRect View = m_ListBoxView;
+	View.HSplitTop(HeaderHeight+Spacing, 0, &View);
+	m_ListBoxView = View;
+}
+
 bool CMenus::CListBox::DoFilter(float FilterHeight, float Spacing)
 {
 	CUIRect Filter;


### PR DESCRIPTION
closes #2738 

other than the problems stated in the issue:

- Reduce `Length` column width for aesthetics.
- Prevent demo detail from rendering before demo info is fetched.
- Remove redundant check that prevents dropdown toggle from showing if the demo is invalid.

![screenshot_2020-09-20_12-51-15](https://user-images.githubusercontent.com/3797859/93710619-05159280-fb40-11ea-961f-315d6fef66a3.png)
