### PR TITLE
Align voting control UI, hide vote after time elapsed, refactoring

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -54,6 +54,10 @@ enum
 	SKINPART_FEET,
 	SKINPART_EYES,
 	NUM_SKINPARTS,
+
+	VOTE_CHOICE_NO = -1,
+	VOTE_CHOICE_PASS = 0,
+	VOTE_CHOICE_YES = 1
 };
 '''
 
@@ -423,7 +427,7 @@ Messages = [
 	]),
 
 	NetMessage("Cl_Vote", [
-		NetIntRange("m_Vote", -1, 1),
+		NetIntRange("m_Vote", 'VOTE_CHOICE_NO', 'VOTE_CHOICE_YES'),
 	]),
 
 	NetMessage("Cl_CallVote", [

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -605,7 +605,7 @@ void CHud::RenderVoting()
 	TextRender()->TextOutlined(&s_ReasonCursor, aBuf, -1);
 
 	CUIRect Base = {5, 88, 100, 4};
-	m_pClient->m_pVoting->RenderBars(Base, false);
+	m_pClient->m_pVoting->RenderBars(Base);
 
 	char aBufYes[64], aBufNo[64];
 	m_pClient->m_pBinds->GetKey("vote yes", aBufYes, sizeof(aBufYes));

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -42,6 +42,7 @@ CRenderTools *CMenus::CUIElementBase::m_pRenderTools = 0;
 CUI *CMenus::CUIElementBase::m_pUI = 0;
 IInput *CMenus::CUIElementBase::m_pInput = 0;
 IClient *CMenus::CUIElementBase::m_pClient = 0;
+CConfig *CMenus::CUIElementBase::m_pConfig = 0;
 
 CMenus::CMenus()
 {

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -10,6 +10,7 @@
 #include <engine/demo.h>
 #include <engine/contacts.h>
 #include <engine/serverbrowser.h>
+#include <engine/config.h>
 
 #include <game/voting.h>
 #include <game/client/component.h>
@@ -92,9 +93,10 @@ public:
 		static CUI *m_pUI;
 		static IInput *m_pInput;
 		static IClient *m_pClient;
+		static CConfig *m_pConfig;
 
 	public:
-		static void Init(CMenus *pMenus) { m_pMenus = pMenus; m_pRenderTools = pMenus->RenderTools(); m_pUI = pMenus->UI(); m_pInput = pMenus->Input(); m_pClient = pMenus->Client(); };
+		static void Init(CMenus *pMenus) { m_pMenus = pMenus; m_pRenderTools = pMenus->RenderTools(); m_pUI = pMenus->UI(); m_pInput = pMenus->Input(); m_pClient = pMenus->Client(); m_pConfig = pMenus->Config(); };
 	};
 
 	class CButtonContainer : public CUIElementBase

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -262,6 +262,7 @@ private:
 		vec2 m_ScrollOffset;
 		char m_aFilterString[64];
 		float m_OffsetFilter;
+		int m_BackgroundCorners;
 
 	protected:
 		CListboxItem DoNextRow();
@@ -275,7 +276,7 @@ private:
 		bool DoFilter(float FilterHeight = 20.0f, float Spacing = 2.0f);
 		void DoFooter(const char *pBottomText, float FooterHeight = 20.0f); // call before DoStart to create a footer
 		void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex,
-					const CUIRect *pRect = 0, bool Background = true, bool *pActive = 0);
+					const CUIRect *pRect = 0, bool Background = true, bool *pActive = 0, int BackgroundCorners = CUI::CORNER_ALL);
 		CListboxItem DoNextItem(const void *pID, bool Selected = false, bool *pActive = 0);
 		CListboxItem DoSubheader();
 		int DoEnd();

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -660,6 +660,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	static int s_ControlPage = 0;
 	const char *pNotification = 0;
 	char aBuf[64];
+	const bool Authed = Client()->RconAuthed();
 
 	if(m_pClient->m_pVoting->IsVoting())
 		pNotification = Localize("Wait for current vote to end before calling a new one.");
@@ -668,8 +669,9 @@ void CMenus::RenderServerControl(CUIRect MainView)
 		str_format(aBuf, sizeof(aBuf), Localize("You must wait %d seconds before making another vote"), m_pClient->m_pVoting->CallvoteBlockTime());
 		pNotification = aBuf;
 	}
+	else if(!Authed && m_pClient->m_aClients[m_pClient->m_LocalClientID].m_Team == TEAM_SPECTATORS)
+		pNotification = Localize("Spectators aren't allowed to start a vote.");
 
-	bool Authed = Client()->RconAuthed();
 	MainView.HSplitBottom(80.0f, &MainView, 0);
 	if(pNotification && !Authed)
 	{
@@ -718,14 +720,11 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	else if(s_ControlPage == 2 && !m_pClient->m_ServerSettings.m_SpecVote)
 		pNotification = Localize("Server does not allow voting to move players to spectators");
 
-	if(!Authed && m_pClient->m_aClients[m_pClient->m_LocalClientID].m_Team == TEAM_SPECTATORS)
-		pNotification = Localize("Spectators aren't allowed to start a vote.");
-
 	if(pNotification && !Authed)
 	{
 		// only print notice
 		MainView.HSplitTop(45.0f, &MainView, 0);
-		RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_ALL, 5.0f);
+		RenderTools()->DrawUIRect(&MainView, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
 		MainView.HMargin(15.0f, &MainView);
 		UI()->DoLabel(&MainView, pNotification, 14.0f, CUI::ALIGN_CENTER);
 		return;
@@ -736,7 +735,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	const float LineHeight = 20.0f;
 	const float ColumnWidth = 120.0f;
 	MainView.HSplitBottom(LineHeight + 2*Spacing + (Authed ? (3*LineHeight + 2*Spacing) : 0.0f), &MainView, &Extended);
-	RenderTools()->DrawUIRect(&Extended, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
+	RenderTools()->DrawUIRect(&Extended, vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), CUI::CORNER_B, 5.0f);
 
 	bool DoCallVote = false;
 	// render page

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -33,7 +33,7 @@ void CMenus::CListBox::DoHeader(const CUIRect *pRect, const char *pTitle,
 
 	// background
 	View.HSplitTop(HeaderHeight+Spacing, &Header, 0);
-	m_pRenderTools->DrawUIRect(&Header, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_T, 5.0f);
+	m_pRenderTools->DrawUIRect(&Header, vec4(0.0f, 0.0f, 0.0f, 0.25f), m_BackgroundCorners&CUI::CORNER_T, 5.0f);
 
 	// draw header
 	View.HSplitTop(HeaderHeight, &Header, &View);
@@ -88,7 +88,7 @@ void CMenus::CListBox::DoFooter(const char *pBottomText, float FooterHeight)
 }
 
 void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, 
-							int SelectedIndex, const CUIRect *pRect, bool Background, bool *pActive)
+							int SelectedIndex, const CUIRect *pRect, bool Background, bool *pActive, int BackgroundCorners)
 {
 	CUIRect View;
 	if(pRect)
@@ -97,8 +97,9 @@ void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, i
 		View = m_ListBoxView;
 
 	// background
+	m_BackgroundCorners = BackgroundCorners;
 	if(Background)
-		m_pRenderTools->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), CUI::CORNER_B, 5.0f);
+		m_pRenderTools->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), m_BackgroundCorners&CUI::CORNER_B, 5.0f);
 
 	// draw footers
 	if(m_pBottomText)

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -33,7 +33,7 @@ void CMenus::CListBox::DoHeader(const CUIRect *pRect, const char *pTitle,
 
 	// background
 	View.HSplitTop(HeaderHeight+Spacing, &Header, 0);
-	m_pRenderTools->DrawUIRect(&Header, vec4(0.0f, 0.0f, 0.0f, 0.25f), m_BackgroundCorners&CUI::CORNER_T, 5.0f);
+	m_pRenderTools->DrawUIRect(&Header, vec4(0.0f, 0.0f, 0.0f, m_pConfig->m_ClMenuAlpha/100.0f), m_BackgroundCorners&CUI::CORNER_T, 5.0f);
 
 	// draw header
 	View.HSplitTop(HeaderHeight, &Header, &View);
@@ -60,7 +60,7 @@ bool CMenus::CListBox::DoFilter(float FilterHeight, float Spacing)
 
 	// background
 	View.HSplitTop(FilterHeight+Spacing, &Filter, 0);
-	m_pRenderTools->DrawUIRect(&Filter, vec4(0.0f, 0.0f, 0.0f, 0.25f), 0, 5.0f);
+	m_pRenderTools->DrawUIRect(&Filter, vec4(0.0f, 0.0f, 0.0f, m_pConfig->m_ClMenuAlpha/100.0f), 0, 5.0f);
 
 	// draw filter
 	View.HSplitTop(FilterHeight, &Filter, &View);
@@ -99,7 +99,7 @@ void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, i
 	// background
 	m_BackgroundCorners = BackgroundCorners;
 	if(Background)
-		m_pRenderTools->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, 0.25f), m_BackgroundCorners&CUI::CORNER_B, 5.0f);
+		m_pRenderTools->DrawUIRect(&View, vec4(0.0f, 0.0f, 0.0f, m_pConfig->m_ClMenuAlpha/100.0f), m_BackgroundCorners&CUI::CORNER_B, 5.0f);
 
 	// draw footers
 	if(m_pBottomText)

--- a/src/game/client/components/voting.h
+++ b/src/game/client/components/voting.h
@@ -26,7 +26,6 @@ class CVoting : public CComponent
 	void Clear();
 	void Callvote(const char *pType, const char *pValue, const char *pReason, bool ForceVote);
 
-public:
 	int m_NumVoteOptions;
 	CVoteOptionClient *m_pFirst;
 	CVoteOptionClient *m_pLast;
@@ -34,30 +33,32 @@ public:
 	CVoteOptionClient *m_pRecycleFirst;
 	CVoteOptionClient *m_pRecycleLast;
 
+public:
 	CVoting();
 	virtual void OnReset();
 	virtual void OnStateChange(int NewState, int OldState);
 	virtual void OnConsoleInit();
 	virtual void OnMessage(int Msgtype, void *pRawMsg);
-	virtual void OnRender();
 
-	void RenderBars(CUIRect Bars, bool Text);
+	void AddOption(const char *pDescription);
+	void RenderBars(CUIRect Bars);
 
 	void CallvoteSpectate(int ClientID, const char *pReason, bool ForceVote = false);
 	void CallvoteKick(int ClientID, const char *pReason, bool ForceVote = false);
 	void CallvoteOption(int OptionID, const char *pReason, bool ForceVote = false);
-	void AddOption(const char *pDescription);
-	void RemovevoteOption(int OptionID);
-	void AddvoteOption(const char *pDescription, const char *pCommand);
+	void RconRemoveVoteOption(int OptionID);
+	void RconAddVoteOption(const char *pDescription, const char *pCommand);
 
-	void Vote(int v); // -1 = no, 1 = yes
+	void Vote(int Choice);
 
 	int SecondsLeft() { return (m_Closetime - time_get())/time_freq(); }
-	bool IsVoting() { return m_Closetime != 0; }
+	bool IsVoting() { return m_Closetime > 0 && m_Closetime > time_get(); }
 	int TakenChoice() const { return m_Voted; }
 	const char *VoteDescription() const { return m_aDescription; }
 	const char *VoteReason() const { return m_aReason; }
 	int CallvoteBlockTime() const { return m_CallvoteBlockTick > Client()->GameTick() ? (m_CallvoteBlockTick-Client()->GameTick())/Client()->GameTickSpeed() : 0; }
+	int NumVoteOptions() const { return m_NumVoteOptions; }
+	const CVoteOptionClient *FirstVoteOption() const { return m_pFirst; }
 };
 
 #endif

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -71,6 +71,7 @@ public:
 
 	enum
 	{
+		CORNER_NONE=0,
 		CORNER_TL=1,
 		CORNER_TR=2,
 		CORNER_BL=4,

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -122,10 +122,6 @@ public:
 	int m_VoteEnforce;
 	enum
 	{
-		VOTE_ENFORCE_UNKNOWN=0,
-		VOTE_ENFORCE_NO,
-		VOTE_ENFORCE_YES,
-
 		VOTE_TIME=25,
 		VOTE_CANCEL_TIME = 10,
 


### PR DESCRIPTION
Implementation:
- Add VOTE_CHOICE_NO, _PASS, _YES constants to protocol and use them instead of the magic values
   - These also replace the VOTE_ENFORCE_* constants in CGameContext.
- Add CUI::CORNER_NONE for better readability instead of passing 0.
- Remove voting `RenderBars` parameter and implementation to render number of votes as text, as it's unused.
- Use size constants for vote option description and command where applicable.
- Rename some variables and methods.
- Encapsulate some of the internal state of CVoting component.

UI:
- Align callvote button with the rest.
- Increase size of vote reason editbox slightly.
- Increase size of "Force vote" button slightly for other languages.
- Hide voting UI after time elapsed (change to `CVoting::IsVoting`). Prevents UI from continuing into negative time left if server fails to end the vote properly.
- Change vote reason clear button to use X sprite like server browser clear button, instead of manually drawing and handling button.
- Adjust corners, remove one layer of background in the voting menu.

Before:

![screenshot_2020-11-17_17-23-20](https://user-images.githubusercontent.com/23437060/99419388-5c47a180-28fc-11eb-98ec-bd326c4b7e6f.png)
![screenshot_2020-11-17_17-23-14](https://user-images.githubusercontent.com/23437060/99419394-5d78ce80-28fc-11eb-9053-d7e68705b661.png)

After:

![screenshot_2020-11-19_16-36-02](https://user-images.githubusercontent.com/23437060/99688208-d48d9e80-2a85-11eb-94e1-806cdd665f1b.png)
![screenshot_2020-11-19_16-36-14](https://user-images.githubusercontent.com/23437060/99688213-d6576200-2a85-11eb-9c84-93e15d3e07f3.png)
![screenshot_2020-11-19_16-36-09](https://user-images.githubusercontent.com/23437060/99688203-d2c3db00-2a85-11eb-9305-2eb5f950894c.png)
![screenshot_2020-11-19_16-35-57](https://user-images.githubusercontent.com/23437060/99688211-d5263500-2a85-11eb-8993-61ab58c6509c.png)

