### PR TITLE
Randomly Choose Least Occupied Spawn Points in Survival.

### DIFF
--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -1072,7 +1072,7 @@ void IGameController::EvaluateSpawnType(CSpawnEval *pEval, int Type) const
 			continue;	// try next spawn point
 
 		vec2 P = m_aaSpawnPoints[Type][i]+Positions[Result];
-		float S = pEval->m_RandomSpawn ? random_int() : EvaluateSpawnPos(pEval, P);
+		float S = pEval->m_RandomSpawn ? (Result + frandom()) : EvaluateSpawnPos(pEval, P);
 		if(!pEval->m_Got || pEval->m_Score > S)
 		{
 			pEval->m_Got = true;


### PR DESCRIPTION
closes #2634 

The occupation info/counter is right above the related code, so let's just use that.
Tested on a map with only two spawn points with two clients. Unless I'm lucky enough to not collide for 50 rounds, it is working.
