### PR TITLE
Merge Player and Tee Settings Tab

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -25,7 +25,7 @@ CCamera::CCamera()
 	m_Positions[POS_DEMOS] = vec2(1500.0f, 500.0f);
 	m_Positions[POS_SETTINGS_GENERAL] = vec2(500.0f, 1000.0f);
 	m_Positions[POS_SETTINGS_PLAYER] = vec2(600.0f, 1000.0f);
-	m_Positions[POS_SETTINGS_TEE] = vec2(700.0f, 1000.0f);
+	m_Positions[POS_SETTINGS_TBD] = vec2(700.0f, 1000.0f);
 	m_Positions[POS_SETTINGS_CONTROLS] = vec2(800.0f, 1000.0f);
 	m_Positions[POS_SETTINGS_GRAPHICS] = vec2(900.0f, 1000.0f);
 	m_Positions[POS_SETTINGS_SOUND] = vec2(1000.0f, 1000.0f);

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -16,7 +16,7 @@ public:
 		POS_DEMOS,
 		POS_SETTINGS_GENERAL, // order here should be the same like enum for settings pages in menu
 		POS_SETTINGS_PLAYER,
-		POS_SETTINGS_TEE,
+		POS_SETTINGS_TBD, // TODO: change removed tee page to something else
 		POS_SETTINGS_CONTROLS,
 		POS_SETTINGS_GRAPHICS,
 		POS_SETTINGS_SOUND,

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -96,6 +96,8 @@ CMenus::CMenus()
 	m_aFilterString[0] = 0;
 
 	m_ActiveListBox = ACTLB_NONE;
+
+	m_PopupSelection = -2;
 }
 
 float CMenus::CButtonContainer::GetFade(bool Checked, float Seconds)
@@ -990,15 +992,17 @@ void CMenus::RenderMenubar(CUIRect Rect)
 			}
 		}
 
+
+		// TODO: replace tee page to something else
 		Box.VSplitLeft(Spacing, 0, &Box); // little space
 		Box.VSplitLeft(ButtonWidth, &Button, &Box);
 		{
 			static CButtonContainer s_TeeButton;
-			if(DoButton_MenuTabTop(&s_TeeButton, Localize("Tee"), Client()->State() == IClient::STATE_OFFLINE && Config()->m_UiSettingsPage == SETTINGS_TEE, &Button,
-				Config()->m_UiSettingsPage == SETTINGS_TEE ? 1.0f : NotActiveAlpha, 1.0f, Corners))
+			if(DoButton_MenuTabTop(&s_TeeButton, Localize("TBD"), Client()->State() == IClient::STATE_OFFLINE && Config()->m_UiSettingsPage == SETTINGS_TBD, &Button,
+				Config()->m_UiSettingsPage == SETTINGS_TBD ? 1.0f : NotActiveAlpha, 1.0f, Corners))
 			{
-				m_pClient->m_pCamera->ChangePosition(CCamera::POS_SETTINGS_TEE);
-				Config()->m_UiSettingsPage = SETTINGS_TEE;
+				m_pClient->m_pCamera->ChangePosition(CCamera::POS_SETTINGS_TBD);
+				Config()->m_UiSettingsPage = SETTINGS_TBD;
 			}
 		}
 
@@ -1425,6 +1429,14 @@ void CMenus::PopupConfirm(const char *pTitle, const char *pMessage, const char *
 	m_Popup = POPUP_CONFIRM;
 }
 
+void CMenus::PopupCountry(int Selection, FPopupButtonCallback pfnOkButtonCallback)
+{
+	m_PopupSelection = Selection;
+	m_aPopupButtons[BUTTON_CONFIRM].m_NextPopup = POPUP_NONE;
+	m_aPopupButtons[BUTTON_CONFIRM].m_pfnCallback = pfnOkButtonCallback;
+	m_Popup = POPUP_COUNTRY;
+}
+
 
 int CMenus::Render()
 {
@@ -1806,13 +1818,6 @@ int CMenus::Render()
 		else if(m_Popup == POPUP_COUNTRY)
 		{
 			// selected filter
-			CBrowserFilter *pFilter = GetSelectedBrowserFilter();
-			CServerFilterInfo FilterInfo;
-			pFilter->GetFilter(&FilterInfo);
-
-			static int s_ActSelection = -2;
-			if(s_ActSelection == -2)
-				s_ActSelection = FilterInfo.m_Country;
 			static CListBox s_ListBox;
 			int OldSelected = -1;
 			s_ListBox.DoStart(40.0f, m_pClient->m_pCountryFlags->Num(), 12, 1, OldSelected, &Box, false);
@@ -1822,7 +1827,7 @@ int CMenus::Render()
 				const CCountryFlags::CCountryFlag *pEntry = m_pClient->m_pCountryFlags->GetByIndex(i);
 				if(pEntry->m_Blocked)
 					continue;
-				if(pEntry->m_CountryCode == s_ActSelection)
+				if(pEntry->m_CountryCode == m_PopupSelection)
 					OldSelected = i;
 
 				CListboxItem Item = s_ListBox.DoNextItem(pEntry, OldSelected == i);
@@ -1858,21 +1863,20 @@ int CMenus::Render()
 
 			const int NewSelected = s_ListBox.DoEnd();
 			if(OldSelected != NewSelected)
-				s_ActSelection = m_pClient->m_pCountryFlags->GetByIndex(NewSelected, true)->m_CountryCode;
+				m_PopupSelection = m_pClient->m_pCountryFlags->GetByIndex(NewSelected, true)->m_CountryCode;
 
 			Part.VMargin(120.0f, &Part);
 
 			static CButtonContainer s_ButtonCountry;
 			if(DoButton_Menu(&s_ButtonCountry, Localize("Ok"), 0, &BottomBar) || m_EnterPressed)
 			{
-				FilterInfo.m_Country = s_ActSelection;
-				pFilter->SetFilter(&FilterInfo);
+				(this->*m_aPopupButtons[BUTTON_CONFIRM].m_pfnCallback)();
 				m_Popup = POPUP_NONE;
 			}
 
 			if(m_EscapePressed)
 			{
-				s_ActSelection = FilterInfo.m_Country;
+				m_PopupSelection = -2;
 				m_Popup = POPUP_NONE;
 			}
 		}

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -901,8 +901,9 @@ void CMenus::RenderMenubar(CUIRect Rect)
 
 	if(Client()->State() == IClient::STATE_ONLINE)
 	{
+		int NumButtons = 6;
 		float Spacing = 3.0f;
-		float ButtonWidth = (Box.w / 6.0f) - (Spacing*5.0) / 6.0f;
+		float ButtonWidth = (Box.w / NumButtons) - (Spacing*5.0) / NumButtons;
 		float Alpha = 1.0f;
 		if(m_GamePage == PAGE_SETTINGS)
 			Alpha = InactiveAlpha;
@@ -960,8 +961,9 @@ void CMenus::RenderMenubar(CUIRect Rect)
 
 	if((Client()->State() == IClient::STATE_OFFLINE && m_MenuPage == PAGE_SETTINGS) || (Client()->State() == IClient::STATE_ONLINE && m_GamePage == PAGE_SETTINGS))
 	{
+		int NumButtons = 5;
 		float Spacing = 3.0f;
-		float ButtonWidth = (Box.w/6.0f)-(Spacing*5.0)/6.0f;
+		float ButtonWidth = (Box.w/NumButtons)-(Spacing*5.0)/NumButtons;
 		float NotActiveAlpha = Client()->State() == IClient::STATE_ONLINE ? 0.5f : 1.0f;
 		int Corners = Client()->State() == IClient::STATE_ONLINE ? CUI::CORNER_T : CUI::CORNER_ALL;
 
@@ -994,18 +996,17 @@ void CMenus::RenderMenubar(CUIRect Rect)
 
 
 		// TODO: replace tee page to something else
-		Box.VSplitLeft(Spacing, 0, &Box); // little space
-		Box.VSplitLeft(ButtonWidth, &Button, &Box);
-		{
-			static CButtonContainer s_TeeButton;
-			if(DoButton_MenuTabTop(&s_TeeButton, Localize("TBD"), Client()->State() == IClient::STATE_OFFLINE && Config()->m_UiSettingsPage == SETTINGS_TBD, &Button,
-				Config()->m_UiSettingsPage == SETTINGS_TBD ? 1.0f : NotActiveAlpha, 1.0f, Corners))
-			{
-				m_pClient->m_pCamera->ChangePosition(CCamera::POS_SETTINGS_TBD);
-				Config()->m_UiSettingsPage = SETTINGS_TBD;
-			}
-		}
-
+		// Box.VSplitLeft(Spacing, 0, &Box); // little space
+		// Box.VSplitLeft(ButtonWidth, &Button, &Box);
+		// {
+		// 	static CButtonContainer s_TeeButton;
+		// 	if(DoButton_MenuTabTop(&s_TeeButton, Localize("TBD"), Client()->State() == IClient::STATE_OFFLINE && Config()->m_UiSettingsPage == SETTINGS_TBD, &Button,
+		// 		Config()->m_UiSettingsPage == SETTINGS_TBD ? 1.0f : NotActiveAlpha, 1.0f, Corners))
+		// 	{
+		// 		m_pClient->m_pCamera->ChangePosition(CCamera::POS_SETTINGS_TBD);
+		// 		Config()->m_UiSettingsPage = SETTINGS_TBD;
+		// 	}
+		// }
 
 		Box.VSplitLeft(Spacing, 0, &Box); // little space
 		Box.VSplitLeft(ButtonWidth, &Button, &Box);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -827,7 +827,7 @@ private:
 	void RenderSkinPartPalette(CUIRect MainView);
 	void RenderSettingsGeneral(CUIRect MainView);
 	void RenderSettingsPlayer(CUIRect MainView);
-	// void RenderSettingsTee(CUIRect MainView);
+	// void RenderSettingsTBD(CUIRect MainView); // TODO: change removed tee page to something else
 	void RenderSettingsTeeBasic(CUIRect MainView);
 	void RenderSettingsTeeCustom(CUIRect MainView);
 	void PopupConfirmDeleteSkin();

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -309,7 +309,7 @@ private:
 
 		SETTINGS_GENERAL=0,
 		SETTINGS_PLAYER,
-		SETTINGS_TEE,
+		SETTINGS_TBD, // TODO: replace this removed tee page
 		SETTINGS_CONTROLS,
 		SETTINGS_GRAPHICS,
 		SETTINGS_SOUND,
@@ -331,6 +331,7 @@ private:
 	bool m_PrevCursorActive;
 	bool m_PopupActive;
 	int m_ActiveListBox;
+	int m_PopupSelection;
 	bool m_SkinModified;
 	bool m_KeyReaderWasActive;
 	bool m_KeyReaderIsActive;
@@ -340,7 +341,7 @@ private:
 	void DefaultButtonCallback() { /* do nothing */ };
 	enum
 	{
-		BUTTON_CONFIRM = 0, // confirm / yes / close
+		BUTTON_CONFIRM = 0, // confirm / yes / close / ok
 		BUTTON_CANCEL, // cancel / no
 		NUM_BUTTONS
 	};
@@ -359,6 +360,7 @@ private:
 		const char *pConfirmButtonLabel, const char *pCancelButtonLabel,
 		FPopupButtonCallback pfnConfirmButtonCallback = &CMenus::DefaultButtonCallback, int ConfirmNextPopup = POPUP_NONE,
 		FPopupButtonCallback pfnCancelButtonCallback = &CMenus::DefaultButtonCallback, int CancelNextPopup = POPUP_NONE);
+	void PopupCountry(int Selection, FPopupButtonCallback pfnOkButtonCallback = &CMenus::DefaultButtonCallback);
 
 	// images
 	struct CMenuImage
@@ -804,6 +806,7 @@ private:
 	void RenderServerbrowserOverlay();
 	void RenderFilterHeader(CUIRect View, int FilterIndex);
 	void PopupConfirmRemoveFilter();
+	void PopupConfirmCountryFilter();
 	int DoBrowserEntry(const void *pID, CUIRect View, const CServerInfo *pEntry, const CBrowserFilter *pFilter, bool Selected, bool ShowServerInfo, CScrollRegion *pScroll = 0);
 	void RenderServerbrowser(CUIRect MainView);
 	static void ConchainConnect(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
@@ -824,7 +827,7 @@ private:
 	void RenderSkinPartPalette(CUIRect MainView);
 	void RenderSettingsGeneral(CUIRect MainView);
 	void RenderSettingsPlayer(CUIRect MainView);
-	void RenderSettingsTee(CUIRect MainView);
+	// void RenderSettingsTee(CUIRect MainView);
 	void RenderSettingsTeeBasic(CUIRect MainView);
 	void RenderSettingsTeeCustom(CUIRect MainView);
 	void PopupConfirmDeleteSkin();
@@ -836,6 +839,7 @@ private:
 	void ResetSettingsControls();
 	void ResetSettingsGraphics();
 	void ResetSettingsSound();
+	void PopupConfirmPlayerCountry();
 
 	bool DoResolutionList(CUIRect* pRect, CListBox* pListBox,
 						  const sorted_array<CVideoMode>& lModes);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -757,6 +757,18 @@ void CMenus::PopupConfirmRemoveFilter()
 	}
 }
 
+void CMenus::PopupConfirmCountryFilter()
+{
+	CBrowserFilter *pFilter = GetSelectedBrowserFilter();
+	CServerFilterInfo FilterInfo;
+	pFilter->GetFilter(&FilterInfo);
+
+	if(m_PopupSelection != -2)
+		FilterInfo.m_Country = m_PopupSelection;
+
+	pFilter->SetFilter(&FilterInfo);
+}
+
 static void FormatScore(char *pBuf, int BufSize, bool TimeScore, const CServerInfo::CClient *pClient)
 {
 	if(TimeScore)
@@ -1967,7 +1979,7 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 
 		static int s_BrFilterCountryIndex = 0;
 		if((FilterInfo.m_SortHash&IServerBrowser::FILTER_COUNTRY) && UI()->DoButtonLogic(&s_BrFilterCountryIndex, &Rect))
-			m_Popup = POPUP_COUNTRY;
+			PopupCountry(FilterInfo.m_Country, &CMenus::PopupConfirmCountryFilter);
 	}
 
 	// level

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -69,7 +69,6 @@ void CMenus::RenderHSLPicker(CUIRect MainView)
 
 	// background
 	float Spacing = 2.0f;
-	float ButtonHeight = 20.0f;
 
 	if(!(*CSkins::ms_apUCCVariables[m_TeePartSelected]))
 		return;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2098,8 +2098,8 @@ void CMenus::RenderSettings(CUIRect MainView)
 		RenderSettingsGeneral(MainView);
 	else if(Config()->m_UiSettingsPage == SETTINGS_PLAYER)
 		RenderSettingsPlayer(MainView);
-	else if(Config()->m_UiSettingsPage == SETTINGS_TBD) {} // TODO: replace removed tee page to something else
-		// RenderSettingsTBD(MainView);
+	else if(Config()->m_UiSettingsPage == SETTINGS_TBD) // TODO: replace removed tee page to something else	
+		Config()->m_UiSettingsPage = SETTINGS_PLAYER; // TODO: remove this
 	else if(Config()->m_UiSettingsPage == SETTINGS_CONTROLS)
 		RenderSettingsControls(MainView);
 	else if(Config()->m_UiSettingsPage == SETTINGS_GRAPHICS)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -311,6 +311,7 @@ void CMenus::RenderHSLPicker(CUIRect MainView)
 
 void CMenus::RenderSkinSelection(CUIRect MainView)
 {
+	static float s_LastSelectionTime = -10.0f;
 	static sorted_array<const CSkins::CSkin *> s_paSkinList;
 	static CListBox s_ListBox;
 	if(m_RefreshSkinSelector)
@@ -365,7 +366,12 @@ void CMenus::RenderSkinSelection(CUIRect MainView)
 
 			Info.m_Size = 50.0f;
 			Item.m_Rect.HSplitTop(5.0f, 0, &Item.m_Rect); // some margin from the top
-			RenderTools()->RenderTee(CAnimState::GetIdle(), &Info, 0, vec2(1.0f, 0.0f), vec2(Item.m_Rect.x+Item.m_Rect.w/2, Item.m_Rect.y+Item.m_Rect.h/2));
+
+			{
+				// interactive tee: tee is happy to be selected
+				int TeeEmote = (Item.m_Selected && s_LastSelectionTime + 0.75f > Client()->LocalTime()) ? EMOTE_HAPPY : EMOTE_NORMAL;
+				RenderTools()->RenderTee(CAnimState::GetIdle(), &Info, TeeEmote, vec2(1.0f, 0.0f), vec2(Item.m_Rect.x+Item.m_Rect.w/2, Item.m_Rect.y+Item.m_Rect.h/2));
+			}
 		
 			CUIRect Label;
 			Item.m_Rect.Margin(5.0f, &Item.m_Rect);
@@ -388,6 +394,7 @@ void CMenus::RenderSkinSelection(CUIRect MainView)
 	const int NewSelected = s_ListBox.DoEnd();
 	if(NewSelected != -1 && NewSelected != OldSelected)
 	{
+		s_LastSelectionTime = Client()->LocalTime();
 		m_pSelectedSkin = s_paSkinList[NewSelected];
 		mem_copy(Config()->m_PlayerSkin, m_pSelectedSkin->m_aName, sizeof(Config()->m_PlayerSkin));
 		for(int p = 0; p < NUM_SKINPARTS; p++)
@@ -1069,62 +1076,6 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	}
 }
 
-// void CMenus::RenderSettingsPlayer(CUIRect MainView)
-// {
-// 	static int s_PlayerCountry = Config()->m_PlayerCountry;
-// 	static char s_aPlayerName[256] = {0};
-// 	static char s_aPlayerClan[256] = {0};
-// 	if(!s_aPlayerName[0])
-// 		str_copy(s_aPlayerName, Config()->m_PlayerName, sizeof(s_aPlayerName));
-// 	if(!s_aPlayerClan[0])
-// 		str_copy(s_aPlayerClan, Config()->m_PlayerClan, sizeof(s_aPlayerClan));
-
-// 	CUIRect Button, Left, Right, TopView, Label, Background;
-
-// 	// render game menu backgrounds
-// 	float ButtonHeight = 20.0f;
-// 	float Spacing = 2.0f;
-// 	float BackgroundHeight = 2.0f*ButtonHeight+Spacing;
-
-// 	MainView.HSplitBottom(80.0f, &MainView, 0); // now we have the total rect for the settings#
-// 	if(this->Client()->State() == IClient::STATE_ONLINE)
-// 		Background = MainView;
-// 	else
-// 		MainView.HSplitTop(20.0f, 0, &Background);
-// 	RenderTools()->DrawUIRect(&Background, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), Client()->State() == IClient::STATE_OFFLINE ? CUI::CORNER_ALL : CUI::CORNER_B, 5.0f);
-// 	MainView.HSplitTop(20.0f, 0, &MainView);
-// 	MainView.HSplitTop(BackgroundHeight, &TopView, &MainView);
-// 	RenderTools()->DrawUIRect(&TopView, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
-
-// 	// render game menu
-// 	TopView.HSplitTop(ButtonHeight, &Label, &TopView);
-// 	Label.y += 2.0f;
-// 	UI()->DoLabel(&Label, Localize("Personal"), ButtonHeight*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
-
-// 	// split menu
-// 	TopView.HSplitTop(Spacing, 0, &TopView);
-// 	TopView.VSplitMid(&Left, &Right, 3.0f);
-
-	// // left menu
-	// Left.HSplitTop(ButtonHeight, &Button, &Left);
-	// static float s_OffsetName = 0.0f;
-	// DoEditBoxOption(Config()->m_PlayerName, Config()->m_PlayerName, sizeof(Config()->m_PlayerName), &Button, Localize("Name"),  100.0f, &s_OffsetName);
-
-	// // right menu
-	// Right.HSplitTop(ButtonHeight, &Button, &Right);
-	// static float s_OffsetClan = 0.0f;
-	// DoEditBoxOption(Config()->m_PlayerClan, Config()->m_PlayerClan, sizeof(Config()->m_PlayerClan), &Button, Localize("Clan"),  100.0f, &s_OffsetClan);
-
-// 	// country flag selector
-
-// 	// check if the new settings require a server reload
-// 	m_NeedRestartPlayer = !(
-// 		s_PlayerCountry == Config()->m_PlayerCountry &&
-// 		!str_comp(s_aPlayerClan, Config()->m_PlayerClan) &&
-// 		!str_comp(s_aPlayerName, Config()->m_PlayerName)
-// 		);
-// }
-
 void CMenus::RenderSettingsTeeBasic(CUIRect MainView)
 {
 	RenderSkinSelection(MainView); // yes thats all here ^^
@@ -1192,15 +1143,17 @@ void CMenus::RenderSettingsTeeCustom(CUIRect MainView)
 void CMenus::RenderSettingsPlayer(CUIRect MainView)
 {
 	static bool s_CustomSkinMenu = false;
+	static int s_PlayerCountry = 0;
 	static char s_aPlayerName[256] = {0};
 	static char s_aPlayerClan[256] = {0};
-	static char s_aPlayerSkin[256] = {0};
-	if(!s_aPlayerName[0])
+
+	if(m_pClient->m_IdentityState < 0)
+	{
+		s_PlayerCountry = Config()->m_PlayerCountry;
 		str_copy(s_aPlayerName, Config()->m_PlayerName, sizeof(s_aPlayerName));
-	if(!s_aPlayerClan[0])
 		str_copy(s_aPlayerClan, Config()->m_PlayerClan, sizeof(s_aPlayerClan));
-	if(!s_aPlayerSkin[0])
-		str_copy(s_aPlayerSkin, Config()->m_PlayerSkin, sizeof(s_aPlayerSkin));
+		m_pClient->m_IdentityState = 0;
+	}
 
 	CUIRect Button, Label, TopView, BottomView, Background, Left, Right;
 
@@ -1214,6 +1167,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	const float ButtonHeight = 20.0f;
 	const float SkinHeight = 50.0f;
 	const float BackgroundHeight = (ButtonHeight+SpacingH) + SkinHeight*2;
+	const vec2 MousePosition = vec2(UI()->MouseX(), UI()->MouseY());
 
 	if(this->Client()->State() == IClient::STATE_ONLINE)
 		Background = MainView;
@@ -1284,7 +1238,17 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 
 		RenderTools()->DrawUIRect(&Top, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
-		RenderTools()->RenderTee(CAnimState::GetIdle(), &OwnSkinInfo, 0, vec2(1, 0), vec2(Top.x+Top.w/2.0f, Top.y+Top.h/2.0f+6.0f));
+		{
+			// interactive tee: tee looking towards cursor, and it is happy when you touch it
+			vec2 TeePosition = vec2(Top.x+Top.w/2.0f, Top.y+Top.h/2.0f+6.0f);
+			vec2 DeltaPosition = MousePosition - TeePosition;
+			float Distance = length(DeltaPosition);
+			vec2 TeeDirection = Distance < 20.0f ? normalize(vec2(DeltaPosition.x, max(DeltaPosition.y, 0.5f))) : normalize(DeltaPosition);
+			int TeeEmote = Distance < 20.0f ? EMOTE_HAPPY : EMOTE_NORMAL;
+			RenderTools()->RenderTee(CAnimState::GetIdle(), &OwnSkinInfo, TeeEmote, TeeDirection, TeePosition);
+			if(Distance < 20.0f && UI()->MouseButtonClicked(0))
+				m_pClient->m_pSounds->Play(CSounds::CHN_GUI, SOUND_PLAYER_SPAWN, 0);
+		}
 
 		// handle right (team skins)
 
@@ -1342,7 +1306,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 			int TeamColor = m_pClient->m_pSkins->GetTeamColor(aUCCVars[p], aColorVars[p], TEAM_BLUE, p);
 			TeamSkinInfo.m_aColors[p] = m_pClient->m_pSkins->GetColorV4(TeamColor, p==SKINPART_MARKING);
 		}
-		RenderTools()->RenderTee(CAnimState::GetIdle(), &TeamSkinInfo, 0, vec2(1, 0), vec2(TeeRight.x+TeeRight.w/2.0f, TeeRight.y+TeeRight.h/2.0f+6.0f));
+		RenderTools()->RenderTee(CAnimState::GetIdle(), &TeamSkinInfo, 0, vec2(-1, 0), vec2(TeeRight.x+TeeRight.w/2.0f, TeeRight.y+TeeRight.h/2.0f+6.0f));
 	}
 
 	Right.HSplitTop(ButtonHeight, &Label, &Right);
@@ -1428,6 +1392,14 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	{
 		s_CustomSkinMenu = !s_CustomSkinMenu;
 	}
+
+	// check if the new settings require a server reload
+	m_NeedRestartPlayer = !(
+		s_PlayerCountry == Config()->m_PlayerCountry &&
+		!str_comp(s_aPlayerClan, Config()->m_PlayerClan) &&
+		!str_comp(s_aPlayerName, Config()->m_PlayerName)
+	);
+	m_pClient->m_IdentityState = m_NeedRestartPlayer ? 1 : 0;
 }
 
 void CMenus::PopupConfirmDeleteSkin()
@@ -2126,8 +2098,8 @@ void CMenus::RenderSettings(CUIRect MainView)
 		RenderSettingsGeneral(MainView);
 	else if(Config()->m_UiSettingsPage == SETTINGS_PLAYER)
 		RenderSettingsPlayer(MainView);
-	else if(Config()->m_UiSettingsPage == SETTINGS_TBD) {}
-		// RenderSettingsTee(MainView);
+	else if(Config()->m_UiSettingsPage == SETTINGS_TBD) {} // TODO: replace removed tee page to something else
+		// RenderSettingsTBD(MainView);
 	else if(Config()->m_UiSettingsPage == SETTINGS_CONTROLS)
 		RenderSettingsControls(MainView);
 	else if(Config()->m_UiSettingsPage == SETTINGS_GRAPHICS)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -490,6 +490,7 @@ void CGameClient::OnReset()
 		m_TeamCooldownTick = 0;
 		m_TeamChangeTime = 0.0f;
 		m_LastSkinChangeTime = Client()->LocalTime();
+		m_IdentityState = -1;
 		mem_zero(&m_GameInfo, sizeof(m_GameInfo));
 		m_DemoSpecMode = SPEC_FREEVIEW;
 		m_DemoSpecID = -1;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -232,6 +232,7 @@ public:
 	float m_TeamChangeTime;
 	bool m_IsXmasDay;
 	float m_LastSkinChangeTime;
+	int m_IdentityState;
 	bool m_IsEasterDay;
 	bool m_InitComplete;
 


### PR DESCRIPTION
closes #2583 

In addition:

- Made the "reconnect to change identity" notification reset after joining a game.
- Made the Tee preview a little more lively based on some suggestions in the discord. (Demo: https://streamable.com/pwjrsl)

Screenshot for good measure:
![screenshot_2020-09-21_15-18-49](https://user-images.githubusercontent.com/3797859/93778450-d4a42600-fc1d-11ea-98b5-d9feabc74a57.png)

