### PR TITLE
Loop the Envelop Timer to Reduce Precision Loss

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -230,7 +230,9 @@ void CMapLayers::EnvelopeEval(float TimeOffset, int Env, float *pChannels, void 
 			{
 				float PrevAnimationTick = fmod(pThis->Client()->PrevGameTick() - pThis->m_pClient->m_Snap.m_pGameData->m_GameStartTick, EnvalopTicks);
 				float CurAnimationTick = fmod(pThis->Client()->GameTick() - pThis->m_pClient->m_Snap.m_pGameData->m_GameStartTick, EnvalopTicks);
-				s_Time = mix(PrevAnimationTick, CurAnimationTick, pThis->Client()->IntraGameTick())/pThis->Client()->GameTickSpeed();
+				if(PrevAnimationTick > CurAnimationTick)
+					CurAnimationTick += EnvalopTicks;
+				s_Time = mix(PrevAnimationTick, CurAnimationTick, pThis->Client()->IntraGameTick()) / pThis->Client()->GameTickSpeed();
 			}
 			else
 				s_Time = pThis->Client()->LocalTime() - pThis->m_OnlineStartTime;


### PR DESCRIPTION
closes #2170 

Tested with demo provided here:
https://github.com/teeworlds/teeworlds/issues/2170#issuecomment-719751765

fmod the ticks with the envelop loop length before interpolating to avoid large int divided by float