### PR TITLE
Enable DamageInd Angle in Client

### DIFF
--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -32,15 +32,16 @@ void CDamageInd::DestroyItem(CDamageInd::CItem *pItem)
 		*pItem = m_aItems[m_NumItems];
 }
 
-void CDamageInd::Create(vec2 Pos, vec2 Dir)
+void CDamageInd::Create(vec2 Pos, vec2 Dir, int ClientID)
 {
 	CItem *pItem = CreateItem();
 	if(pItem)
 	{
 		pItem->m_Pos = Pos;
 		pItem->m_LifeTime = 0.75f;
-		pItem->m_Dir = Dir*-1;
+		pItem->m_Dir = Dir;
 		pItem->m_StartAngle = (frandom() - 1.0f) * 2.0f * pi;
+		pItem->m_ClientID = ClientID;
 	}
 }
 
@@ -58,7 +59,7 @@ void CDamageInd::OnRender()
 		else
 		{
 			vec2 Pos = mix(m_aItems[i].m_Pos+m_aItems[i].m_Dir*75.0f, m_aItems[i].m_Pos, clamp((m_aItems[i].m_LifeTime-0.60f)/0.15f, 0.0f, 1.0f));
-			const float Alpha = clamp(m_aItems[i].m_LifeTime * 10.0f, 0.0f, 1.0f); // 0.1 -> 0.0 == 1.0 -> 0.0
+			const float Alpha = clamp(m_aItems[i].m_LifeTime * 10.0f, 0.0f, 1.0f);
 			Graphics()->SetColor(1.0f*Alpha, 1.0f*Alpha, 1.0f*Alpha, Alpha);
 			Graphics()->QuadsSetRotation(m_aItems[i].m_StartAngle + m_aItems[i].m_LifeTime * 2.0f);
 			RenderTools()->SelectSprite(SPRITE_STAR1);

--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -13,6 +13,7 @@ class CDamageInd : public CComponent
 		vec2 m_Dir;
 		float m_LifeTime;
 		float m_StartAngle;
+		int m_ClientID;
 	};
 
 	enum
@@ -29,7 +30,7 @@ class CDamageInd : public CComponent
 public:
 	CDamageInd();
 
-	void Create(vec2 Pos, vec2 Dir);
+	void Create(vec2 Pos, vec2 Dir, int ClientID);
 
 	virtual void OnRender();
 	virtual void OnReset();

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -58,8 +58,6 @@ void CEffects::CreateDamageIndicator(CDamageIndInfo *pDamage, int ClientID)
 
 	float s = Angle-pi/3;
 	float e = Angle+pi/3;
-
-	int HealthDamageIndex = (pDamage->m_ArmorAmount) / 2;
 	for(int i = 0; i < Amount; i++)
 	{
 		float f = mix(s, e, float(i+1)/float(Amount+1));

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -24,7 +24,7 @@ void CEffects::CreateDamageIndicator(CDamageIndInfo *pDamage)
 	if(pDamage->Amount == 0 || pDamage->NumEvents == 0)
 		return;
 
-	float Angle = pDamage->Angle / pDamage->NumEvents;
+	float Angle = atan2f(pDamage->SumSin / pDamage->NumEvents, pDamage->SumCos / pDamage->NumEvents);
 	vec2 Pos = pDamage->Pos / pDamage->NumEvents;
 
 	float s = Angle-pi/3;
@@ -73,14 +73,16 @@ void CEffects::DamageIndicator(vec2 Pos, int Amount, float Angle, int ClientID)
 		CDamageIndInfo Damage;
 		Damage.Pos = Pos;
 		Damage.Amount = Amount;
-		Damage.Angle = Angle;
+		Damage.SumSin = sinf(Angle);
+		Damage.SumCos = cosf(Angle);
 		Damage.NumEvents = 1;
 		CreateDamageIndicator(&Damage);
 	}
 	else
 	{
 		m_aClientDamage[ClientID].Amount += Amount;
-		m_aClientDamage[ClientID].Angle += Angle;
+		m_aClientDamage[ClientID].SumSin += sinf(Angle);
+		m_aClientDamage[ClientID].SumCos += cosf(Angle);
 		m_aClientDamage[ClientID].Pos += Pos;
 		m_aClientDamage[ClientID].NumEvents++;
 	}

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -8,23 +8,33 @@ class CEffects : public CComponent
 {
 	struct CDamageIndInfo
 	{
-		vec2 Pos;
-		int Amount;
-		float SumSin;
-		float SumCos;
-		int NumEvents;
+		vec2 m_Pos;
+		int m_HealthAmount;
+		int m_ArmorAmount;
+		float m_SumSin;
+		float m_SumCos;
+		int m_NumEvents;
 	};
+
+	struct CDamageIndState
+	{
+		int m_LastDamageTick;
+		int m_Variation;
+		int m_LastDamage;
+	};
+
 	bool m_Add50hz;
 	bool m_Add100hz;
 
 	CDamageIndInfo m_aClientDamage[MAX_CLIENTS];
-	void CreateDamageIndicator(CDamageIndInfo *pDamage);
+	CDamageIndState m_aClientDamageState[MAX_CLIENTS];
+	void CreateDamageIndicator(CDamageIndInfo *pDamage, int ClientID);
 
 public:
 	CEffects();
 
 	void AirJump(vec2 Pos);
-	void DamageIndicator(vec2 Pos, int Amount, float Angle, int ClientID);
+	void DamageIndicator(vec2 Pos, int HealthAmount, int ArmorAmount, float Angle, int ClientID);
 	void PowerupShine(vec2 Pos, vec2 Size);
 	void SmokeTrail(vec2 Pos, vec2 Vel);
 	void SkidTrail(vec2 Pos, vec2 Vel);
@@ -36,6 +46,7 @@ public:
 
 	void ApplyDamageIndicators();
 
+	virtual void OnReset();
 	virtual void OnRender();
 	float GetEffectsSpeed();
 };

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -10,7 +10,8 @@ class CEffects : public CComponent
 	{
 		vec2 Pos;
 		int Amount;
-		float Angle;
+		float SumSin;
+		float SumCos;
 		int NumEvents;
 	};
 	bool m_Add50hz;

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -6,16 +6,24 @@
 
 class CEffects : public CComponent
 {
+	struct CDamageIndInfo
+	{
+		vec2 Pos;
+		int Amount;
+		float Angle;
+		int NumEvents;
+	};
 	bool m_Add50hz;
 	bool m_Add100hz;
 
-	int m_DamageTaken;
-	float m_DamageTakenTick;
+	CDamageIndInfo m_aClientDamage[MAX_CLIENTS];
+	void CreateDamageIndicator(CDamageIndInfo *pDamage);
+
 public:
 	CEffects();
 
 	void AirJump(vec2 Pos);
-	void DamageIndicator(vec2 Pos, int Amount);
+	void DamageIndicator(vec2 Pos, int Amount, float Angle, int ClientID);
 	void PowerupShine(vec2 Pos, vec2 Size);
 	void SmokeTrail(vec2 Pos, vec2 Vel);
 	void SkidTrail(vec2 Pos, vec2 Vel);
@@ -24,6 +32,8 @@ public:
 	void PlayerDeath(vec2 Pos, int ClientID);
 	void Explosion(vec2 Pos);
 	void HammerHit(vec2 Pos);
+
+	void ApplyDamageIndicators();
 
 	virtual void OnRender();
 	float GetEffectsSpeed();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1080,7 +1080,7 @@ void CGameClient::ProcessEvents()
 		if(Item.m_Type == NETEVENTTYPE_DAMAGE)
 		{
 			CNetEvent_Damage *ev = (CNetEvent_Damage *)pData;
-			m_pEffects->DamageIndicator(vec2(ev->m_X, ev->m_Y), ev->m_HealthAmount + ev->m_ArmorAmount);
+			m_pEffects->DamageIndicator(vec2(ev->m_X, ev->m_Y), ev->m_HealthAmount + ev->m_ArmorAmount, ev->m_Angle / 256.0f, ev->m_ClientID);
 		}
 		else if(Item.m_Type == NETEVENTTYPE_EXPLOSION)
 		{
@@ -1108,6 +1108,7 @@ void CGameClient::ProcessEvents()
 			m_pSounds->PlayAt(CSounds::CHN_WORLD, ev->m_SoundID, 1.0f, vec2(ev->m_X, ev->m_Y));
 		}
 	}
+	m_pEffects->ApplyDamageIndicators();
 }
 
 void CGameClient::ProcessTriggeredEvents(int Events, vec2 Pos)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1080,7 +1080,7 @@ void CGameClient::ProcessEvents()
 		if(Item.m_Type == NETEVENTTYPE_DAMAGE)
 		{
 			CNetEvent_Damage *ev = (CNetEvent_Damage *)pData;
-			m_pEffects->DamageIndicator(vec2(ev->m_X, ev->m_Y), ev->m_HealthAmount + ev->m_ArmorAmount, ev->m_Angle / 256.0f, ev->m_ClientID);
+			m_pEffects->DamageIndicator(vec2(ev->m_X, ev->m_Y), ev->m_HealthAmount, ev->m_ArmorAmount, ev->m_Angle / 256.0f, ev->m_ClientID);
 		}
 		else if(Item.m_Type == NETEVENTTYPE_EXPLOSION)
 		{

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -30,7 +30,7 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 	m_From = From;
 	m_Pos = At;
 	m_Energy = -1;
-	pHit->TakeDamage(vec2(0.f, 0.f), normalize(To-From), g_pData->m_Weapons.m_aId[WEAPON_LASER].m_Damage, m_Owner, WEAPON_LASER);
+	pHit->TakeDamage(vec2(0.f, 0.f), normalize(From-To), g_pData->m_Weapons.m_aId[WEAPON_LASER].m_Damage, m_Owner, WEAPON_LASER);
 	return true;
 }
 


### PR DESCRIPTION
closes #2787

TLDR; the angle is enabled but it looks different (duh).

Not sure if the laser's damage angle is intended but it is being sent like this, I didn't modify any server code.

A pretty big change is that I removed the code to layout the stars in a circle, which removes the effect where the stars goes around the tee when you are quickly firing pistols towards a **stationary tee**, that effect is not very visible when tees are moving anyway. Furthermore, it was on a global timer so when the fight is really hectic the stars may seemingly come from all over the place.

Seems like the intention of that piece of code was to stop shotgun damage stars from grouping together. I used the ClientID (thanks Dune) to process all damage events within a snapshot before creating stars, so the shotgun damage is laid out pretty nicely.

In cases where the shotgun is fired towards a tee from far distance. The bullets might not hit the target within a tick hence creating two or three groups of stars, although looks weird, but the behaviour is actually in line with hit sounds where the sound would play multiple times and give you one set of stars per sound. (Plus, the fact that the stars from shotguns are usually in 1 + 2 formation and usually don't collides makes this behaviour looks fine)

In rare cases where multiple attackers hitting a single target within one tick, the stars will layout in one single group with the angle averaged out, which is harder to solve with no attacker info. But it means the fight is probably chaotic enough for this to happen regularly where the grouped damage might be better to look at.

Preview (ignore the wacky skin marking please):
![image](https://user-images.githubusercontent.com/3797859/97463589-df6b7c80-197a-11eb-919c-bb2f10dbe445.png)
![image](https://user-images.githubusercontent.com/3797859/97463615-e6928a80-197a-11eb-820e-5af403e2ea2f.png)
![image](https://user-images.githubusercontent.com/3797859/97463631-eb573e80-197a-11eb-9d24-281ef0ce3326.png)
![image](https://user-images.githubusercontent.com/3797859/97463646-ef835c00-197a-11eb-9b87-093bfe2b8cb0.png)
![image](https://user-images.githubusercontent.com/3797859/97463665-f4481000-197a-11eb-8984-2eb64b340709.png)

_Sidenote: modders can send stars using a ClientID of -1 to simulate 0.6's star behaviour (i.e. stars wont group at all for client -1)._

