### PR TITLE
Various UI Changes + Skin Randomizer

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1621,7 +1621,7 @@ void CMenus::Render()
 		else if(m_Popup == POPUP_PASSWORD)
 		{
 			pTitle = Localize("Password incorrect");
-			pExtraText = "Please enter the password.";
+			pExtraText = Localize("Please enter the password.");
 		}
 		else if(m_Popup == POPUP_QUIT)
 		{

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -267,8 +267,9 @@ private:
 	public:
 		CListBox();
 
+		void DoBegin(const CUIRect *pRect);
 		void DoHeader(const CUIRect *pRect, const char *pTitle, float HeaderHeight = 20.0f, float Spacing = 2.0f);
-		void DoSubHeader(float HeaderHeight = 20.0f, float Spacing = 2.0f);
+		void DoSpacing(float Spacing = 20.0f);
 		bool DoFilter(float FilterHeight = 20.0f, float Spacing = 2.0f);
 		void DoFooter(const char *pBottomText, float FooterHeight = 20.0f); // call before DoStart to create a footer
 		void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex,

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1013,7 +1013,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	}
 
 	// list background
-	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
+	RenderTools()->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_L, 5.0f);
 	{
 		int Column = COL_BROWSER_PING;
 		switch(Config()->m_BrSort)

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -500,7 +500,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	// do headers
 	for(int i = 0; i < NumCols; i++)
 	{
-		if(DoButton_GridHeader(ms_aDemoCols[i].m_Caption, ms_aDemoCols[i].m_Caption, Config()->m_BrDemoSort == ms_aDemoCols[i].m_Sort, ms_aDemoCols[i].m_Align, &ms_aDemoCols[i].m_Rect, CUI::CORNER_T))
+		if(DoButton_GridHeader(ms_aDemoCols[i].m_Caption, ms_aDemoCols[i].m_Caption, Config()->m_BrDemoSort == ms_aDemoCols[i].m_Sort, ms_aDemoCols[i].m_Align, &ms_aDemoCols[i].m_Rect, CUI::CORNER_ALL))
 		{
 			if(ms_aDemoCols[i].m_Sort != -1)
 			{
@@ -519,7 +519,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		}
 	}
 
-	s_ListBox.DoSubHeader(GetListHeaderHeight(), 0.0f);
+	s_ListBox.DoSpacing(GetListHeaderHeight());
 
 	s_ListBox.DoStart(20.0f, m_lDemos.size(), 1, 3, m_DemolistSelectedIndex);
 	for(sorted_array<CDemoItem>::range r = m_lDemos.all(); !r.empty(); r.pop_front())

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -19,6 +19,12 @@ CMenus::CListBox::CListBox()
 	m_OffsetFilter = 0.0f;
 }
 
+void CMenus::CListBox::DoBegin(const CUIRect *pRect)
+{
+	// setup the variables
+	m_ListBoxView = *pRect;
+}
+
 void CMenus::CListBox::DoHeader(const CUIRect *pRect, const char *pTitle,
 							   float HeaderHeight, float Spacing)
 {
@@ -40,10 +46,10 @@ void CMenus::CListBox::DoHeader(const CUIRect *pRect, const char *pTitle,
 	m_ListBoxView = View;
 }
 
-void CMenus::CListBox::DoSubHeader(float HeaderHeight, float Spacing)
+void CMenus::CListBox::DoSpacing(float Spacing)
 {
 	CUIRect View = m_ListBoxView;
-	View.HSplitTop(HeaderHeight+Spacing, 0, &View);
+	View.HSplitTop(Spacing, 0, &View);
 	m_ListBoxView = View;
 }
 

--- a/src/game/client/components/menus_scrollregion.cpp
+++ b/src/game/client/components/menus_scrollregion.cpp
@@ -33,15 +33,16 @@ void CMenus::CScrollRegion::Begin(CUIRect* pClipRect, vec2* pOutOffset, CScrollR
 	const bool ForceShowScrollbar = m_Params.m_Flags&CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH;
 
 	CUIRect ScrollBarBg;
-	CUIRect* pModifyRect = (ContentOverflows || ForceShowScrollbar) ? pClipRect : 0;
+	bool HasScrollBar = ContentOverflows || ForceShowScrollbar;
+	CUIRect* pModifyRect = HasScrollBar ? pClipRect : 0;
 	pClipRect->VSplitRight(m_Params.m_ScrollbarWidth, pModifyRect, &ScrollBarBg);
 	ScrollBarBg.Margin(m_Params.m_ScrollbarMargin, &m_RailRect);
 
 	// only show scrollbar if required
-	if(ContentOverflows || ForceShowScrollbar)
+	if(HasScrollBar)
 	{
 		if(m_Params.m_ScrollbarBgColor.a > 0)
-			m_pRenderTools->DrawRoundRect(&ScrollBarBg, m_Params.m_ScrollbarBgColor, 4.0f);
+			m_pRenderTools->DrawUIRect(&ScrollBarBg, m_Params.m_ScrollbarBgColor, CUI::CORNER_R, 4.0f);
 		if(m_Params.m_RailBgColor.a > 0)
 			m_pRenderTools->DrawRoundRect(&m_RailRect, m_Params.m_RailBgColor, m_RailRect.w/2.0f);
 	}
@@ -49,7 +50,7 @@ void CMenus::CScrollRegion::Begin(CUIRect* pClipRect, vec2* pOutOffset, CScrollR
 		m_ContentScrollOff.y = 0;
 
 	if(m_Params.m_ClipBgColor.a > 0)
-		m_pRenderTools->DrawRoundRect(pClipRect, m_Params.m_ClipBgColor, 4.0f);
+		m_pRenderTools->DrawUIRect(pClipRect, m_Params.m_ClipBgColor, HasScrollBar ? CUI::CORNER_L : CUI::CORNER_ALL, 4.0f);
 
 	m_pUI->ClipEnable(pClipRect);
 

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -403,6 +403,30 @@ int CSkins::FindSkinPart(int Part, const char *pName, bool AllowSpecialPart)
 	return -1;
 }
 
+void CSkins::RandomizeSkin()
+{
+	for(int p = 0; p < NUM_SKINPARTS; p++)
+	{
+		int Hue = random_int() % 255;
+		int Sat = random_int() % 255;
+		int Lgt = random_int() % 255;
+		int Alp = 0;
+		if (p == 1) // 1 == SKINPART_MARKING
+			Alp = random_int() % 255;
+		int NewVal = (Alp << 24) + (Hue << 16) + (Sat << 8) + Lgt;
+		*CSkins::ms_apUCCVariables[p] = true;
+		*CSkins::ms_apColorVariables[p] = NewVal;
+	}
+
+	for(int p = 0; p < NUM_SKINPARTS; p++)
+	{
+		const CSkins::CSkinPart *s = GetSkinPart(p, random_int() % NumSkinPart(p));
+		while(s->m_Flags&CSkins::SKINFLAG_SPECIAL)
+			s = GetSkinPart(p, random_int() % NumSkinPart(p));
+		mem_copy(CSkins::ms_apSkinVariables[p], s->m_aName, MAX_SKIN_LENGTH);
+	}
+}
+
 vec3 CSkins::GetColorV3(int v) const
 {
 	float Dark = DARKEST_COLOR_LGT/255.0f;

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -411,11 +411,11 @@ void CSkins::RandomizeSkin()
 		int Sat = random_int() % 255;
 		int Lgt = random_int() % 255;
 		int Alp = 0;
-		if (p == 1) // 1 == SKINPART_MARKING
+		if (p == 1) // SKINPART_MARKING
 			Alp = random_int() % 255;
-		int NewVal = (Alp << 24) + (Hue << 16) + (Sat << 8) + Lgt;
+		int ColorVariable = (Alp << 24) | (Hue << 16) | (Sat << 8) | Lgt;
 		*CSkins::ms_apUCCVariables[p] = true;
-		*CSkins::ms_apColorVariables[p] = NewVal;
+		*CSkins::ms_apColorVariables[p] = ColorVariable;
 	}
 
 	for(int p = 0; p < NUM_SKINPARTS; p++)

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -67,6 +67,7 @@ public:
 	int Find(const char *pName, bool AllowSpecialSkin);
 	const CSkinPart *GetSkinPart(int Part, int Index);
 	int FindSkinPart(int Part, const char *pName, bool AllowSpecialPart);
+	void RandomizeSkin();
 
 	vec3 GetColorV3(int v) const;
 	vec4 GetColorV4(int v, bool UseAlpha) const;


### PR DESCRIPTION
Sorry this is unprompted. Just a few small changes plus reimpletmented #2613 (because I forgot to create new branches)

Changes:

- Add missing Localizations for "Please enter the password." and skin parts catagories (due to missing context)
- Allow listbox to have no header and remove the listbox's header in skin part selection which is a duplicated info.
- Make scrollregion's scrollbar more integrated into the content.
  - basically removed this corner gap ![image](https://user-images.githubusercontent.com/3797859/96362693-a9035580-1161-11eb-8c91-656f6dcac13b.png)
- Change demo list's column header to CORNER_ALL to make it the same as server browser's header.
- Added skinparts' name into the selection list as well, because why not, we have a search bar on top.
- Implemented a cleaner version of the skin randomizer.

closes #2613
