### PR TITLE
Check Existing File Before Saving Skins

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1870,6 +1870,31 @@ int fs_file_time(const char *name, time_t *created, time_t *modified)
 	return 0;
 }
 
+int fs_file_name(const char *name, char *buffer, int length)
+{
+#if defined(CONF_FAMILY_WINDOWS)
+	WIN32_FIND_DATA finddata;
+	HANDLE handle;
+
+	handle = FindFirstFileA(name, &finddata);
+
+	if (handle == INVALID_HANDLE_VALUE)
+		return -1;
+
+	str_copy(buffer, finddata.cFileName, length);
+
+	FindClose(handle);
+	return 0;
+#else
+	struct stat sb;
+	if (stat(name, &sb) == -1)
+		return -1;
+
+	str_copy(buffer, name, length);
+	return 0;
+#endif
+}
+
 void swap_endian(void *data, unsigned elem_size, unsigned num)
 {
 	char *src = (char*) data;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1358,8 +1358,6 @@ typedef struct
 	time_t m_TimeModified; // seconds since UNIX Epoch
 } CFsFileInfo;
 
-/* Group: Filesystem */
-
 /*
 	Function: fs_listdir_fileinfo
 		Lists the files in a directory and gets additional file information
@@ -1549,6 +1547,20 @@ char *fs_read_str(const char *name);
 		- Returned time is in seconds since UNIX Epoch
 */
 int fs_file_time(const char *name, time_t *created, time_t *modified);
+
+/*
+	Function: fs_file_name
+		Gets the stored name in filesystem of a file.
+
+	Parameters:
+		name - The filename
+		buffer - The buffer to store the real filename
+		length - size of the buffer
+
+	Returns:
+		0 on success non-zero on failure
+*/
+int fs_file_name(const char *name, char *buffer, int length);
 
 /*
 	Group: Undocumented

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -608,6 +608,14 @@ public:
 		return !fs_file_time(aBuf, pCreated, pModified);
 	}
 
+	virtual bool GetFileSystemFileName(const char *pFilename, int StorageType, char *pBuffer, int Length)
+	{
+		char aBuf[IO_MAX_PATH_LENGTH];
+		GetCompletePath(StorageType, pFilename, aBuf, sizeof(aBuf));
+
+		return !fs_file_name(aBuf, pBuffer, Length);
+	}
+
 	static IStorage *Create(const char *pApplicationName, int StorageType, int NumArgs, const char **ppArguments)
 	{
 		CStorage *p = new CStorage();

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -35,6 +35,7 @@ public:
 	virtual void GetCompletePath(int Type, const char *pDir, char *pBuffer, unsigned BufferSize) = 0;
 	virtual bool GetHashAndSize(const char *pFilename, int StorageType, SHA256_DIGEST *pSha256, unsigned *pCrc, unsigned *pSize) = 0;
 	virtual bool GetFileTime(const char *pFilename, int StorageType, time_t *pCreated, time_t *pModified) = 0;
+	virtual bool GetFileSystemFileName(const char *pFilename, int StorageType, char *pBuffer, int Length) = 0;
 };
 
 IStorage *CreateStorage(const char *pApplicationName, int StorageType, int NumArgs, const char **ppArguments);

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -557,6 +557,13 @@ void CSkins::SaveSkinfile(const char *pSaveSkinName)
 {
 	char aBuf[IO_MAX_PATH_LENGTH];
 	str_format(aBuf, sizeof(aBuf), "skins/%s.json", pSaveSkinName);
+
+	char aFileSystemFileName[IO_MAX_PATH_LENGTH];
+	if(Storage()->GetFileSystemFileName(aBuf, IStorage::TYPE_SAVE, aFileSystemFileName, IO_MAX_PATH_LENGTH))
+		str_format(aBuf, sizeof(aBuf), "skins/%s", aFileSystemFileName);
+	else
+		str_format(aFileSystemFileName, sizeof(aFileSystemFileName), "%s.json", pSaveSkinName);
+
 	IOHANDLE File = Storage()->OpenFile(aBuf, IOFLAG_WRITE, IStorage::TYPE_SAVE);
 	if(!File)
 		return;
@@ -603,6 +610,10 @@ void CSkins::SaveSkinfile(const char *pSaveSkinName)
 	Writer.EndObject();
 	Writer.EndObject();
 
+	// remove file extension
+	int Length = str_length(aFileSystemFileName);
+	aFileSystemFileName[Length-5] = 0;
+
 	// add new skin to the skin list
-	AddSkin(pSaveSkinName);
+	AddSkin(aFileSystemFileName);
 }


### PR DESCRIPTION
closes #2802

For windows, find the file using given filename and get the real filename preserved in the filesystem.
For unix, just check whether a file exists. If it exists, then return the given filename as the real filename. (Not sure if unix system allows case insensitive filesystem, or if there's a similar way to check.)

Then use the real filename to find from and update to the skin list. if a file isn't found, use the given filename.