### PR TITLE
KISSify TextRender and Increase Number of Lines in MOTD

### DIFF
--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -556,7 +556,6 @@ CWordWidthHint CTextRender::MakeWord(CTextCursor *pCursor, const char *pText, co
 	Hint.m_GlyphCount = 0;
 	Hint.m_EffectiveAdvanceX = pCursor->m_Advance.x;
 	Hint.m_EndsWithNewline = false;
-	Hint.m_EndOfWord = false;
 	Hint.m_IsBroken = false;
 
 	if(*pText == '\0' || pCur > pEnd)
@@ -625,7 +624,6 @@ CWordWidthHint CTextRender::MakeWord(CTextCursor *pCursor, const char *pText, co
 
 		if(IsSpace || Chr == 0)
 		{
-			Hint.m_EndOfWord = true;
 			Hint.m_EndsWithNewline = Chr == '\n';
 			if(AllowNewline && Hint.m_EndsWithNewline)
 			{
@@ -641,10 +639,7 @@ CWordWidthHint CTextRender::MakeWord(CTextCursor *pCursor, const char *pText, co
 
 		// break every char on non latin/greek characters
 		if(!isWestern(Chr))
-		{
-			Hint.m_EndOfWord = true;
 			break;
-		}
 	}
 
 	return Hint;

--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -435,11 +435,11 @@ bool CGlyphMap::RenderGlyph(CGlyph *pGlyph, bool Render)
 
 		TouchPage(AtlasIndex);
 
-		float UVscale = 1.0f / TEXTURE_SIZE;
-		pGlyph->m_aUvCoords[0] = (Position.x + Spacing) * UVscale;
-		pGlyph->m_aUvCoords[1] = (Position.y + Spacing) * UVscale;
-		pGlyph->m_aUvCoords[2] = pGlyph->m_aUvCoords[0] + OutlinedWidth * UVscale;
-		pGlyph->m_aUvCoords[3] = pGlyph->m_aUvCoords[1] + OutlinedHeight * UVscale;
+		float UVScale = 1.0f / TEXTURE_SIZE;
+		pGlyph->m_aUvCoords[0] = (Position.x + Spacing) * UVScale;
+		pGlyph->m_aUvCoords[1] = (Position.y + Spacing) * UVScale;
+		pGlyph->m_aUvCoords[2] = pGlyph->m_aUvCoords[0] + OutlinedWidth * UVScale;
+		pGlyph->m_aUvCoords[3] = pGlyph->m_aUvCoords[1] + OutlinedHeight * UVScale;
 	}
 
 	float Scale = 1.0f / FontSize;
@@ -502,7 +502,7 @@ vec2 CGlyphMap::Kerning(CGlyph *pLeft, CGlyph *pRight, int PixelSize)
 	return Vec;
 }
 
-int CGlyphMap::GetFontSizeIndex(int PixelSize)
+int CGlyphMap::GetFontSizeIndex(int PixelSize) const
 {
 	for(unsigned i = 0; i < NUM_FONT_SIZES; i++)
 	{
@@ -655,7 +655,7 @@ void CTextRender::TextRefreshGlyphs(CTextCursor *pCursor)
 
 	if(NumTotalPages != pCursor->m_PageCountWhenDrawn)
 	{
-		// pages were dropped, rerender glyphs
+		// pages were dropped, re-render glyphs
 		for(int i = 0; i < pCursor->m_Glyphs.size(); ++i)
 			m_pGlyphMap->RenderGlyph(pCursor->m_Glyphs[i].m_pGlyph, true);
 		pCursor->m_PageCountWhenDrawn = m_pGlyphMap->NumTotalPages();
@@ -750,6 +750,7 @@ void CTextRender::LoadFonts(IStorage *pStorage, IConsole *pConsole)
 {
 	// read file data into buffer
 	const char *pFilename = "fonts/index.json";
+
 	IOHANDLE File = pStorage->OpenFile(pFilename, IOFLAG_READ, IStorage::TYPE_ALL);
 	if(!File)
 	{
@@ -1233,18 +1234,18 @@ void CTextRender::DrawTextShadowed(CTextCursor *pCursor, vec2 ShadowOffset, floa
 vec2 CTextRender::CaretPosition(CTextCursor *pCursor, int NumChars)
 {
 	int CursorChars = 0;
-	int NumGlpyhs = pCursor->m_Glyphs.size();
-	if(NumGlpyhs == 0 || NumChars == 0)
+	int NumGlyphs = pCursor->m_Glyphs.size();
+	if(NumGlyphs == 0 || NumChars == 0)
 		return pCursor->m_CursorPos;
 
-	for(int i = 0; i < NumGlpyhs; ++i)
+	for(int i = 0; i < NumGlyphs; ++i)
 	{
 		CursorChars += pCursor->m_Glyphs[i].m_NumChars;
 		if(CursorChars > NumChars)
 			return pCursor->m_CursorPos + pCursor->m_Glyphs[i].m_Advance;
 	}
 
-	CScaledGlyph *pLastScaled = &pCursor->m_Glyphs[NumGlpyhs-1];
+	CScaledGlyph *pLastScaled = &pCursor->m_Glyphs[NumGlyphs-1];
 	return pCursor->m_CursorPos + pLastScaled->m_Advance + vec2(pLastScaled->m_pGlyph->m_AdvanceX, 0) * pLastScaled->m_Size;
 }
 

--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -434,7 +434,7 @@ bool CGlyphMap::RenderGlyph(CGlyph *pGlyph, bool Render)
 		FT_Done_Glyph((FT_Glyph)Glyph);
 
 		TouchPage(AtlasIndex);
-		
+
 		float UVscale = 1.0f / TEXTURE_SIZE;
 		pGlyph->m_aUvCoords[0] = (Position.x + Spacing) * UVscale;
 		pGlyph->m_aUvCoords[1] = (Position.y + Spacing) * UVscale;
@@ -1149,7 +1149,7 @@ void CTextRender::DrawText(CTextCursor *pCursor, vec2 Offset, int Texture, bool 
 	for(int i = NumQuads - 1; i >= 0; --i)
 	{
 		const CScaledGlyph& rScaled = pCursor->m_Glyphs[i];
-	    m_pGlyphMap->TouchPage(rScaled.m_pGlyph->m_AtlasIndex);
+		m_pGlyphMap->TouchPage(rScaled.m_pGlyph->m_AtlasIndex);
 		const CGlyph *pGlyph = rScaled.m_pGlyph;
 
 		if(Line != rScaled.m_Line)

--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -607,7 +607,7 @@ CWordWidthHint CTextRender::MakeWord(CTextCursor *pCursor, const char *pText, co
 			break;
 		}
 
-		if(Render && pGlyph->m_AtlasIndex >= 0)
+		if(Render)
 		{
 			CScaledGlyph Scaled;
 			Scaled.m_pGlyph = pGlyph;
@@ -631,7 +631,8 @@ CWordWidthHint CTextRender::MakeWord(CTextCursor *pCursor, const char *pText, co
 			{
 				// remove redundant space
 				Hint.m_GlyphCount--;
-				pCursor->m_Glyphs.remove_index(pCursor->m_Glyphs.size()-1);
+				if(Render)
+					pCursor->m_Glyphs.remove_index(pCursor->m_Glyphs.size()-1);
 			}
 			break;
 		}
@@ -1149,7 +1150,6 @@ void CTextRender::DrawText(CTextCursor *pCursor, vec2 Offset, int Texture, bool 
 	for(int i = NumQuads - 1; i >= 0; --i)
 	{
 		const CScaledGlyph& rScaled = pCursor->m_Glyphs[i];
-		m_pGlyphMap->TouchPage(rScaled.m_pGlyph->m_AtlasIndex);
 		const CGlyph *pGlyph = rScaled.m_pGlyph;
 
 		if(Line != rScaled.m_Line)
@@ -1163,8 +1163,10 @@ void CTextRender::DrawText(CTextCursor *pCursor, vec2 Offset, int Texture, bool 
 				LineOffset.x = 0;
 		}
 
-		if(i < StartGlyph || i >= EndGlyphs)
+		if(pGlyph->m_AtlasIndex < 0 || i < StartGlyph || i >= EndGlyphs)
 			continue;
+
+		m_pGlyphMap->TouchPage(pGlyph->m_AtlasIndex);
 
 		vec4 Color;
 		if(IsSecondary)

--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -366,7 +366,7 @@ void CGlyphMap::SetVariantFaceByName(const char *pFamilyName)
 
 bool CGlyphMap::RenderGlyph(CGlyph *pGlyph, bool Render)
 {
-	if(Render && pGlyph->m_Rendered && m_aAtlasPages[pGlyph->m_AtlasIndex].m_ID == pGlyph->m_PageID)
+	if(Render && pGlyph->m_Rendered && pGlyph->m_AtlasIndex >= 0 && m_aAtlasPages[pGlyph->m_AtlasIndex].m_ID == pGlyph->m_PageID)
 	{
 		TouchPage(pGlyph->m_AtlasIndex);
 		return true;
@@ -404,10 +404,10 @@ bool CGlyphMap::RenderGlyph(CGlyph *pGlyph, bool Render)
 	int AtlasIndex = -1;
 	int Page = -1;
 
-	if(Render)
+	if(Render && BitmapWidth > 0 && BitmapHeight > 0)
 	{
 		// find space in atlas
-		ivec2 Position;
+		ivec2 Position = ivec2(0, 0);
 		AtlasIndex = FitGlyph(Width, Height, &Position);
 		Page = m_aAtlasPages[AtlasIndex].m_ID;
 
@@ -434,7 +434,7 @@ bool CGlyphMap::RenderGlyph(CGlyph *pGlyph, bool Render)
 		FT_Done_Glyph((FT_Glyph)Glyph);
 
 		TouchPage(AtlasIndex);
-
+		
 		float UVscale = 1.0f / TEXTURE_SIZE;
 		pGlyph->m_aUvCoords[0] = (Position.x + Spacing) * UVscale;
 		pGlyph->m_aUvCoords[1] = (Position.y + Spacing) * UVscale;
@@ -607,7 +607,7 @@ CWordWidthHint CTextRender::MakeWord(CTextCursor *pCursor, const char *pText, co
 			break;
 		}
 
-		if(Render)
+		if(Render && pGlyph->m_AtlasIndex >= 0)
 		{
 			CScaledGlyph Scaled;
 			Scaled.m_pGlyph = pGlyph;

--- a/src/engine/client/textrender.h
+++ b/src/engine/client/textrender.h
@@ -143,7 +143,6 @@ struct CWordWidthHint
 	float m_EffectiveAdvanceX;
 	int m_CharCount;
 	int m_GlyphCount;
-	bool m_EndOfWord;
 	bool m_EndsWithNewline;
 	bool m_IsBroken;
 };

--- a/src/engine/client/textrender.h
+++ b/src/engine/client/textrender.h
@@ -115,8 +115,8 @@ public:
 	CGlyphMap(IGraphics *pGraphics, FT_Library FtLibrary);
 	~CGlyphMap();
 
-	IGraphics::CTextureHandle GetTexture(int Index) { return m_aTextures[Index]; }
-	FT_Face GetDefaultFace() { return m_DefaultFace; };
+	IGraphics::CTextureHandle GetTexture(int Index) const { return m_aTextures[Index]; }
+	FT_Face GetDefaultFace() const { return m_DefaultFace; };
 	int AddFace(FT_Face Face);
 	void SetDefaultFaceByName(const char *pFamilyName);
 	void AddFallbackFaceByName(const char *pFamilyName);
@@ -124,10 +124,10 @@ public:
 	
 	bool RenderGlyph(CGlyph *pGlyph, bool Render);
 	CGlyph *GetGlyph(int Chr, int FontSizeIndex, bool Render);
-	int GetFontSizeIndex(int PixelSize);
+	int GetFontSizeIndex(int PixelSize) const;
 	vec2 Kerning(CGlyph *pLeft, CGlyph *pRight, int PixelSize);
 
-	int NumTotalPages() { return m_NumTotalPages; }
+	int NumTotalPages() const { return m_NumTotalPages; }
 	void TouchPage(int Index);
 	void PagesAccessReset();
 };
@@ -199,8 +199,8 @@ public:
 	void TextColor(float r, float g, float b, float a);
 	void TextSecondaryColor(float r, float g, float b, float a);
 
-	vec4 GetColor() { return vec4(m_TextR, m_TextG, m_TextB, m_TextA); }
-	vec4 GetSecondaryColor() { return vec4(m_TextSecondaryR, m_TextSecondaryG, m_TextSecondaryB, m_TextSecondaryA); }
+	vec4 GetColor() const { return vec4(m_TextR, m_TextG, m_TextB, m_TextA); }
+	vec4 GetSecondaryColor() const { return vec4(m_TextSecondaryR, m_TextSecondaryG, m_TextSecondaryB, m_TextSecondaryA); }
 
 	float TextWidth(float FontSize, const char *pText, int Length);
 	void TextDeferred(CTextCursor *pCursor, const char *pText, int Length);

--- a/src/engine/client/textrender.h
+++ b/src/engine/client/textrender.h
@@ -64,41 +64,29 @@ struct CGlyphIndex
 	friend bool operator >=(const CGlyphIndex& l, const CGlyphIndex& r) { return !(l < r); };
 };
 
-class CAtlas
-{
-	array<ivec3> m_Sections;
-
-	int m_ID;
-	int m_Width;
-	int m_Height;
-
-	ivec2 m_Offset;
-
-	int m_LastFrameAccess;
-	int m_Access;
-	bool m_IsEmpty;
-
-	int TrySection(int Index, int Width, int Height);
-public:
-	CAtlas() { m_LastFrameAccess = 0; m_Access = 0; }
-	void Init(int Index, int X, int Y, int Width, int Height);
-
-	ivec2 Add(int Width, int Height);
-
-	int GetWidth() { return m_Width; }
-	int GetHeight() { return m_Height; }
-	int GetOffsetX() { return m_Offset.x; }
-	int GetOffsetY() { return m_Offset.y; }
-
-	int GetPageID() { return m_ID; }
-	void Touch() { m_Access++; }
-	int GetAccess() { return m_LastFrameAccess; }
-	void Update() { m_LastFrameAccess = m_Access; m_Access = 0; }
-	bool IsEmpty() { return m_IsEmpty; }
-};
-
 class CGlyphMap
 {
+	class CAtlas
+	{
+	public:
+		array<ivec3> m_Sections;
+
+		int m_ID;
+		int m_Width;
+		int m_Height;
+
+		ivec2 m_Offset;
+
+		int m_LastFrameAccess;
+		int m_Access;
+		bool m_IsEmpty;
+
+		CAtlas() { m_LastFrameAccess = 0; m_Access = 0; }
+		int TrySection(int Index, int Width, int Height);
+		void Init(int Index, int X, int Y, int Width, int Height);
+		ivec2 Add(int Width, int Height);
+	};
+
 	IGraphics *m_pGraphics;
 	FT_Stroker m_FtStroker;
 	IGraphics::CTextureHandle m_aTextures[2];
@@ -140,6 +128,7 @@ public:
 	vec2 Kerning(CGlyph *pLeft, CGlyph *pRight, int PixelSize);
 
 	int NumTotalPages() { return m_NumTotalPages; }
+	void TouchPage(int Index);
 	void PagesAccessReset();
 };
 

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -9,9 +9,6 @@
 #include <engine/console.h>
 #include <engine/graphics.h>
 
-#define TEXTALIGN_MASK_HORI 3
-#define TEXTALIGN_MASK_VERT 12
-
 // TextRender Features
 enum
 {
@@ -22,11 +19,14 @@ enum
 	TEXTFLAG_ALLOW_NEWLINE=2,
 
 	// Display "…" when the text is truncated
-	// TODO: implement this
 	TEXTFLAG_ELLIPSIS=4,
 
 	// If set, newline will try not to break words
 	TEXTFLAG_WORD_WRAP=8,
+
+	// Masks
+	TEXTALIGN_MASK_HORI=3,
+	TEXTALIGN_MASK_VERT=12
 };
 
 enum ETextAlignment

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -56,7 +56,7 @@ class CScaledGlyph
 public:
 	CGlyph *m_pGlyph;
 	float m_Size;
-	int m_NumChars; // TODO: handle this
+	int m_NumChars;
 	int m_Line;
 	vec2 m_Advance;
 	vec4 m_TextColor;
@@ -66,8 +66,8 @@ public:
 struct CTextBoundingBox
 {
 	float x, y, w, h;
-	float Right() { return x + w; }
-	float Bottom() { return y + h; }
+	float Right() const { return x + w; }
+	float Bottom() const { return y + h; }
 };
 
 class CTextCursor
@@ -91,7 +91,7 @@ class CTextCursor
 	array<CScaledGlyph> m_Glyphs;
 	int64 m_StringVersion;
 
-	CTextBoundingBox AlignedBoundingBox()
+	CTextBoundingBox AlignedBoundingBox() const
 	{
 		CTextBoundingBox Box;
 		if((m_Align & TEXTALIGN_MASK_HORI) == TEXTALIGN_RIGHT)
@@ -157,15 +157,15 @@ public:
 
 	void MoveTo(float x, float y) { m_CursorPos = vec2(x, y); }
 	void MoveTo(vec2 Position) { m_CursorPos = Position; }
-	float Width() { return m_Width; }
-	float Height() { return m_Height; }
-	float BaseLineY() { return m_NextLineAdvanceY; }
-	vec2 CursorPosition() { return m_CursorPos; }
-	vec2 AdvancePosition() { return m_CursorPos + m_Advance; }
-	bool IsTruncated() { return m_Truncated; }
-	int LineCount() { return m_LineCount; }
-	int GlyphCount() { return m_Glyphs.size(); }
-	int CharCount() { return m_CharCount; }
+	float Width() const { return m_Width; }
+	float Height() const { return m_Height; }
+	float BaseLineY() const { return m_NextLineAdvanceY; }
+	vec2 CursorPosition() const { return m_CursorPos; }
+	vec2 AdvancePosition() const { return m_CursorPos + m_Advance; }
+	bool IsTruncated() const { return m_Truncated; }
+	int LineCount() const { return m_LineCount; }
+	int GlyphCount() const { return m_Glyphs.size(); }
+	int CharCount() const { return m_CharCount; }
 
 	// Default Cursor: Top left single line no width limit
 	CTextCursor() { Set(10.0f, 0, 0, 0); Reset(); }
@@ -173,7 +173,7 @@ public:
 	CTextCursor(float FontSize, float x, float y, int Flags = 0) { Set(FontSize, x, y, Flags); Reset(); }
 
 	// Exposed Bounding Box, converted to screen coord.
-	CTextBoundingBox BoundingBox()
+	CTextBoundingBox BoundingBox() const
 	{
 		CTextBoundingBox Box = AlignedBoundingBox();
 		Box.x += m_CursorPos.x;
@@ -181,7 +181,7 @@ public:
 		return Box;
 	}
 
-	bool Rendered() { return m_Glyphs.size() > 0; }
+	bool Rendered() const { return m_Glyphs.size() > 0; }
 };
 
 class ITextRender : public IInterface
@@ -205,8 +205,8 @@ public:
 	inline void TextColor(const vec4 &Color) { TextColor(Color.r, Color.g, Color.b, Color.a); }
 	inline void TextSecondaryColor(const vec4 &Color) { TextSecondaryColor(Color.r, Color.g, Color.b, Color.a); }
 
-	virtual vec4 GetColor() = 0;
-	virtual vec4 GetSecondaryColor() = 0;
+	virtual vec4 GetColor() const = 0;
+	virtual vec4 GetSecondaryColor() const = 0;
 
 	// These should be only called after TextDeferred, TextOutlined or TextShadowed
 	// TODO: allow changing quad colors

--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -36,12 +36,15 @@ void CMotd::OnRender()
 	if(!IsActive())
 		return;
 
-	float Width = 400*3.0f*Graphics()->ScreenAspect();
-	float Height = 400*3.0f;
+	const float Width = 400*3.0f*Graphics()->ScreenAspect();
+	const float Height = 400*3.0f;
 
 	Graphics()->MapScreen(0, 0, Width, Height);
 
-	float h = 800.0f;
+	const int MaxLines = 24;
+	const float TextSize = 32.0f;
+
+	float h = MaxLines * TextSize + 2 * 25.0f;
 	float w = 650.0f;
 	float x = Width/2 - w/2;
 	float y = 150.0f;
@@ -50,13 +53,12 @@ void CMotd::OnRender()
 	Graphics()->BlendNormal();
 	RenderTools()->DrawRoundRect(&Rect, vec4(0.0f, 0.0f, 0.0f, 0.5f), 30.0f);
 
-	Rect.Margin(30.0f, &Rect);
+	Rect.Margin(25.0f, &Rect);
 
-	float TextSize = 32.0f;
-	m_ServerMotdCursor.m_Flags = TEXTFLAG_ALLOW_NEWLINE | TEXTFLAG_WORD_WRAP;
+	m_ServerMotdCursor.m_Flags = TEXTFLAG_ALLOW_NEWLINE | TEXTFLAG_WORD_WRAP | TEXTFLAG_ELLIPSIS;
 	m_ServerMotdCursor.m_FontSize = TextSize;
 	m_ServerMotdCursor.m_MaxWidth = Rect.w;
-	m_ServerMotdCursor.m_MaxLines = (int)(Rect.h/TextSize);
+	m_ServerMotdCursor.m_MaxLines = MaxLines;
 
 	m_ServerMotdCursor.Reset(m_ServerMotdTime);
 	m_ServerMotdCursor.MoveTo(Rect.x, Rect.y);


### PR DESCRIPTION
@fokkonaut reported that the new TextRender fits 23 lines in MOTD window instead of 24 lines before the textrender update.

* Reduced the margin of MOTD window and changed to the logic from "fit text inside rect" to "fit rect to contain 24 lines".
* Flagged MOTD text to use auto ellipsis feature, because the in-game menu can display more MOTD text, so it is nice to have an indicator showing there are more text available.
* KISSified `TextDeferred` just because I was working on it.


Preview:
![image](https://user-images.githubusercontent.com/3797859/99556665-c8113380-29fc-11eb-82c6-a86001c86d11.png)