### PR TITLE
Implement absolute joystick ingame input mode, improve labeled scrollbar option usability

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -222,6 +222,22 @@ bool CInput::JoystickRelative(float *pX, float *pY)
 	return false;
 }
 
+bool CInput::JoystickAbsolute(float *pX, float *pY)
+{
+	if(m_pConfig->m_JoystickEnable && GetActiveJoystick())
+	{
+		const vec2 RawJoystickPos = vec2(GetJoystickAxisValue(m_pConfig->m_JoystickX), GetJoystickAxisValue(m_pConfig->m_JoystickY));
+		const float DeadZone = m_pConfig->m_JoystickTolerance/50.0f;
+		if(length(RawJoystickPos) > DeadZone)
+		{
+			*pX = RawJoystickPos.x;
+			*pY = RawJoystickPos.y;
+			return true;
+		}
+	}
+	return false;
+}
+
 bool CInput::MouseRelative(float *pX, float *pY)
 {
 	if(!m_MouseInputRelative)
@@ -229,7 +245,7 @@ bool CInput::MouseRelative(float *pX, float *pY)
 
 	int MouseX = 0, MouseY = 0;
 	SDL_GetRelativeMouseState(&MouseX, &MouseY);
-	if (MouseX || MouseY)
+	if(MouseX || MouseY)
 	{
 		*pX = MouseX;
 		*pY = MouseY;

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -56,6 +56,7 @@ public:
 	int GetJoystickNumAxes();
 	float GetJoystickAxisValue(int Axis);
 	bool JoystickRelative(float *pX, float *pY);
+	bool JoystickAbsolute(float *pX, float *pY);
 
 	void MouseModeRelative();
 	void MouseModeAbsolute();

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -72,6 +72,7 @@ public:
 	virtual int GetJoystickNumAxes() = 0;
 	virtual float GetJoystickAxisValue(int Axis) = 0;
 	virtual bool JoystickRelative(float *pX, float *pY) = 0;
+	virtual bool JoystickAbsolute(float *pX, float *pY) = 0;
 
 	// mouse
 	virtual void MouseModeRelative() = 0;
@@ -85,9 +86,9 @@ public:
 
 	int CursorRelative(float *pX, float *pY)
 	{
-		if (MouseRelative(pX, pY))
+		if(MouseRelative(pX, pY))
 			return CURSOR_MOUSE;
-		if (JoystickRelative(pX, pY))
+		if(JoystickRelative(pX, pY))
 			return CURSOR_JOYSTICK;
 		return CURSOR_NONE;
 	}

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -75,6 +75,7 @@ MACRO_CONFIG_INT(InpMousesens, inp_mousesens, 100, 1, 100000, CFGFLAG_SAVE|CFGFL
 
 MACRO_CONFIG_INT(JoystickEnable , joystick_enable, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Enable joystick")
 MACRO_CONFIG_STR(JoystickGUID, joystick_guid, 34, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick GUID which uniquely identifies the active joystick")
+MACRO_CONFIG_INT(JoystickAbsolute, joystick_absolute, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Enable absolute joystick aiming ingame")
 MACRO_CONFIG_INT(JoystickSens, joystick_sens, 100, 1, 100000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick sensitivity")
 MACRO_CONFIG_INT(JoystickX, joystick_x, 0, 0, 12, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick axis that controls X axis of cursor")
 MACRO_CONFIG_INT(JoystickY, joystick_y, 1, 0, 12, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Joystick axis that controls Y axis of cursor")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -212,6 +212,17 @@ bool CControls::OnCursorMove(float x, float y, int CursorType)
 	if(m_pClient->IsWorldPaused() || (m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_pChat->IsActive()))
 		return false;
 
+	if(CursorType == IInput::CURSOR_JOYSTICK
+		&& Config()->m_JoystickAbsolute
+		&& m_pClient->m_Snap.m_pGameData
+		&& !m_pClient->m_Snap.m_SpecInfo.m_Active)
+	{
+		float absX = 0.0f, absY = 0.0f;
+		if(Input()->JoystickAbsolute(&absX, &absY))
+			m_MousePos = vec2(absX, absY) * GetMaxMouseDistance();
+		return true;
+	}
+
 	float Factor = 1.0f;
 	switch(CursorType)
 	{
@@ -236,17 +247,20 @@ void CControls::ClampMousePos()
 	}
 	else
 	{
-		float MouseMax;
-		if(Config()->m_ClDynamicCamera)
-		{
-			float CameraMaxDistance = 200.0f;
-			float FollowFactor = Config()->m_ClMouseFollowfactor/100.0f;
-			MouseMax = min(CameraMaxDistance/FollowFactor + Config()->m_ClMouseDeadzone, (float)Config()->m_ClMouseMaxDistanceDynamic);
-		}
-		else
-			MouseMax = (float)Config()->m_ClMouseMaxDistanceStatic;
-
+		const float MouseMax = GetMaxMouseDistance();
 		if(length(m_MousePos) > MouseMax)
 			m_MousePos = normalize(m_MousePos)*MouseMax;
 	}
+}
+
+float CControls::GetMaxMouseDistance() const
+{
+	if(Config()->m_ClDynamicCamera)
+	{
+		float CameraMaxDistance = 200.0f;
+		float FollowFactor = Config()->m_ClMouseFollowfactor/100.0f;
+		return min(CameraMaxDistance/FollowFactor + Config()->m_ClMouseDeadzone, (float)Config()->m_ClMouseMaxDistanceDynamic);
+	}
+	else
+		return (float)Config()->m_ClMouseMaxDistanceStatic;
 }

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -28,5 +28,6 @@ public:
 
 	int SnapInput(int *pData);
 	void ClampMousePos();
+	float GetMaxMouseDistance() const;
 };
 #endif

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -583,6 +583,9 @@ void CMenus::DoScrollbarOptionLabeled(void *pID, int *pOption, const CUIRect *pR
 	ScrollBar.VMargin(4.0f, &ScrollBar);
 	Value = pScale->ToAbsolute(DoScrollbarH(pID, &ScrollBar, pScale->ToRelative(Value, 0, Max)), 0, Max);
 
+	if(UI()->HotItem() != pID && UI()->MouseHovered(pRect) && UI()->MouseButtonClicked(0))
+		Value = (Value + 1) % Num;
+
 	*pOption = clamp(Value, 0, Max);
 }
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -574,9 +574,8 @@ void CMenus::DoScrollbarOptionLabeled(void *pID, int *pOption, const CUIRect *pR
 	RenderTools()->DrawUIRect(pRect, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 
 	CUIRect Label, ScrollBar;
-	pRect->VSplitLeft(5.0f, 0, &Label);
+	pRect->VSplitLeft(pRect->h+5.0f, 0, &Label);
 	Label.VSplitRight(60.0f, &Label, &ScrollBar);
-
 	Label.y += 2.0f;
 	UI()->DoLabel(&Label, aBuf, FontSize, CUI::ALIGN_LEFT);
 

--- a/src/game/client/components/menus_callback.cpp
+++ b/src/game/client/components/menus_callback.cpp
@@ -168,7 +168,11 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 		{
 			NumOptions++; // joystick selection
 		}
-		NumOptions += 3; // ingame sens, ui sens, tolerance
+		NumOptions += 3; // mode, ui sens, tolerance
+		if(!Config()->m_JoystickAbsolute)
+		{
+			NumOptions++; // ingame sens
+		}
 		NumOptions += m_pClient->Input()->GetJoystickNumAxes(); // axis selection
 	}
 	const float ButtonHeight = 20.0f;
@@ -181,8 +185,7 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 	CUIRect Button;
 	View.HSplitTop(Spacing, 0, &View);
 	View.HSplitTop(ButtonHeight, &Button, &View);
-	static int s_ButtonJoystickEnable = 0;
-	if(DoButton_CheckBox(&s_ButtonJoystickEnable, Localize("Enable joystick"), Config()->m_JoystickEnable, &Button))
+	if(DoButton_CheckBox(&Config()->m_JoystickEnable, Localize("Enable joystick"), Config()->m_JoystickEnable, &Button))
 	{
 		Config()->m_JoystickEnable ^= 1;
 	}
@@ -204,13 +207,24 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 				}
 			}
 
-			View.HSplitTop(Spacing, 0, &View);
-			View.HSplitTop(ButtonHeight, &Button, &View);
-			DoScrollbarOption(&Config()->m_JoystickSens, &Config()->m_JoystickSens, &Button, Localize("Ingame joystick sens."), 1, 500, &LogarithmicScrollbarScale);
+			{
+				View.HSplitTop(Spacing, 0, &View);
+				View.HSplitTop(ButtonHeight, &Button, &View);
+				const int NumLabels = 2;
+				const char *aLabels[NumLabels] = { Localize("Relative", "Ingame joystick mode"), Localize("Absolute", "Ingame joystick mode")};
+				DoScrollbarOptionLabeled(&Config()->m_JoystickAbsolute, &Config()->m_JoystickAbsolute, &Button, Localize("Ingame joystick mode"), aLabels, NumLabels);
+			}
+
+			if(!Config()->m_JoystickAbsolute)
+			{
+				View.HSplitTop(Spacing, 0, &View);
+				View.HSplitTop(ButtonHeight, &Button, &View);
+				DoScrollbarOption(&Config()->m_JoystickSens, &Config()->m_JoystickSens, &Button, Localize("Ingame joystick sensitivity"), 1, 500, &LogarithmicScrollbarScale);
+			}
 
 			View.HSplitTop(Spacing, 0, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);
-			DoScrollbarOption(&Config()->m_UiJoystickSens, &Config()->m_UiJoystickSens, &Button, Localize("Menu/Editor joystick sens."), 1, 500, &LogarithmicScrollbarScale);
+			DoScrollbarOption(&Config()->m_UiJoystickSens, &Config()->m_UiJoystickSens, &Button, Localize("Menu/Editor joystick sensitivity"), 1, 500, &LogarithmicScrollbarScale);
 
 			View.HSplitTop(Spacing, 0, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -966,7 +966,6 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	{
 		GameRight.HSplitTop(Spacing, 0, &GameRight);
 		GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
-		Button.VSplitLeft(ButtonHeight, 0, &Button);
 		/*RenderTools()->DrawUIRect(&Button, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
 		CUIRect Text;
 		Button.VSplitLeft(ButtonHeight+5.0f, 0, &Button);


### PR DESCRIPTION
Implement absolute joystick input mode and add option to settings (closes #2612).

The sensitivity is unused in absolute mode, hence the option is hidden when absolute mode is enabled.

The tolerance works just like with relative input. All joystick inputs with smaller length are ignored. I did not implement it to snap back to the player in that case, because that would make alternate mouse input impossible and does not have any benefits IMO.

Settings page:

![screenshot_2020-10-10_12-04-48](https://user-images.githubusercontent.com/23437060/95652399-00198280-0af1-11eb-83d0-fac9feb7f96d.png)

![screenshot_2020-10-10_12-04-51](https://user-images.githubusercontent.com/23437060/95652402-03147300-0af1-11eb-8882-84dc5628245b.png)

The relative/absolute toggle uses `DoScrollbarOptionLabeled`, which is also adapted so the background can be clicked to toggle between the options instead of dragging the scrollbar.

The padding is fixed to be inside the background, like the other `*Option`-methods, so all the labels align:

![grafik](https://user-images.githubusercontent.com/23437060/95652457-55559400-0af1-11eb-92ef-553f9778b2b7.png)
