### PR TITLE
MacOS CI workaround

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,10 @@ jobs:
     - name: Prepare MacOS
       if: contains(matrix.os, 'macOS')
       run: |
+        brew uninstall openssl@1.0.2t
+        brew uninstall python@2.7.17
+        brew untap local/openssl
+        brew untap local/python2
         brew update
         brew install pkg-config sdl2
 
@@ -124,6 +128,10 @@ jobs:
     - name: Prepare MacOS
       if: contains(matrix.os, 'macOS')
       run: |
+        brew uninstall openssl@1.0.2t
+        brew uninstall python@2.7.17
+        brew untap local/openssl
+        brew untap local/python2
         brew update
         brew install sdl2
         cd bam


### PR DESCRIPTION
using common workaround posted here https://github.com/actions/virtual-environments/issues/1811
closes #2786 

I have no idea why they closed it with only a workaround posted.
We can also just ignore brew errors but this way at least we can keep macOS's build log clean.