### PR TITLE
Adaptable Marking (No GFX Update)

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -447,6 +447,30 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Create(const CCommandBuffer::
 	mem_free(pTexData);
 }
 
+void CCommandProcessorFragment_OpenGL::Cmd_Stencil_Begin(const CCommandBuffer::CStencilBeginCommand *pCommand)
+{ 
+	glClear(GL_STENCIL_BUFFER_BIT);
+	glEnable(GL_STENCIL_TEST);
+	glEnable(GL_ALPHA_TEST);
+	glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+	glStencilFunc(GL_ALWAYS, 1, 1);
+	glStencilOp(GL_REPLACE, GL_REPLACE, GL_REPLACE);
+	glAlphaFunc(GL_GREATER, 0.5f);
+} 
+
+void CCommandProcessorFragment_OpenGL::Cmd_Stencil_End(const CCommandBuffer::CStencilEndCommand *pCommand)
+{
+	glDisable(GL_ALPHA_TEST);
+	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	glStencilFunc(GL_EQUAL, 1, 1);
+	glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+}
+
+void CCommandProcessorFragment_OpenGL::Cmd_Stencil_Clear(const CCommandBuffer::CStencilClearCommand *pCommand)
+{
+	glDisable(GL_STENCIL_TEST);
+}
+
 void CCommandProcessorFragment_OpenGL::Cmd_Clear(const CCommandBuffer::CClearCommand *pCommand)
 {
 	glClearColor(pCommand->m_Color.r, pCommand->m_Color.g, pCommand->m_Color.b, 0.0f);
@@ -528,6 +552,9 @@ bool CCommandProcessorFragment_OpenGL::RunCommand(const CCommandBuffer::CCommand
 	case CCommandBuffer::CMD_TEXTURE_CREATE: Cmd_Texture_Create(static_cast<const CCommandBuffer::CTextureCreateCommand *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_TEXTURE_DESTROY: Cmd_Texture_Destroy(static_cast<const CCommandBuffer::CTextureDestroyCommand *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_TEXTURE_UPDATE: Cmd_Texture_Update(static_cast<const CCommandBuffer::CTextureUpdateCommand *>(pBaseCommand)); break;
+	case CCommandBuffer::CMD_STENCIL_BEGIN: Cmd_Stencil_Begin(static_cast<const CCommandBuffer::CStencilBeginCommand *>(pBaseCommand)); break;
+	case CCommandBuffer::CMD_STENCIL_END: Cmd_Stencil_End(static_cast<const CCommandBuffer::CStencilEndCommand *>(pBaseCommand)); break;
+	case CCommandBuffer::CMD_STENCIL_CLEAR: Cmd_Stencil_Clear(static_cast<const CCommandBuffer::CStencilClearCommand *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_CLEAR: Cmd_Clear(static_cast<const CCommandBuffer::CClearCommand *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_RENDER: Cmd_Render(static_cast<const CCommandBuffer::CRenderCommand *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_SCREENSHOT: Cmd_Screenshot(static_cast<const CCommandBuffer::CScreenshotCommand *>(pBaseCommand)); break;
@@ -619,6 +646,9 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *pScreen, int *pWin
 			return -1;
 		}
 	}
+
+	// enable stencil buffer
+	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 
 	// set screen
 	SDL_Rect ScreenPos;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -447,26 +447,25 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Create(const CCommandBuffer::
 	mem_free(pTexData);
 }
 
-void CCommandProcessorFragment_OpenGL::Cmd_Stencil_Begin(const CCommandBuffer::CStencilBeginCommand *pCommand)
+void CCommandProcessorFragment_OpenGL::Cmd_AlphaMask_Begin(const CCommandBuffer::CAlphaMaskBeginCommand *pCommand)
 { 
 	glClear(GL_STENCIL_BUFFER_BIT);
 	glEnable(GL_STENCIL_TEST);
-	glEnable(GL_ALPHA_TEST);
 	glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 	glStencilFunc(GL_ALWAYS, 1, 1);
 	glStencilOp(GL_REPLACE, GL_REPLACE, GL_REPLACE);
-	glAlphaFunc(GL_GREATER, 0.5f);
+	glAlphaFunc(GL_GREATER, pCommand->m_Threshold);
 } 
 
-void CCommandProcessorFragment_OpenGL::Cmd_Stencil_End(const CCommandBuffer::CStencilEndCommand *pCommand)
+void CCommandProcessorFragment_OpenGL::Cmd_AlphaMask_End(const CCommandBuffer::CAlphaMaskEndCommand *pCommand)
 {
-	glDisable(GL_ALPHA_TEST);
 	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 	glStencilFunc(GL_EQUAL, 1, 1);
 	glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+	glAlphaFunc(GL_GREATER, 0);
 }
 
-void CCommandProcessorFragment_OpenGL::Cmd_Stencil_Clear(const CCommandBuffer::CStencilClearCommand *pCommand)
+void CCommandProcessorFragment_OpenGL::Cmd_AlphaMask_Clear(const CCommandBuffer::CAlphaMaskClearCommand *pCommand)
 {
 	glDisable(GL_STENCIL_TEST);
 }
@@ -552,9 +551,9 @@ bool CCommandProcessorFragment_OpenGL::RunCommand(const CCommandBuffer::CCommand
 	case CCommandBuffer::CMD_TEXTURE_CREATE: Cmd_Texture_Create(static_cast<const CCommandBuffer::CTextureCreateCommand *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_TEXTURE_DESTROY: Cmd_Texture_Destroy(static_cast<const CCommandBuffer::CTextureDestroyCommand *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_TEXTURE_UPDATE: Cmd_Texture_Update(static_cast<const CCommandBuffer::CTextureUpdateCommand *>(pBaseCommand)); break;
-	case CCommandBuffer::CMD_STENCIL_BEGIN: Cmd_Stencil_Begin(static_cast<const CCommandBuffer::CStencilBeginCommand *>(pBaseCommand)); break;
-	case CCommandBuffer::CMD_STENCIL_END: Cmd_Stencil_End(static_cast<const CCommandBuffer::CStencilEndCommand *>(pBaseCommand)); break;
-	case CCommandBuffer::CMD_STENCIL_CLEAR: Cmd_Stencil_Clear(static_cast<const CCommandBuffer::CStencilClearCommand *>(pBaseCommand)); break;
+	case CCommandBuffer::CMD_ALPHAMASK_BEGIN: Cmd_AlphaMask_Begin(static_cast<const CCommandBuffer::CAlphaMaskBeginCommand *>(pBaseCommand)); break;
+	case CCommandBuffer::CMD_ALPHAMASK_END: Cmd_AlphaMask_End(static_cast<const CCommandBuffer::CAlphaMaskEndCommand *>(pBaseCommand)); break;
+	case CCommandBuffer::CMD_ALPHAMASK_CLEAR: Cmd_AlphaMask_Clear(static_cast<const CCommandBuffer::CAlphaMaskClearCommand *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_CLEAR: Cmd_Clear(static_cast<const CCommandBuffer::CClearCommand *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_RENDER: Cmd_Render(static_cast<const CCommandBuffer::CRenderCommand *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_SCREENSHOT: Cmd_Screenshot(static_cast<const CCommandBuffer::CScreenshotCommand *>(pBaseCommand)); break;

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -131,9 +131,9 @@ private:
 	void Cmd_Texture_Update(const CCommandBuffer::CTextureUpdateCommand *pCommand);
 	void Cmd_Texture_Destroy(const CCommandBuffer::CTextureDestroyCommand *pCommand);
 	void Cmd_Texture_Create(const CCommandBuffer::CTextureCreateCommand *pCommand);
-	void Cmd_Stencil_Begin(const CCommandBuffer::CStencilBeginCommand *pCommand);
-	void Cmd_Stencil_End(const CCommandBuffer::CStencilEndCommand *pCommand);
-	void Cmd_Stencil_Clear(const CCommandBuffer::CStencilClearCommand *pCommand);
+	void Cmd_AlphaMask_Begin(const CCommandBuffer::CAlphaMaskBeginCommand *pCommand);
+	void Cmd_AlphaMask_End(const CCommandBuffer::CAlphaMaskEndCommand *pCommand);
+	void Cmd_AlphaMask_Clear(const CCommandBuffer::CAlphaMaskClearCommand *pCommand);
 	void Cmd_Clear(const CCommandBuffer::CClearCommand *pCommand);
 	void Cmd_Render(const CCommandBuffer::CRenderCommand *pCommand);
 	void Cmd_Screenshot(const CCommandBuffer::CScreenshotCommand *pCommand);

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -131,6 +131,9 @@ private:
 	void Cmd_Texture_Update(const CCommandBuffer::CTextureUpdateCommand *pCommand);
 	void Cmd_Texture_Destroy(const CCommandBuffer::CTextureDestroyCommand *pCommand);
 	void Cmd_Texture_Create(const CCommandBuffer::CTextureCreateCommand *pCommand);
+	void Cmd_Stencil_Begin(const CCommandBuffer::CStencilBeginCommand *pCommand);
+	void Cmd_Stencil_End(const CCommandBuffer::CStencilEndCommand *pCommand);
+	void Cmd_Stencil_Clear(const CCommandBuffer::CStencilClearCommand *pCommand);
 	void Cmd_Clear(const CCommandBuffer::CClearCommand *pCommand);
 	void Cmd_Render(const CCommandBuffer::CRenderCommand *pCommand);
 	void Cmd_Screenshot(const CCommandBuffer::CScreenshotCommand *pCommand);

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -177,21 +177,22 @@ void CGraphics_Threaded::ClipDisable()
 	m_State.m_ClipEnable = false;
 }
 
-void CGraphics_Threaded::StencilBegin()
+void CGraphics_Threaded::AlphaMaskBegin(float Threshold)
 {
-	CCommandBuffer::CStencilBeginCommand Cmd;
+	CCommandBuffer::CAlphaMaskBeginCommand Cmd;
+	Cmd.m_Threshold = Threshold;
 	m_pCommandBuffer->AddCommand(Cmd);
 }
 
-void CGraphics_Threaded::StencilEnd()
+void CGraphics_Threaded::AlphaMaskEnd()
 {
-	CCommandBuffer::CStencilEndCommand Cmd;
+	CCommandBuffer::CAlphaMaskEndCommand Cmd;
 	m_pCommandBuffer->AddCommand(Cmd);
 }
 
-void CGraphics_Threaded::StencilClear()
+void CGraphics_Threaded::AlphaMaskClear()
 {
-	CCommandBuffer::CStencilClearCommand Cmd;
+	CCommandBuffer::CAlphaMaskClearCommand Cmd;
 	m_pCommandBuffer->AddCommand(Cmd);
 }
 

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -177,6 +177,24 @@ void CGraphics_Threaded::ClipDisable()
 	m_State.m_ClipEnable = false;
 }
 
+void CGraphics_Threaded::StencilBegin()
+{
+	CCommandBuffer::CStencilBeginCommand Cmd;
+	m_pCommandBuffer->AddCommand(Cmd);
+}
+
+void CGraphics_Threaded::StencilEnd()
+{
+	CCommandBuffer::CStencilEndCommand Cmd;
+	m_pCommandBuffer->AddCommand(Cmd);
+}
+
+void CGraphics_Threaded::StencilClear()
+{
+	CCommandBuffer::CStencilClearCommand Cmd;
+	m_pCommandBuffer->AddCommand(Cmd);
+}
+
 void CGraphics_Threaded::BlendNone()
 {
 	m_State.m_BlendMode = CCommandBuffer::BLEND_NONE;

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -74,6 +74,11 @@ public:
 		CMD_TEXTURE_DESTROY,
 		CMD_TEXTURE_UPDATE,
 
+		// stencil commands
+		CMD_STENCIL_BEGIN,
+		CMD_STENCIL_END,
+		CMD_STENCIL_CLEAR,
+
 		// rendering
 		CMD_CLEAR,
 		CMD_RENDER,
@@ -244,6 +249,21 @@ public:
 		int m_Slot;
 	};
 
+	struct CStencilBeginCommand : public CCommand
+	{
+		CStencilBeginCommand() : CCommand(CMD_STENCIL_BEGIN) {}
+	};
+
+	struct CStencilEndCommand : public CCommand
+	{
+		CStencilEndCommand() : CCommand(CMD_STENCIL_END) {}
+	};
+
+	struct CStencilClearCommand : public CCommand
+	{
+		CStencilClearCommand() : CCommand(CMD_STENCIL_CLEAR) {}
+	};
+
 	//
 	CCommandBuffer(unsigned CmdBufferSize, unsigned DataBufferSize)
 	: m_CmdBuffer(CmdBufferSize), m_DataBuffer(DataBufferSize)
@@ -386,6 +406,10 @@ public:
 
 	virtual void ClipEnable(int x, int y, int w, int h);
 	virtual void ClipDisable();
+
+	virtual void StencilBegin();
+	virtual void StencilEnd();
+	virtual void StencilClear();
 
 	virtual void BlendNone();
 	virtual void BlendNormal();

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -75,9 +75,9 @@ public:
 		CMD_TEXTURE_UPDATE,
 
 		// stencil commands
-		CMD_STENCIL_BEGIN,
-		CMD_STENCIL_END,
-		CMD_STENCIL_CLEAR,
+		CMD_ALPHAMASK_BEGIN,
+		CMD_ALPHAMASK_END,
+		CMD_ALPHAMASK_CLEAR,
 
 		// rendering
 		CMD_CLEAR,
@@ -249,19 +249,21 @@ public:
 		int m_Slot;
 	};
 
-	struct CStencilBeginCommand : public CCommand
+	struct CAlphaMaskBeginCommand : public CCommand
 	{
-		CStencilBeginCommand() : CCommand(CMD_STENCIL_BEGIN) {}
+		CAlphaMaskBeginCommand() : CCommand(CMD_ALPHAMASK_BEGIN) {}
+
+		float m_Threshold;
 	};
 
-	struct CStencilEndCommand : public CCommand
+	struct CAlphaMaskEndCommand : public CCommand
 	{
-		CStencilEndCommand() : CCommand(CMD_STENCIL_END) {}
+		CAlphaMaskEndCommand() : CCommand(CMD_ALPHAMASK_END) {}
 	};
 
-	struct CStencilClearCommand : public CCommand
+	struct CAlphaMaskClearCommand : public CCommand
 	{
-		CStencilClearCommand() : CCommand(CMD_STENCIL_CLEAR) {}
+		CAlphaMaskClearCommand() : CCommand(CMD_ALPHAMASK_CLEAR) {}
 	};
 
 	//
@@ -407,9 +409,9 @@ public:
 	virtual void ClipEnable(int x, int y, int w, int h);
 	virtual void ClipDisable();
 
-	virtual void StencilBegin();
-	virtual void StencilEnd();
-	virtual void StencilClear();
+	virtual void AlphaMaskBegin(float Threshold);
+	virtual void AlphaMaskEnd();
+	virtual void AlphaMaskClear();
 
 	virtual void BlendNone();
 	virtual void BlendNormal();

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -107,6 +107,10 @@ public:
 	virtual void ClipEnable(int x, int y, int w, int h) = 0;
 	virtual void ClipDisable() = 0;
 
+	virtual void StencilBegin() = 0;
+	virtual void StencilEnd() = 0;
+	virtual void StencilClear() = 0;
+
 	virtual void MapScreen(float TopLeftX, float TopLeftY, float BottomRightX, float BottomRightY) = 0;
 	virtual void GetScreen(float *pTopLeftX, float *pTopLeftY, float *pBottomRightX, float *pBottomRightY) = 0;
 

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -107,9 +107,9 @@ public:
 	virtual void ClipEnable(int x, int y, int w, int h) = 0;
 	virtual void ClipDisable() = 0;
 
-	virtual void StencilBegin() = 0;
-	virtual void StencilEnd() = 0;
-	virtual void StencilClear() = 0;
+	virtual void AlphaMaskBegin(float Threshold = 0.5f) = 0;
+	virtual void AlphaMaskEnd() = 0;
+	virtual void AlphaMaskClear() = 0;
 
 	virtual void MapScreen(float TopLeftX, float TopLeftY, float BottomRightX, float BottomRightY) = 0;
 	virtual void GetScreen(float *pTopLeftX, float *pTopLeftY, float *pBottomRightX, float *pBottomRightY) = 0;

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -420,6 +420,17 @@ void CRenderTools::RenderTee(CAnimState *pAnim, const CTeeRenderInfo *pInfo, int
 				// draw marking
 				if(pInfo->m_aTextures[SKINPART_MARKING].IsValid() && !OutLine)
 				{
+					// set stencil
+					Graphics()->StencilBegin();
+					Graphics()->QuadsBegin();
+					Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle*pi*2);
+					Graphics()->SetColor(1, 1, 1, 1);
+					SelectSprite(SPRITE_TEE_BODY, 0, 0, 0);
+					Item = BodyItem;
+					Graphics()->QuadsDraw(&Item, 1);
+					Graphics()->QuadsEnd();
+					Graphics()->StencilEnd();
+
 					Graphics()->TextureSet(pInfo->m_aTextures[SKINPART_MARKING]);
 					Graphics()->QuadsBegin();
 					Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle*pi*2);
@@ -429,6 +440,8 @@ void CRenderTools::RenderTee(CAnimState *pAnim, const CTeeRenderInfo *pInfo, int
 					Item = BodyItem;
 					Graphics()->QuadsDraw(&Item, 1);
 					Graphics()->QuadsEnd();
+
+					Graphics()->StencilClear();
 				}
 
 				// draw body (in front of marking)

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -421,7 +421,7 @@ void CRenderTools::RenderTee(CAnimState *pAnim, const CTeeRenderInfo *pInfo, int
 				if(pInfo->m_aTextures[SKINPART_MARKING].IsValid() && !OutLine)
 				{
 					// set stencil
-					Graphics()->StencilBegin();
+					Graphics()->AlphaMaskBegin();
 					Graphics()->QuadsBegin();
 					Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle*pi*2);
 					Graphics()->SetColor(1, 1, 1, 1);
@@ -429,7 +429,7 @@ void CRenderTools::RenderTee(CAnimState *pAnim, const CTeeRenderInfo *pInfo, int
 					Item = BodyItem;
 					Graphics()->QuadsDraw(&Item, 1);
 					Graphics()->QuadsEnd();
-					Graphics()->StencilEnd();
+					Graphics()->AlphaMaskEnd();
 
 					Graphics()->TextureSet(pInfo->m_aTextures[SKINPART_MARKING]);
 					Graphics()->QuadsBegin();
@@ -441,7 +441,7 @@ void CRenderTools::RenderTee(CAnimState *pAnim, const CTeeRenderInfo *pInfo, int
 					Graphics()->QuadsDraw(&Item, 1);
 					Graphics()->QuadsEnd();
 
-					Graphics()->StencilClear();
+					Graphics()->AlphaMaskClear();
 				}
 
 				// draw body (in front of marking)


### PR DESCRIPTION
closes https://github.com/teeworlds/teeworlds/issues/2157

Implemented this by rendering the body colour textures onto stencil buffer to cut marking textures.
I did not update any textures so there are no visible changes.

Basically, allows you to do these:
![image](https://user-images.githubusercontent.com/3797859/97261449-d46cfb00-1859-11eb-8d22-ae7ffea9132c.png)
with a marking texture like this:
![image](https://user-images.githubusercontent.com/3797859/97261652-3a598280-185a-11eb-9a2b-91121a643149.png)


(the followings are experiments by Souly on discord)
![image](https://user-images.githubusercontent.com/3797859/97261471-de8ef980-1859-11eb-8212-dd4d62df0925.png)
![image](https://user-images.githubusercontent.com/3797859/97261486-e484da80-1859-11eb-9a28-96c36bec9a5d.png)
![image](https://user-images.githubusercontent.com/3797859/97261495-e6e73480-1859-11eb-9c2d-27e7dc872a31.png)
