### PR TITLE
Increase size and alpha of server broadcast backdrop, refactor CBroadcast

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -28,7 +28,7 @@ MACRO_CONFIG_INT(ClAutoStatScreenshot, cl_auto_statscreenshot, 0, 0, 1, CFGFLAG_
 MACRO_CONFIG_INT(ClAutoScreenshotMax, cl_auto_screenshot_max, 10, 0, 1000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Maximum number of automatically created screenshots (0 = no limit)")
 
 MACRO_CONFIG_INT(ClShowServerBroadcast, cl_show_server_broadcast, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Show server broadcast")
-MACRO_CONFIG_INT(ClColoredBroadcast, cl_colored_broadcast, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Enable colored server broadcasts")
+MACRO_CONFIG_INT(ClColoredBroadcast, cl_colored_broadcast, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Enable colored server broadcasts")
 
 MACRO_CONFIG_INT(ClSaveServerPasswords, cl_save_server_passwords, 1, 0, 2, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Save server passwords (0 = never, 1 = only favorites, 2 = all servers)")
 

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -13,25 +13,12 @@
 #include "scoreboard.h"
 #include "motd.h"
 
-#define BROADCAST_FONTSIZE_BIG 11.0f
-#define BROADCAST_FONTSIZE_SMALL 6.5f
+static const float BROADCAST_FONTSIZE_BIG = 11.0f;
+static const float BROADCAST_FONTSIZE_SMALL = 6.5f;
 
 inline bool IsCharANum(char c)
 {
 	return c >= '0' && c <= '9';
-}
-
-inline int WordLengthBack(const char *pText, int MaxChars)
-{
-	int s = 0;
-	while(MaxChars--)
-	{
-		if((*pText == '\n' || *pText == '\t' || *pText == ' '))
-			return s;
-		pText--;
-		s++;
-	}
-	return 0;
 }
 
 inline bool IsCharWhitespace(char c)
@@ -39,25 +26,35 @@ inline bool IsCharWhitespace(char c)
 	return c == '\n' || c == '\t' || c == ' ';
 }
 
+inline int WordLengthBack(const char *pText, int MaxChars)
+{
+	int s = 0;
+	while(MaxChars--)
+	{
+		if(IsCharWhitespace(*pText))
+			return s;
+		pText--;
+		s++;
+	}
+	return 0;
+}
+
 void CBroadcast::RenderServerBroadcast()
 {
-	if(!Config()->m_ClShowServerBroadcast || m_pClient->m_MuteServerBroadcast)
+	if(!Config()->m_ClShowServerBroadcast || m_MuteServerBroadcast || m_aSrvBroadcastMsg[0] == 0)
 		return;
-
-	const bool ColoredBroadcastEnabled = Config()->m_ClColoredBroadcast;
-	const float Height = 300;
-	const float Width = Height*Graphics()->ScreenAspect();
+	if(m_pClient->m_pChat->IsActive())
+		return;
 
 	const float DisplayDuration = 10.0f;
 	const float DisplayStartFade = 9.0f;
 	const float DeltaTime = Client()->LocalTime() - m_SrvBroadcastReceivedTime;
 
-	if(m_aSrvBroadcastMsg[0] == 0 || DeltaTime > DisplayDuration)
+	if(DeltaTime > DisplayDuration)
 		return;
 
-	if(m_pClient->m_pChat->IsActive() || m_pClient->Client()->State() != IClient::STATE_ONLINE)
-		return;
-
+	const float Height = 300;
+	const float Width = Height*Graphics()->ScreenAspect();
 	Graphics()->MapScreen(0, 0, Width, Height);
 
 	const float Fade = 1.0f - max(0.0f, (DeltaTime - DisplayStartFade) / (DisplayDuration - DisplayStartFade));
@@ -70,8 +67,6 @@ void CBroadcast::RenderServerBroadcast()
 	BcView.w *= 0.5f;
 	BcView.h *= 0.2f;
 
-	vec4 ColorTop(0, 0, 0, 0);
-	vec4 ColorBot(0, 0, 0, 0.4f * Fade);
 	CUIRect BgRect;
 	BcView.HSplitBottom(10.0f, 0, &BgRect);
 	BcView.HSplitBottom(6.0f, &BcView, 0);
@@ -130,10 +125,10 @@ void CBroadcast::RenderServerBroadcast()
 	}
 
 	IGraphics::CColorVertex aColorVert[4] = {
-		IGraphics::CColorVertex(0, 0,0,0, 0.0f),
-		IGraphics::CColorVertex(1, 0,0,0, 0.4f * Fade),
-		IGraphics::CColorVertex(2, 0,0,0, 0.0f),
-		IGraphics::CColorVertex(3, 0,0,0, 0.0f)
+		IGraphics::CColorVertex(0, 0, 0, 0, 0.0f),
+		IGraphics::CColorVertex(1, 0, 0, 0, 0.4f * Fade),
+		IGraphics::CColorVertex(2, 0, 0, 0, 0.0f),
+		IGraphics::CColorVertex(3, 0, 0, 0, 0.0f)
 	};
 
 	Graphics()->SetColorVertex(aColorVert, 4);
@@ -142,27 +137,29 @@ void CBroadcast::RenderServerBroadcast()
 
 	Graphics()->QuadsEnd();
 
-	RenderTools()->DrawUIRect4(&BgRect, ColorTop, ColorTop,
-							   ColorBot, ColorBot, 0, 0);
-
+	{
+		vec4 ColorTop(0, 0, 0, 0);
+		vec4 ColorBot(0, 0, 0, 0.4f * Fade);
+		RenderTools()->DrawUIRect4(&BgRect, ColorTop, ColorTop, ColorBot, ColorBot, 0, 0);
+	}
 
 	BcView.VMargin(5.0f, &BcView);
 	BcView.HSplitBottom(2.0f, &BcView, 0);
 
 	// draw lines
+	const bool ColoredBroadcastEnabled = Config()->m_ClColoredBroadcast;
 	const float FontSize = m_SrvBroadcastFontSize;
 	const int LineCount = m_SrvBroadcastLineCount;
-	const char* pBroadcastMsg = m_aSrvBroadcastMsg;
-	CTextCursor Cursor;
 
 	const vec2 ShadowOff(1.0f, 2.0f);
 	const vec4 ShadowColorBlack(0, 0, 0, 0.9f * Fade);
 	const vec4 TextColorWhite(1, 1, 1, Fade);
-	float y = BcView.y + BcView.h - LineCount * FontSize;
 
+	float y = BcView.y + BcView.h - LineCount * FontSize;
 	for(int l = 0; l < LineCount; l++)
 	{
 		const CBcLineInfo& Line = m_aSrvBroadcastLines[l];
+		CTextCursor Cursor;
 		TextRender()->SetCursor(&Cursor, BcView.x + (BcView.w - Line.m_Width) * 0.5f, y,
 								FontSize, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = BcView.w;
@@ -171,7 +168,7 @@ void CBroadcast::RenderServerBroadcast()
 		if(ColoredBroadcastEnabled)
 		{
 			int DrawnStrLen = 0;
-			int ThisCharPos = Line.m_pStrStart - pBroadcastMsg;
+			int ThisCharPos = Line.m_pStrStart - m_aSrvBroadcastMsg;
 			while(DrawnStrLen < Line.m_StrLen)
 			{
 				int StartColorID = -1;
@@ -234,12 +231,30 @@ void CBroadcast::RenderServerBroadcast()
 	TextRender()->TextOutlineColor(0, 0, 0, 0.3f);
 }
 
+void CBroadcast::RenderClientBroadcast()
+{
+	if(m_pClient->m_pScoreboard->IsActive() || m_pClient->m_pMotd->IsActive() || m_aBroadcastText[0] == 0)
+		return;
+	if(Client()->LocalTime() >= m_BroadcastTime)
+		return;
+
+	const float Height = 300;
+	const float Width = Height*Graphics()->ScreenAspect();
+
+	Graphics()->MapScreen(0, 0, Width, Height);
+
+	CTextCursor Cursor;
+	TextRender()->SetCursor(&Cursor, m_BroadcastRenderOffset, 40.0f, 12.0f, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
+	Cursor.m_LineWidth = Width - m_BroadcastRenderOffset;
+	TextRender()->TextEx(&Cursor, m_aBroadcastText, -1);
+}
+
 CBroadcast::CBroadcast()
 {
 	OnReset();
 }
 
-void CBroadcast::DoBroadcast(const char *pText)
+void CBroadcast::DoClientBroadcast(const char *pText)
 {
 	str_copy(m_aBroadcastText, pText, sizeof(m_aBroadcastText));
 	CTextCursor Cursor;
@@ -254,170 +269,176 @@ void CBroadcast::OnReset()
 {
 	m_BroadcastTime = 0;
 	m_SrvBroadcastReceivedTime = 0;
+	m_MuteServerBroadcast = false;
 }
 
 void CBroadcast::OnMessage(int MsgType, void* pRawMsg)
 {
 	// process server broadcast message
-	if(MsgType == NETMSGTYPE_SV_BROADCAST && Config()->m_ClShowServerBroadcast &&
-	   !m_pClient->m_MuteServerBroadcast)
+	if(MsgType == NETMSGTYPE_SV_BROADCAST)
 	{
-		CNetMsg_Sv_Broadcast *pMsg = (CNetMsg_Sv_Broadcast *)pRawMsg;
+		OnBroadcastMessage((CNetMsg_Sv_Broadcast *)pRawMsg);
+	}
+}
 
-		// new broadcast message
-		int RcvMsgLen = str_length(pMsg->m_pMessage);
-		mem_zero(m_aSrvBroadcastMsg, sizeof(m_aSrvBroadcastMsg));
-		m_aSrvBroadcastMsgLen = 0;
-		m_SrvBroadcastReceivedTime = Client()->LocalTime();
+void CBroadcast::OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg)
+{
+	if(!Config()->m_ClShowServerBroadcast || m_MuteServerBroadcast)
+		return;
 
-		const CBcColor White = { 255, 255, 255, 0 };
-		m_aSrvBroadcastColorList[0] = White;
-		m_SrvBroadcastColorCount = 1;
+	// new broadcast message
+	const int RcvMsgLen = str_length(pMsg->m_pMessage);
+	mem_zero(m_aSrvBroadcastMsg, sizeof(m_aSrvBroadcastMsg));
+	m_aSrvBroadcastMsgLen = 0;
+	m_SrvBroadcastReceivedTime = Client()->LocalTime();
 
-		CBcLineInfo UserLines[MAX_BROADCAST_LINES];
-		int UserLineCount = 0;
-		int LastUserLineStartPoint = 0;
+	const CBcColor White = { 255, 255, 255, 0 };
+	m_aSrvBroadcastColorList[0] = White;
+	m_SrvBroadcastColorCount = 1;
 
-		// parse colors
-		for(int i = 0; i < RcvMsgLen; i++)
+	CBcLineInfo UserLines[MAX_BROADCAST_LINES];
+	int UserLineCount = 0;
+	int LastUserLineStartPoint = 0;
+
+	// parse colors
+	for(int i = 0; i < RcvMsgLen; i++)
+	{
+		const char* c = pMsg->m_pMessage + i;
+		const char* pTmp = c;
+		int CharUtf8 = str_utf8_decode(&pTmp);
+		const int Utf8Len = pTmp-c;
+
+		if(*c == CharUtf8 && *c == '^')
 		{
-			const char* c = pMsg->m_pMessage + i;
-			const char* pTmp = c;
-			int CharUtf8 = str_utf8_decode(&pTmp);
-			const int Utf8Len = pTmp-c;
-
-			if(*c == CharUtf8 && *c == '^')
+			if(i+3 < RcvMsgLen && IsCharANum(c[1]) && IsCharANum(c[2])  && IsCharANum(c[3]))
 			{
-				if(i+3 < RcvMsgLen && IsCharANum(c[1]) && IsCharANum(c[2])  && IsCharANum(c[3]))
-				{
-					u8 r = (c[1] - '0') * 24 + 39;
-					u8 g = (c[2] - '0') * 24 + 39;
-					u8 b = (c[3] - '0') * 24 + 39;
-					CBcColor Color = { r, g, b, m_aSrvBroadcastMsgLen };
-					if(m_SrvBroadcastColorCount < MAX_BROADCAST_COLORS)
-						m_aSrvBroadcastColorList[m_SrvBroadcastColorCount++] = Color;
-					i += 3;
-					continue;
-				}
+				u8 r = (c[1] - '0') * 24 + 39;
+				u8 g = (c[2] - '0') * 24 + 39;
+				u8 b = (c[3] - '0') * 24 + 39;
+				CBcColor Color = { r, g, b, m_aSrvBroadcastMsgLen };
+				if(m_SrvBroadcastColorCount < MAX_BROADCAST_COLORS)
+					m_aSrvBroadcastColorList[m_SrvBroadcastColorCount++] = Color;
+				i += 3;
+				continue;
 			}
+		}
 
-			if(*c == CharUtf8 && *c == '\\')
-			{
-				if(i+1 < RcvMsgLen && c[1] == 'n' && UserLineCount < MAX_BROADCAST_LINES)
-				{
-					CBcLineInfo Line = { m_aSrvBroadcastMsg+LastUserLineStartPoint,
-										 m_aSrvBroadcastMsgLen-LastUserLineStartPoint, 0 };
-					if(Line.m_StrLen > 0)
-						UserLines[UserLineCount++] = Line;
-					LastUserLineStartPoint = m_aSrvBroadcastMsgLen;
-					i++;
-					continue;
-				}
-			}
-
-			if(*c == '\n')
+		if(*c == CharUtf8 && *c == '\\')
+		{
+			if(i+1 < RcvMsgLen && c[1] == 'n' && UserLineCount < MAX_BROADCAST_LINES)
 			{
 				CBcLineInfo Line = { m_aSrvBroadcastMsg+LastUserLineStartPoint,
 									 m_aSrvBroadcastMsgLen-LastUserLineStartPoint, 0 };
 				if(Line.m_StrLen > 0)
 					UserLines[UserLineCount++] = Line;
 				LastUserLineStartPoint = m_aSrvBroadcastMsgLen;
+				i++;
 				continue;
 			}
-
-			if(m_aSrvBroadcastMsgLen+Utf8Len < MAX_BROADCAST_MSG_LENGTH)
-				m_aSrvBroadcastMsg[m_aSrvBroadcastMsgLen++] = *c;
 		}
 
-		// last user defined line
-		if(LastUserLineStartPoint > 0 && UserLineCount < 3)
+		if(*c == '\n')
 		{
 			CBcLineInfo Line = { m_aSrvBroadcastMsg+LastUserLineStartPoint,
 								 m_aSrvBroadcastMsgLen-LastUserLineStartPoint, 0 };
 			if(Line.m_StrLen > 0)
 				UserLines[UserLineCount++] = Line;
+			LastUserLineStartPoint = m_aSrvBroadcastMsgLen;
+			continue;
 		}
 
-		const float Height = 300;
-		const float Width = Height*Graphics()->ScreenAspect();
-		const float LineMaxWidth = Width * 0.5f - 10.0f;
-
-		// process boradcast message
-		const char* pBroadcastMsg = m_aSrvBroadcastMsg;
-		const int MsgLen = m_aSrvBroadcastMsgLen;
-
-		CTextCursor Cursor;
-		Graphics()->MapScreen(0, 0, Width, Height);
-
-		// one line == big font
-		// 2+ lines == small font
-		m_SrvBroadcastLineCount = 0;
-		float FontSize = BROADCAST_FONTSIZE_BIG;
-
-		if(UserLineCount <= 1) // auto mode
-		{
-			TextRender()->SetCursor(&Cursor, 0, 0, FontSize, 0);
-			Cursor.m_LineWidth = LineMaxWidth;
-			TextRender()->TextEx(&Cursor, pBroadcastMsg, MsgLen);
-
-			// can't fit on one line, reduce size
-			Cursor.m_LineCount = min(Cursor.m_LineCount, (int)MAX_BROADCAST_LINES);
-			FontSize = mix(BROADCAST_FONTSIZE_BIG, BROADCAST_FONTSIZE_SMALL,
-						   Cursor.m_LineCount/(float)MAX_BROADCAST_LINES);
-
-			// make lines
-			int CurCharCount = 0;
-			while(CurCharCount < MsgLen && m_SrvBroadcastLineCount < MAX_BROADCAST_LINES)
-			{
-				const char* RemainingMsg = pBroadcastMsg + CurCharCount;
-
-				TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_STOP_AT_END);
-				Cursor.m_LineWidth = LineMaxWidth;
-
-				TextRender()->TextEx(&Cursor, RemainingMsg, -1);
-				int StrLen = Cursor.m_CharCount;
-
-				// don't cut words
-				if(CurCharCount + StrLen < MsgLen)
-				{
-					const int WorldLen = WordLengthBack(RemainingMsg + StrLen, StrLen);
-					if(WorldLen > 0 && WorldLen < StrLen)
-					{
-						StrLen -= WorldLen;
-						TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_STOP_AT_END);
-						Cursor.m_LineWidth = LineMaxWidth;
-						TextRender()->TextEx(&Cursor, RemainingMsg, StrLen);
-					}
-				}
-
-				const float TextWidth = Cursor.m_X-Cursor.m_StartX;
-
-				CBcLineInfo Line = { RemainingMsg, StrLen, TextWidth };
-				m_aSrvBroadcastLines[m_SrvBroadcastLineCount++] = Line;
-				CurCharCount += StrLen;
-			}
-		}
-		else // user defined lines mode
-		{
-			FontSize = mix(BROADCAST_FONTSIZE_BIG, BROADCAST_FONTSIZE_SMALL,
-						   UserLineCount/(float)MAX_BROADCAST_LINES);
-
-			for(int i = 0; i < UserLineCount && m_SrvBroadcastLineCount < MAX_BROADCAST_LINES; i++)
-			{
-				TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_STOP_AT_END);
-				Cursor.m_LineWidth = LineMaxWidth;
-				TextRender()->TextEx(&Cursor, UserLines[i].m_pStrStart, UserLines[i].m_StrLen);
-
-				const float TextWidth = Cursor.m_X-Cursor.m_StartX;
-				const int StrLen = Cursor.m_CharCount;
-
-				CBcLineInfo Line = { UserLines[i].m_pStrStart, StrLen, TextWidth };
-				m_aSrvBroadcastLines[m_SrvBroadcastLineCount++] = Line;
-			}
-		}
-
-		m_SrvBroadcastFontSize = FontSize;
+		if(m_aSrvBroadcastMsgLen+Utf8Len < MAX_BROADCAST_MSG_LENGTH)
+			m_aSrvBroadcastMsg[m_aSrvBroadcastMsgLen++] = *c;
 	}
+
+	// last user defined line
+	if(LastUserLineStartPoint > 0 && UserLineCount < 3)
+	{
+		CBcLineInfo Line = { m_aSrvBroadcastMsg+LastUserLineStartPoint,
+							 m_aSrvBroadcastMsgLen-LastUserLineStartPoint, 0 };
+		if(Line.m_StrLen > 0)
+			UserLines[UserLineCount++] = Line;
+	}
+
+	const float Height = 300;
+	const float Width = Height*Graphics()->ScreenAspect();
+	const float LineMaxWidth = Width * 0.5f - 10.0f;
+
+	// process broadcast message
+	const char* pBroadcastMsg = m_aSrvBroadcastMsg;
+	const int MsgLen = m_aSrvBroadcastMsgLen;
+
+	CTextCursor Cursor;
+	Graphics()->MapScreen(0, 0, Width, Height);
+
+	// one line == big font
+	// 2+ lines == small font
+	m_SrvBroadcastLineCount = 0;
+	float FontSize = BROADCAST_FONTSIZE_BIG;
+
+	if(UserLineCount <= 1) // auto mode
+	{
+		TextRender()->SetCursor(&Cursor, 0, 0, FontSize, 0);
+		Cursor.m_LineWidth = LineMaxWidth;
+		TextRender()->TextEx(&Cursor, pBroadcastMsg, MsgLen);
+
+		// can't fit on one line, reduce size
+		Cursor.m_LineCount = min(Cursor.m_LineCount, (int)MAX_BROADCAST_LINES);
+		FontSize = mix(BROADCAST_FONTSIZE_BIG, BROADCAST_FONTSIZE_SMALL,
+					   Cursor.m_LineCount/(float)MAX_BROADCAST_LINES);
+
+		// make lines
+		int CurCharCount = 0;
+		while(CurCharCount < MsgLen && m_SrvBroadcastLineCount < MAX_BROADCAST_LINES)
+		{
+			const char* RemainingMsg = pBroadcastMsg + CurCharCount;
+
+			TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_STOP_AT_END);
+			Cursor.m_LineWidth = LineMaxWidth;
+
+			TextRender()->TextEx(&Cursor, RemainingMsg, -1);
+			int StrLen = Cursor.m_CharCount;
+
+			// don't cut words
+			if(CurCharCount + StrLen < MsgLen)
+			{
+				const int WorldLen = WordLengthBack(RemainingMsg + StrLen, StrLen);
+				if(WorldLen > 0 && WorldLen < StrLen)
+				{
+					StrLen -= WorldLen;
+					TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_STOP_AT_END);
+					Cursor.m_LineWidth = LineMaxWidth;
+					TextRender()->TextEx(&Cursor, RemainingMsg, StrLen);
+				}
+			}
+
+			const float TextWidth = Cursor.m_X-Cursor.m_StartX;
+
+			CBcLineInfo Line = { RemainingMsg, StrLen, TextWidth };
+			m_aSrvBroadcastLines[m_SrvBroadcastLineCount++] = Line;
+			CurCharCount += StrLen;
+		}
+	}
+	else // user defined lines mode
+	{
+		FontSize = mix(BROADCAST_FONTSIZE_BIG, BROADCAST_FONTSIZE_SMALL,
+					   UserLineCount/(float)MAX_BROADCAST_LINES);
+
+		for(int i = 0; i < UserLineCount && m_SrvBroadcastLineCount < MAX_BROADCAST_LINES; i++)
+		{
+			TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_STOP_AT_END);
+			Cursor.m_LineWidth = LineMaxWidth;
+			TextRender()->TextEx(&Cursor, UserLines[i].m_pStrStart, UserLines[i].m_StrLen);
+
+			const float TextWidth = Cursor.m_X-Cursor.m_StartX;
+			const int StrLen = Cursor.m_CharCount;
+
+			CBcLineInfo Line = { UserLines[i].m_pStrStart, StrLen, TextWidth };
+			m_aSrvBroadcastLines[m_SrvBroadcastLineCount++] = Line;
+		}
+	}
+
+	m_SrvBroadcastFontSize = FontSize;
 }
 
 void CBroadcast::OnRender()
@@ -425,21 +446,6 @@ void CBroadcast::OnRender()
 	if(Client()->State() < IClient::STATE_ONLINE)
 		return;
 
-	// server broadcast
 	RenderServerBroadcast();
-
-	// client broadcast
-	if(m_pClient->m_pScoreboard->IsActive() || m_pClient->m_pMotd->IsActive())
-		return;
-
-	Graphics()->MapScreen(0, 0, 300*Graphics()->ScreenAspect(), 300);
-
-	if(Client()->LocalTime() < m_BroadcastTime)
-	{
-		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, m_BroadcastRenderOffset, 40.0f, 12.0f, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
-		Cursor.m_LineWidth = 300*Graphics()->ScreenAspect()-m_BroadcastRenderOffset;
-		TextRender()->TextEx(&Cursor, m_aBroadcastText, -1);
-	}
+	RenderClientBroadcast();
 }
-

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -58,18 +58,18 @@ void CBroadcast::RenderServerBroadcast()
 	Graphics()->MapScreen(0, 0, Width, Height);
 
 	const float Fade = 1.0f - max(0.0f, (DeltaTime - DisplayStartFade) / (DisplayDuration - DisplayStartFade));
+	const float FontSize = m_SrvBroadcastFontSize;
+	const int LineCount = m_SrvBroadcastLineCount;
 
-	CUIRect ScreenRect = {0, 0, Width, Height};
-
-	CUIRect BcView = ScreenRect;
-	BcView.x += Width * 0.25f;
-	BcView.y += Height * 0.8f;
-	BcView.w *= 0.5f;
-	BcView.h *= 0.2f;
+	CUIRect BcView;
+	BcView.w = Width * 0.5f;
+	BcView.h = 1.5f * LineCount * FontSize + 4.0f;
+	BcView.x = BcView.w * 0.5f;
+	BcView.y = Height - BcView.h;
 
 	CUIRect BgRect;
-	BcView.HSplitBottom(10.0f, 0, &BgRect);
-	BcView.HSplitBottom(6.0f, &BcView, 0);
+	BcView.HSplitBottom(1.5f * LineCount * FontSize, 0, &BgRect);
+	BcView.HSplitBottom(2.0f, &BcView, 0);
 
 	// draw bottom bar
 	const float CornerWidth = 10.0f;
@@ -126,7 +126,7 @@ void CBroadcast::RenderServerBroadcast()
 
 	IGraphics::CColorVertex aColorVert[4] = {
 		IGraphics::CColorVertex(0, 0, 0, 0, 0.0f),
-		IGraphics::CColorVertex(1, 0, 0, 0, 0.4f * Fade),
+		IGraphics::CColorVertex(1, 0, 0, 0, 0.7f * Fade),
 		IGraphics::CColorVertex(2, 0, 0, 0, 0.0f),
 		IGraphics::CColorVertex(3, 0, 0, 0, 0.0f)
 	};
@@ -138,9 +138,9 @@ void CBroadcast::RenderServerBroadcast()
 	Graphics()->QuadsEnd();
 
 	{
-		vec4 ColorTop(0, 0, 0, 0);
-		vec4 ColorBot(0, 0, 0, 0.4f * Fade);
-		RenderTools()->DrawUIRect4(&BgRect, ColorTop, ColorTop, ColorBot, ColorBot, 0, 0);
+		vec4 ColorTop(0, 0, 0, 0.01f * Fade);
+		vec4 ColorBot(0, 0, 0, 0.7f * Fade);
+		RenderTools()->DrawUIRect4(&BgRect, ColorTop, ColorTop, ColorBot, ColorBot, 0, 0.0f);
 	}
 
 	BcView.VMargin(5.0f, &BcView);
@@ -148,8 +148,6 @@ void CBroadcast::RenderServerBroadcast()
 
 	// draw lines
 	const bool ColoredBroadcastEnabled = Config()->m_ClColoredBroadcast;
-	const float FontSize = m_SrvBroadcastFontSize;
-	const int LineCount = m_SrvBroadcastLineCount;
 
 	const vec2 ShadowOff(1.0f, 2.0f);
 	const vec4 ShadowColorBlack(0, 0, 0, 0.9f * Fade);

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -6,9 +6,12 @@
 
 class CBroadcast : public CComponent
 {
+	// client broadcast
 	char m_aBroadcastText[128];
 	float m_BroadcastTime;
 	float m_BroadcastRenderOffset;
+
+	void RenderClientBroadcast();
 
 	// server broadcast
 	typedef unsigned char u8;
@@ -39,13 +42,18 @@ class CBroadcast : public CComponent
 	int m_SrvBroadcastLineCount;
 	float m_SrvBroadcastReceivedTime;
 	float m_SrvBroadcastFontSize;
+	bool m_MuteServerBroadcast;
 
+	void OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg);
 	void RenderServerBroadcast();
 
 public:
 	CBroadcast();
 
-	void DoBroadcast(const char *pText);
+	void DoClientBroadcast(const char *pText);
+
+	void ToggleMuteServerBroadcast() { m_MuteServerBroadcast = !m_MuteServerBroadcast; };
+	bool IsMuteServerBroadcast() const { return m_MuteServerBroadcast; };
 
 	virtual void OnReset();
 	virtual void OnMessage(int MsgType, void *pRawMsg);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -22,6 +22,7 @@
 #include "menus.h"
 #include "motd.h"
 #include "voting.h"
+#include "broadcast.h"
 
 void CMenus::GetSwitchTeamInfo(CSwitchTeamInfo *pInfo)
 {
@@ -416,10 +417,9 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 		CUIRect Button;
 		ServerInfo.HSplitBottom(20.0f, &ServerInfo, &Button);
 		static int s_MuteBroadcast = 0;
-		if(DoButton_CheckBox(&s_MuteBroadcast, Localize("Mute broadcasts"),
-							 m_pClient->m_MuteServerBroadcast, &Button))
+		if(DoButton_CheckBox(&s_MuteBroadcast, Localize("Mute broadcasts"), m_pClient->m_pBroadcast->IsMuteServerBroadcast(), &Button))
 		{
-			m_pClient->m_MuteServerBroadcast ^= 1;
+			m_pClient->m_pBroadcast->ToggleMuteServerBroadcast();
 		}
 	}
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -495,7 +495,6 @@ void CGameClient::OnReset()
 		m_DemoSpecMode = SPEC_FREEVIEW;
 		m_DemoSpecID = -1;
 		m_Tuning = CTuningParams();
-		m_MuteServerBroadcast = false;
 		m_LastGameStartTick = -1;
 		m_LastFlagCarrierRed = FLAG_MISSING;
 		m_LastFlagCarrierBlue = FLAG_MISSING;
@@ -708,7 +707,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 				break;
 			case GAMEMSG_TEAM_ALL:
 				{
-					const char *pMsg;
+					const char *pMsg = "";
 					switch(GetStrTeam(aParaI[0], TeamPlay))
 					{
 					case STR_TEAM_GAME: pMsg = Localize("All players were moved to the game"); break;
@@ -716,7 +715,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 					case STR_TEAM_BLUE: pMsg = Localize("All players were moved to the blue team"); break;
 					case STR_TEAM_SPECTATORS: pMsg = Localize("All players were moved to the spectators"); break;
 					}
-					m_pBroadcast->DoBroadcast(pMsg);
+					m_pBroadcast->DoClientBroadcast(pMsg);
 				}
 				break;
 			case GAMEMSG_TEAM_BALANCE_VICTIM:
@@ -727,7 +726,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 					case STR_TEAM_RED: pMsg = Localize("You were moved to the red team due to team balancing"); break;
 					case STR_TEAM_BLUE: pMsg = Localize("You were moved to the blue team due to team balancing"); break;
 					}
-					m_pBroadcast->DoBroadcast(pMsg);
+					m_pBroadcast->DoClientBroadcast(pMsg);
 				}
 				break;
 			case GAMEMSG_CTF_GRAB:
@@ -797,7 +796,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 			m_pChat->AddLine(pText);
 			break;
 		case DO_BROADCAST:
-			m_pBroadcast->DoBroadcast(pText);
+			m_pBroadcast->DoClientBroadcast(pText);
 			break;
 		}
 	}

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -228,7 +228,6 @@ public:
 	CClientData m_aClients[MAX_CLIENTS];
 	int m_LocalClientID;
 	int m_TeamCooldownTick;
-	bool m_MuteServerBroadcast;
 	float m_TeamChangeTime;
 	bool m_IsXmasDay;
 	float m_LastSkinChangeTime;


### PR DESCRIPTION
- Increase size of backdrop to cover the text and slightly increase alpha values (closes #2753), decrease margin below the broadcast:
  
  - ![screenshot_2020-10-03_15-31-25](https://user-images.githubusercontent.com/23437060/94993127-0fe41480-058f-11eb-8d80-770fdf8216c8.png)
  - ![screenshot_2020-10-03_15-31-21](https://user-images.githubusercontent.com/23437060/94993128-11154180-058f-11eb-91c1-21e1114ab092.png)
  - ![screenshot_2020-10-03_15-31-17](https://user-images.githubusercontent.com/23437060/94993129-12466e80-058f-11eb-8f12-85c15cc6d560.png)

- Enable colored broadcasts per default.
- Refactor CBroadcast:
  - Improve distinction between client and server broadcast by renaming and extracting methods.
  - Move `m_MuteServerBroadcast` flag from CGameclient to CBroadcast.

