### PR TITLE
Fix envelopes resetting to time 0 on demo/world pause

### DIFF
--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -14,7 +14,6 @@ class CMapLayers : public CComponent
 	int m_CurrentLocalTick;
 	int m_LastLocalTick;
 	float m_OnlineStartTime;
-	bool m_EnvelopeUpdate;
 
 	array<CEnvPoint> m_lEnvPoints;
 	array<CEnvPoint> m_lEnvPointsMenu;


### PR DESCRIPTION
When a demo / the server game world is paused, the envelopes were reset to time 0 which rapidly changes their position.

This is fixed by declaring the time as static, so it persists over pausation of the demo and the world. The m_EnvelopeUpdate flag is removed because it was only ever being set to true (when first seeking to a position), at which point the paused-state of the demo player is ignored and the envelopes begin working properly.

There is a separate issue with the game world being paused in a demo. Right now the envelopes will continue running in the demo player when the client/server demo had a paused game world.