### PR TITLE
Fix animations not being paused when world is paused in demo, refactoring

### DIFF
--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -11,7 +11,7 @@ class CDamageInd : public CComponent
 	{
 		vec2 m_Pos;
 		vec2 m_Dir;
-		float m_StartTime;
+		float m_LifeTime;
 		float m_StartAngle;
 	};
 

--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -23,13 +23,14 @@ class CDamageInd : public CComponent
 	CItem m_aItems[MAX_ITEMS];
 	int m_NumItems;
 
-	CItem *CreateI();
-	void DestroyI(CItem *i);
+	CItem *CreateItem();
+	void DestroyItem(CItem *pItem);
 
 public:
 	CDamageInd();
 
 	void Create(vec2 Pos, vec2 Dir);
+
 	virtual void OnRender();
 	virtual void OnReset();
 };

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -67,23 +67,24 @@ void CItems::RenderProjectile(const CNetObj_Projectile *pCurrent, int ItemID)
 	if(pCurrent->m_Type == WEAPON_GRENADE)
 	{
 		m_pClient->m_pEffects->SmokeTrail(Pos, Vel*-1);
+		const float Now = Client()->LocalTime();
 		static float s_Time = 0.0f;
-		static float s_LastLocalTime = Client()->LocalTime();
+		static float s_LastLocalTime = Now;
 
 		if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 		{
 			const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
-			if(!pInfo->m_Paused)
-				s_Time += (Client()->LocalTime()-s_LastLocalTime)*pInfo->m_Speed;
+			if(!pInfo->m_Paused && !m_pClient->IsWorldPaused())
+				s_Time += (Now-s_LastLocalTime)*pInfo->m_Speed;
 		}
 		else
 		{
 			if(!m_pClient->IsWorldPaused())
-				s_Time += Client()->LocalTime()-s_LastLocalTime;
+				s_Time += Now-s_LastLocalTime;
 		}
 
 		Graphics()->QuadsSetRotation(s_Time*pi*2*2 + ItemID);
-		s_LastLocalTime = Client()->LocalTime();
+		s_LastLocalTime = Now;
 	}
 	else
 	{
@@ -148,23 +149,24 @@ void CItems::RenderPickup(const CNetObj_Pickup *pPrev, const CNetObj_Pickup *pCu
 
 	Graphics()->QuadsSetRotation(Angle);
 
+	const float Now = Client()->LocalTime();
 	static float s_Time = 0.0f;
-	static float s_LastLocalTime = Client()->LocalTime();
+	static float s_LastLocalTime = Now;
 	float Offset = Pos.y/32.0f + Pos.x/32.0f;
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
 		const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
-		if(!pInfo->m_Paused)
-			s_Time += (Client()->LocalTime()-s_LastLocalTime)*pInfo->m_Speed;
+		if(!pInfo->m_Paused && !m_pClient->IsWorldPaused())
+			s_Time += (Now-s_LastLocalTime)*pInfo->m_Speed;
 	}
 	else
 	{
 		if(!m_pClient->IsWorldPaused())
-			s_Time += Client()->LocalTime()-s_LastLocalTime;
+			s_Time += Now-s_LastLocalTime;
  	}
 	Pos.x += cosf(s_Time*2.0f+Offset)*2.5f;
 	Pos.y += sinf(s_Time*2.0f+Offset)*2.5f;
-	s_LastLocalTime = Client()->LocalTime();
+	s_LastLocalTime = Now;
 	RenderTools()->DrawSprite(Pos.x, Pos.y, Size);
 	Graphics()->QuadsEnd();
 }

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -38,7 +38,7 @@ void CItems::RenderProjectile(const CNetObj_Projectile *pCurrent, int ItemID)
 	}
 
 	static float s_LastGameTickTime = Client()->GameTickTime();
-	if(!m_pClient->IsWorldPaused())
+	if(!m_pClient->IsWorldPaused() && !m_pClient->IsDemoPlaybackPaused())
 		s_LastGameTickTime = Client()->GameTickTime();
 	
 	float Ct;
@@ -70,19 +70,7 @@ void CItems::RenderProjectile(const CNetObj_Projectile *pCurrent, int ItemID)
 		const float Now = Client()->LocalTime();
 		static float s_Time = 0.0f;
 		static float s_LastLocalTime = Now;
-
-		if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
-		{
-			const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
-			if(!pInfo->m_Paused && !m_pClient->IsWorldPaused())
-				s_Time += (Now-s_LastLocalTime)*pInfo->m_Speed;
-		}
-		else
-		{
-			if(!m_pClient->IsWorldPaused())
-				s_Time += Now-s_LastLocalTime;
-		}
-
+		s_Time += (Now - s_LastLocalTime) * m_pClient->GetAnimationPlaybackSpeed();
 		Graphics()->QuadsSetRotation(s_Time*pi*2*2 + ItemID);
 		s_LastLocalTime = Now;
 	}
@@ -152,18 +140,8 @@ void CItems::RenderPickup(const CNetObj_Pickup *pPrev, const CNetObj_Pickup *pCu
 	const float Now = Client()->LocalTime();
 	static float s_Time = 0.0f;
 	static float s_LastLocalTime = Now;
-	float Offset = Pos.y/32.0f + Pos.x/32.0f;
-	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
-	{
-		const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
-		if(!pInfo->m_Paused && !m_pClient->IsWorldPaused())
-			s_Time += (Now-s_LastLocalTime)*pInfo->m_Speed;
-	}
-	else
-	{
-		if(!m_pClient->IsWorldPaused())
-			s_Time += Now-s_LastLocalTime;
- 	}
+	s_Time += (Now - s_LastLocalTime) * m_pClient->GetAnimationPlaybackSpeed();
+	const float Offset = Pos.y/32.0f + Pos.x/32.0f;
 	Pos.x += cosf(s_Time*2.0f+Offset)*2.5f;
 	Pos.y += sinf(s_Time*2.0f+Offset)*2.5f;
 	s_LastLocalTime = Now;

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -22,8 +22,6 @@
 CMapLayers::CMapLayers(int Type)
 {
 	m_Type = Type;
-	m_CurrentLocalTick = 0;
-	m_LastLocalTick = 0;
 	m_pMenuMap = 0;
 	m_pMenuLayers = 0;
 	m_OnlineStartTime = 0;
@@ -192,16 +190,6 @@ void CMapLayers::LoadEnvPoints(const CLayers *pLayers, array<CEnvPoint>& lEnvPoi
 	}
 }
 
-void CMapLayers::EnvelopeUpdate()
-{
-	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
-	{
-		const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
-		m_CurrentLocalTick = pInfo->m_CurrentTick;
-		m_LastLocalTick = pInfo->m_CurrentTick;
-	}
-}
-
 void CMapLayers::EnvelopeEval(float TimeOffset, int Env, float *pChannels, void *pUser)
 {
 	CMapLayers *pThis = (CMapLayers *)pUser;
@@ -230,23 +218,8 @@ void CMapLayers::EnvelopeEval(float TimeOffset, int Env, float *pChannels, void 
 		return;
 
 	const CMapItemEnvelope *pItem = (CMapItemEnvelope *)pLayers->Map()->GetItem(Start+Env, 0, 0);
-	const float TickSpeed = (float)pThis->Client()->GameTickSpeed();
 	static float s_Time = 0.0f;
-	if(pThis->Client()->State() == IClient::STATE_DEMOPLAYBACK)
-	{
-		const IDemoPlayer::CInfo *pInfo = pThis->DemoPlayer()->BaseInfo();
-		if(pThis->m_CurrentLocalTick != pInfo->m_CurrentTick)
-		{
-			pThis->m_LastLocalTick = pThis->m_CurrentLocalTick;
-			pThis->m_CurrentLocalTick = pInfo->m_CurrentTick;
-		}
-
-		s_Time = mix(
-			pThis->m_LastLocalTick - pInfo->m_FirstTick,
-			pThis->m_CurrentLocalTick - pInfo->m_FirstTick,
-			pThis->Client()->IntraGameTick()) / TickSpeed;
-	}
-	else if(pThis->Client()->State() == IClient::STATE_ONLINE)
+	if(pThis->Client()->State() == IClient::STATE_ONLINE || pThis->Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
 		if(pThis->m_pClient->m_Snap.m_pGameData && !pThis->m_pClient->IsWorldPaused())
 		{
@@ -255,7 +228,7 @@ void CMapLayers::EnvelopeEval(float TimeOffset, int Env, float *pChannels, void 
 				s_Time = mix(
 					pThis->Client()->PrevGameTick() - pThis->m_pClient->m_Snap.m_pGameData->m_GameStartTick,
 					pThis->Client()->GameTick() - pThis->m_pClient->m_Snap.m_pGameData->m_GameStartTick,
-					pThis->Client()->IntraGameTick()) / TickSpeed;
+					pThis->Client()->IntraGameTick()) / (float)pThis->Client()->GameTickSpeed();
 			}
 			else
 				s_Time = pThis->Client()->LocalTime() - pThis->m_OnlineStartTime;
@@ -265,7 +238,7 @@ void CMapLayers::EnvelopeEval(float TimeOffset, int Env, float *pChannels, void 
 	{
 		s_Time = pThis->Client()->LocalTime();
 	}
-	CRenderTools::RenderEvalEnvelope(pPoints + pItem->m_StartPoint, pItem->m_NumPoints, 4, s_Time+TimeOffset, pChannels);
+	CRenderTools::RenderEvalEnvelope(pPoints + pItem->m_StartPoint, pItem->m_NumPoints, 4, s_Time + TimeOffset, pChannels);
 }
 
 void CMapLayers::OnRender()

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -11,8 +11,6 @@ class CMapLayers : public CComponent
 	IEngineMap *m_pMenuMap;
 
 	int m_Type;
-	int m_CurrentLocalTick;
-	int m_LastLocalTick;
 	float m_OnlineStartTime;
 
 	array<CEnvPoint> m_lEnvPoints;
@@ -43,8 +41,6 @@ public:
 	virtual void OnShutdown();
 	virtual void OnRender();
 	virtual void OnMapLoad();
-
-	void EnvelopeUpdate();
 
 	static void ConchainBackgroundMap(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -344,8 +344,6 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		m_pClient->m_SuppressEvents = true;
 		DemoPlayer()->SetPos(PositionToSeek);
 		m_pClient->m_SuppressEvents = false;
-		m_pClient->m_pMapLayersBackGround->EnvelopeUpdate();
-		m_pClient->m_pMapLayersForeGround->EnvelopeUpdate();
 	}
 }
 

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -37,18 +37,8 @@ void CParticles::OnReset()
 
 void CParticles::Add(int Group, CParticle *pPart)
 {
-	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
-	{
-		const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
-		if(pInfo->m_Paused || m_pClient->IsWorldPaused())
-			return;
-	}
-	else
-	{
-		if(m_pClient->IsWorldPaused())
-			return;
-	}
-
+	if(m_pClient->IsWorldPaused() || m_pClient->IsDemoPlaybackPaused())
+		return;
 	if (m_FirstFree == -1)
 		return;
 
@@ -74,17 +64,20 @@ void CParticles::Add(int Group, CParticle *pPart)
 
 void CParticles::Update(float TimePassed)
 {
-	static float FrictionFraction = 0;
-	FrictionFraction += TimePassed;
+	if(TimePassed <= 0.0f)
+		return;
 
-	if(FrictionFraction > 2.0f) // safty messure
-		FrictionFraction = 0;
+	static float s_FrictionFraction = 0.0f;
+	s_FrictionFraction += TimePassed;
+
+	if(s_FrictionFraction > 2.0f) // safety messure
+		s_FrictionFraction = 0.0f;
 
 	int FrictionCount = 0;
-	while(FrictionFraction > 0.05f)
+	while(s_FrictionFraction > 0.05f)
 	{
 		FrictionCount++;
-		FrictionFraction -= 0.05f;
+		s_FrictionFraction -= 0.05f;
 	}
 
 	for(int g = 0; g < NUM_GROUPS; g++)
@@ -137,21 +130,9 @@ void CParticles::OnRender()
 	if(Client()->State() < IClient::STATE_ONLINE)
 		return;
 
-	static int64 s_LastTime = 0;
 	int64 Now = time_get();
-
-	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
-	{
-		const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
-		if(!pInfo->m_Paused && !m_pClient->IsWorldPaused())
-			Update((float)((Now-s_LastTime)/(double)time_freq())*pInfo->m_Speed);
-	}
-	else
-	{
-		if(!m_pClient->IsWorldPaused())
-			Update((float)((Now-s_LastTime)/(double)time_freq()));
-	}
-
+	static int64 s_LastTime = Now;
+	Update((float)((Now-s_LastTime)/(double)time_freq()) * m_pClient->GetAnimationPlaybackSpeed());
 	s_LastTime = Now;
 }
 

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -40,7 +40,7 @@ void CParticles::Add(int Group, CParticle *pPart)
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
 		const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
-		if(pInfo->m_Paused)
+		if(pInfo->m_Paused || m_pClient->IsWorldPaused())
 			return;
 	}
 	else
@@ -143,7 +143,7 @@ void CParticles::OnRender()
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
 		const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
-		if(!pInfo->m_Paused)
+		if(!pInfo->m_Paused && !m_pClient->IsWorldPaused())
 			Update((float)((Now-s_LastTime)/(double)time_freq())*pInfo->m_Speed);
 	}
 	else

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -169,7 +169,7 @@ void CPlayers::RenderPlayer(
 	{
 		m_pClient->UsePredictedChar(&Prev, &Player, &IntraTick, ClientID);
 	}
-	const bool WorldPaused = m_pClient->IsWorldPaused();
+	const bool Paused = m_pClient->IsWorldPaused() || m_pClient->IsDemoPlaybackPaused();
 
 	vec2 Direction = direction(Angle);
 	vec2 Position = mix(vec2(Prev.m_X, Prev.m_Y), vec2(Player.m_X, Player.m_Y), IntraTick);
@@ -201,7 +201,7 @@ void CPlayers::RenderPlayer(
 		State.Add(&g_pData->m_aAnimations[ANIM_WALK], WalkTime, 1.0f);
 
 	static float s_LastGameTickTime = Client()->GameTickTime();
-	if(!WorldPaused)
+	if(!Paused)
 		s_LastGameTickTime = Client()->GameTickTime();
 	if (Player.m_Weapon == WEAPON_HAMMER)
 	{
@@ -283,21 +283,10 @@ void CPlayers::RenderPlayer(
 			{
 				int IteX = random_int() % g_pData->m_Weapons.m_aId[iw].m_NumSpriteMuzzles;
 				static int s_LastIteX = IteX;
-				if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
-				{
-					const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
-					if(pInfo->m_Paused)
-						IteX = s_LastIteX;
-					else
-						s_LastIteX = IteX;
-				}
+				if(Paused)
+					IteX = s_LastIteX;
 				else
-				{
-					if(WorldPaused)
-						IteX = s_LastIteX;
-					else
-						s_LastIteX = IteX;
-				}
+					s_LastIteX = IteX;
 				if(g_pData->m_Weapons.m_aId[iw].m_aSpriteMuzzles[IteX])
 				{
 					vec2 Dir = vec2(pPlayerChar->m_X,pPlayerChar->m_Y) - vec2(pPrevChar->m_X, pPrevChar->m_Y);
@@ -319,7 +308,7 @@ void CPlayers::RenderPlayer(
 			// TODO: should be an animation
 			Recoil = 0;
 			static float s_LastIntraTick = IntraTick;
-			if(!WorldPaused)
+			if(!Paused)
 				s_LastIntraTick = IntraTick;
 
 			float a = (Client()->GameTick()-Player.m_AttackTick+s_LastIntraTick)/5.0f;
@@ -345,21 +334,10 @@ void CPlayers::RenderPlayer(
 
 				int IteX = random_int() % g_pData->m_Weapons.m_aId[iw].m_NumSpriteMuzzles;
 				static int s_LastIteX = IteX;
-				if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
-				{
-					const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
-					if(pInfo->m_Paused)
-						IteX = s_LastIteX;
-					else
-						s_LastIteX = IteX;
-				}
+				if(Paused)
+					IteX = s_LastIteX;
 				else
-				{
-					if(WorldPaused)
-						IteX = s_LastIteX;
-					else
-						s_LastIteX = IteX;
-				}
+					s_LastIteX = IteX;
 				if (Alpha > 0.0f && g_pData->m_Weapons.m_aId[iw].m_aSpriteMuzzles[IteX])
 				{
 					float OffsetY = -g_pData->m_Weapons.m_aId[iw].m_Muzzleoffsety;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -134,6 +134,16 @@ const char *CGameClient::GetItemName(int Type) const { return m_NetObjHandler.Ge
 bool CGameClient::IsXmas() const { return Config()->m_ClShowXmasHats == 2 || (Config()->m_ClShowXmasHats == 1 && m_IsXmasDay); }
 bool CGameClient::IsEaster() const { return Config()->m_ClShowEasterEggs == 2 || (Config()->m_ClShowEasterEggs == 1 && m_IsEasterDay); }
 
+bool CGameClient::IsDemoPlaybackPaused() const { return Client()->State() == IClient::STATE_DEMOPLAYBACK && DemoPlayer()->BaseInfo()->m_Paused; }
+float CGameClient::GetAnimationPlaybackSpeed() const
+{
+	if(IsWorldPaused() || IsDemoPlaybackPaused())
+		return 0.0f;
+	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
+		return DemoPlayer()->BaseInfo()->m_Speed;
+	return 1.0f;
+}
+
 enum
 {
 	STR_TEAM_GAME,

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -297,6 +297,8 @@ public:
 	bool IsEaster() const;
 	int RacePrecision() const { return m_Snap.m_pGameDataRace ? m_Snap.m_pGameDataRace->m_Precision : 3; }
 	bool IsWorldPaused() const { return m_Snap.m_pGameData && (m_Snap.m_pGameData->m_GameStateFlags&(GAMESTATEFLAG_PAUSED|GAMESTATEFLAG_ROUNDOVER|GAMESTATEFLAG_GAMEOVER)); }
+	bool IsDemoPlaybackPaused() const;
+	float GetAnimationPlaybackSpeed() const;
 
 	//
 	void DoEnterMessage(const char *pName, int ClientID, int Team);


### PR DESCRIPTION
Closes #2751.

Demo player handling in `CMapLayers`, including the `EnvelopeUpdate` method, was actually obsolete, as the client ticks are properly synchronized with the demo playback.