### PR TITLE
UI & Input Refactoring: implement text selection, implement tooltips, fix various issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1469,7 +1469,6 @@ if(CLIENT)
     components/menus_demo.cpp
     components/menus_ingame.cpp
     components/menus_listbox.cpp
-    components/menus_scrollregion.cpp
     components/menus_settings.cpp
     components/menus_start.cpp
     components/motd.cpp
@@ -1507,6 +1506,8 @@ if(CLIENT)
     ui.h
     ui_rect.cpp
     ui_rect.h
+    ui_scrollregion.cpp
+    ui_scrollregion.h
   )
   set_src(GAME_EDITOR GLOB src/game/editor
     auto_map.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1468,7 +1468,6 @@ if(CLIENT)
     components/menus_callback.cpp
     components/menus_demo.cpp
     components/menus_ingame.cpp
-    components/menus_listbox.cpp
     components/menus_settings.cpp
     components/menus_start.cpp
     components/motd.cpp
@@ -1504,6 +1503,8 @@ if(CLIENT)
     render_map.cpp
     ui.cpp
     ui.h
+    ui_listbox.cpp
+    ui_listbox.h
     ui_rect.cpp
     ui_rect.h
     ui_scrollregion.cpp

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -16,6 +16,7 @@
 #include <game/client/component.h>
 #include <game/client/localization.h>
 #include <game/client/ui.h>
+#include <game/client/ui_scrollregion.h>
 
 #include "skins.h"
 
@@ -53,102 +54,6 @@ private:
 	void DoJoystickBar(const CUIRect *pRect, float Current, float Tolerance, bool Active);
 	void DoButton_KeySelect(CButtonContainer *pBC, const char *pText, const CUIRect *pRect);
 	int DoKeyReader(CButtonContainer *pPC, const CUIRect *pRect, int Key, int Modifier, int *pNewModifier);
-
-	// Scroll region : found in menus_scrollregion.cpp
-	struct CScrollRegionParams
-	{
-		float m_ScrollbarWidth;
-		float m_ScrollbarMargin;
-		float m_SliderMinHeight;
-		float m_ScrollUnit;
-		vec4 m_ClipBgColor;
-		vec4 m_ScrollbarBgColor;
-		vec4 m_RailBgColor;
-		vec4 m_SliderColor;
-		vec4 m_SliderColorHover;
-		vec4 m_SliderColorGrabbed;
-		int m_Flags;
-
-		enum {
-			FLAG_CONTENT_STATIC_WIDTH = 0x1
-		};
-
-		CScrollRegionParams()
-		{
-			m_ScrollbarWidth = 20;
-			m_ScrollbarMargin = 5;
-			m_SliderMinHeight = 25;
-			m_ScrollUnit = 10;
-			m_ClipBgColor = vec4(0.0f, 0.0f, 0.0f, 0.25f);
-			m_ScrollbarBgColor = vec4(0.0f, 0.0f, 0.0f, 0.25f);
-			m_RailBgColor = vec4(1.0f, 1.0f, 1.0f, 0.25f);
-			m_SliderColor = vec4(0.8f, 0.8f, 0.8f, 1.0f);
-			m_SliderColorHover = vec4(1.0f, 1.0f, 1.0f, 1.0f);
-			m_SliderColorGrabbed = vec4(0.9f, 0.9f, 0.9f, 1.0f);
-			m_Flags = 0;
-		}
-	};
-
-	/*
-	Usage:
-		-- Initialization --
-		static CScrollRegion s_ScrollRegion;
-		vec2 ScrollOffset(0, 0);
-		s_ScrollRegion.Begin(&ScrollRegionRect, &ScrollOffset);
-		Content = ScrollRegionRect;
-		Content.y += ScrollOffset.y;
-
-		-- "Register" your content rects --
-		CUIRect Rect;
-		Content.HSplitTop(SomeValue, &Rect, &Content);
-		s_ScrollRegion.AddRect(Rect);
-
-		-- [Optional] Knowing if a rect is clipped --
-		s_ScrollRegion.IsRectClipped(Rect);
-
-		-- [Optional] Scroll to a rect (to the last added rect)--
-		...
-		s_ScrollRegion.AddRect(Rect);
-		s_ScrollRegion.ScrollHere(Option);
-
-		-- End --
-		s_ScrollRegion.End();
-	*/
-	// Instances of CScrollRegion must be static, as member addresses are used as UI item IDs
-	class CScrollRegion : private CUIElementBase
-	{
-	private:
-		float m_ScrollY;
-		float m_ContentH;
-		float m_RequestScrollY; // [0, ContentHeight]
-
-		float m_AnimTime;
-		float m_AnimInitScrollY;
-		float m_AnimTargetScrollY;
-
-		CUIRect m_ClipRect;
-		CUIRect m_RailRect;
-		CUIRect m_LastAddedRect; // saved for ScrollHere()
-		vec2 m_SliderGrabPos; // where did user grab the slider
-		vec2 m_ContentScrollOff;
-		CScrollRegionParams m_Params;
-
-	public:
-		enum {
-			SCROLLHERE_KEEP_IN_VIEW=0,
-			SCROLLHERE_TOP,
-			SCROLLHERE_BOTTOM,
-		};
-
-		CScrollRegion();
-		void Begin(CUIRect* pClipRect, vec2* pOutOffset, CScrollRegionParams* pParams = 0);
-		void End();
-		void AddRect(CUIRect Rect);
-		void ScrollHere(int Option = CScrollRegion::SCROLLHERE_KEEP_IN_VIEW);
-		bool IsRectClipped(const CUIRect& Rect) const;
-		bool IsScrollbarShown() const;
-		bool IsAnimating() const;
-	};
 
 	// Listbox : found in menus_listbox.cpp
 	struct CListboxItem

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -16,6 +16,7 @@
 #include <game/client/component.h>
 #include <game/client/localization.h>
 #include <game/client/ui.h>
+#include <game/client/ui_listbox.h>
 #include <game/client/ui_scrollregion.h>
 
 #include "skins.h"
@@ -54,60 +55,6 @@ private:
 	void DoJoystickBar(const CUIRect *pRect, float Current, float Tolerance, bool Active);
 	void DoButton_KeySelect(CButtonContainer *pBC, const char *pText, const CUIRect *pRect);
 	int DoKeyReader(CButtonContainer *pPC, const CUIRect *pRect, int Key, int Modifier, int *pNewModifier);
-
-	// Listbox : found in menus_listbox.cpp
-	struct CListboxItem
-	{
-		bool m_Visible;
-		bool m_Selected;
-		bool m_Disabled;
-		CUIRect m_Rect;
-	};
-
-	// Instances of CListBox must be static, as member addresses are used as UI item IDs
-	class CListBox : private CUIElementBase
-	{
-	private:
-		CUIRect m_ListBoxView;
-		float m_ListBoxRowHeight;
-		int m_ListBoxItemIndex;
-		int m_ListBoxSelectedIndex;
-		int m_ListBoxNewSelected;
-		int m_ListBoxNewSelOffset;
-		int m_ListBoxUpdateScroll;
-		int m_ListBoxDoneEvents;
-		int m_ListBoxNumItems;
-		int m_ListBoxItemsPerRow;
-		bool m_ListBoxItemActivated;
-		const char *m_pBottomText;
-		float m_FooterHeight;
-		CScrollRegion m_ScrollRegion;
-		vec2 m_ScrollOffset;
-		char m_aFilterString[64];
-		CLineInput m_FilterInput;
-		int m_BackgroundCorners;
-
-	protected:
-		CListboxItem DoNextRow();
-
-	public:
-		CListBox();
-
-		void DoBegin(const CUIRect *pRect);
-		void DoHeader(const CUIRect *pRect, const char *pTitle, float HeaderHeight = 20.0f, float Spacing = 2.0f);
-		void DoSpacing(float Spacing = 20.0f);
-		bool DoFilter(float FilterHeight = 20.0f, float Spacing = 2.0f);
-		void DoFooter(const char *pBottomText, float FooterHeight = 20.0f); // call before DoStart to create a footer
-		void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex,
-					const CUIRect *pRect = 0, bool Background = true, bool *pActive = 0, int BackgroundCorners = CUIRect::CORNER_ALL);
-		CListboxItem DoNextItem(const void *pID, bool Selected = false, bool *pActive = 0);
-		CListboxItem DoSubheader();
-		int DoEnd();
-		bool FilterMatches(const char *pNeedle) const;
-		bool WasItemActivated() const { return m_ListBoxItemActivated; }
-		float GetScrollBarWidth() const { return m_ScrollRegion.IsScrollbarShown() ? 20 : 0; } // defined in menus_scrollregion.cpp
-	};
-
 
 	enum
 	{

--- a/src/game/client/ui_listbox.h
+++ b/src/game/client/ui_listbox.h
@@ -1,0 +1,60 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_CLIENT_UI_LISTBOX_H
+#define GAME_CLIENT_UI_LISTBOX_H
+
+#include "ui_scrollregion.h"
+
+struct CListboxItem
+{
+	bool m_Visible;
+	bool m_Selected;
+	bool m_Disabled;
+	CUIRect m_Rect;
+};
+
+// Instances of CListBox must be static, as member addresses are used as UI item IDs
+class CListBox : private CUIElementBase
+{
+private:
+	CUIRect m_ListBoxView;
+	float m_ListBoxRowHeight;
+	int m_ListBoxItemIndex;
+	int m_ListBoxSelectedIndex;
+	int m_ListBoxNewSelected;
+	int m_ListBoxNewSelOffset;
+	int m_ListBoxUpdateScroll;
+	bool m_ListBoxDoneEvents;
+	int m_ListBoxNumItems;
+	int m_ListBoxItemsPerRow;
+	bool m_ListBoxItemActivated;
+	const char *m_pBottomText;
+	float m_FooterHeight;
+	CScrollRegion m_ScrollRegion;
+	vec2 m_ScrollOffset;
+	CLineInput m_FilterInput;
+	char m_aFilterString[128];
+	int m_BackgroundCorners;
+
+protected:
+	CListboxItem DoNextRow();
+
+public:
+	CListBox();
+
+	void DoBegin(const CUIRect *pRect);
+	void DoHeader(const CUIRect *pRect, const char *pTitle, float HeaderHeight = 20.0f, float Spacing = 2.0f);
+	void DoSpacing(float Spacing = 20.0f);
+	bool DoFilter(float FilterHeight = 20.0f, float Spacing = 2.0f);
+	void DoFooter(const char *pBottomText, float FooterHeight = 20.0f); // call before DoStart to create a footer
+	void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex,
+				const CUIRect *pRect = 0, bool Background = true, bool *pActive = 0, int BackgroundCorners = CUIRect::CORNER_ALL);
+	CListboxItem DoNextItem(const void *pID, bool Selected = false, bool *pActive = 0);
+	CListboxItem DoSubheader();
+	int DoEnd();
+	bool FilterMatches(const char *pNeedle) const;
+	bool WasItemActivated() const { return m_ListBoxItemActivated; }
+	float GetScrollBarWidth() const { return m_ScrollRegion.IsScrollbarShown() ? 20 : 0; }
+};
+
+#endif

--- a/src/game/client/ui_listbox.h
+++ b/src/game/client/ui_listbox.h
@@ -23,7 +23,7 @@ private:
 	int m_ListBoxSelectedIndex;
 	int m_ListBoxNewSelected;
 	int m_ListBoxNewSelOffset;
-	int m_ListBoxUpdateScroll;
+	bool m_ListBoxUpdateScroll;
 	bool m_ListBoxDoneEvents;
 	int m_ListBoxNumItems;
 	int m_ListBoxItemsPerRow;
@@ -55,6 +55,7 @@ public:
 	bool FilterMatches(const char *pNeedle) const;
 	bool WasItemActivated() const { return m_ListBoxItemActivated; }
 	float GetScrollBarWidth() const { return m_ScrollRegion.IsScrollbarShown() ? 20 : 0; }
+	void ScrollToSelection() { m_ListBoxUpdateScroll = true; }
 };
 
 #endif

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -1,18 +1,14 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <math.h>
-
 #include <base/system.h>
-#include <base/math.h>
 #include <base/vmath.h>
 
-#include <engine/config.h>
+#include <engine/client.h>
 #include <engine/keys.h>
-#include <engine/shared/config.h>
 
-#include "menus.h"
+#include "ui_scrollregion.h"
 
-CMenus::CScrollRegion::CScrollRegion()
+CScrollRegion::CScrollRegion()
 {
 	m_ScrollY = 0;
 	m_ContentH = 0;
@@ -24,7 +20,7 @@ CMenus::CScrollRegion::CScrollRegion()
 	m_Params = CScrollRegionParams();
 }
 
-void CMenus::CScrollRegion::Begin(CUIRect* pClipRect, vec2* pOutOffset, CScrollRegionParams* pParams)
+void CScrollRegion::Begin(CUIRect *pClipRect, vec2 *pOutOffset, CScrollRegionParams *pParams)
 {
 	if(pParams)
 		m_Params = *pParams;
@@ -34,7 +30,7 @@ void CMenus::CScrollRegion::Begin(CUIRect* pClipRect, vec2* pOutOffset, CScrollR
 
 	CUIRect ScrollBarBg;
 	bool HasScrollBar = ContentOverflows || ForceShowScrollbar;
-	CUIRect* pModifyRect = HasScrollBar ? pClipRect : 0;
+	CUIRect *pModifyRect = HasScrollBar ? pClipRect : 0;
 	pClipRect->VSplitRight(m_Params.m_ScrollbarWidth, pModifyRect, &ScrollBarBg);
 	ScrollBarBg.Margin(m_Params.m_ScrollbarMargin, &m_RailRect);
 
@@ -59,7 +55,7 @@ void CMenus::CScrollRegion::Begin(CUIRect* pClipRect, vec2* pOutOffset, CScrollR
 	*pOutOffset = m_ContentScrollOff;
 }
 
-void CMenus::CScrollRegion::End()
+void CScrollRegion::End()
 {
 	UI()->ClipDisable();
 
@@ -127,7 +123,7 @@ void CMenus::CScrollRegion::End()
 
 	bool Hovered = false;
 	bool Grabbed = false;
-	const void* pID = &m_ScrollY;
+	const void *pID = &m_ScrollY;
 	const bool InsideSlider = UI()->MouseHovered(&Slider);
 	const bool InsideRail = UI()->MouseHovered(&m_RailRect);
 
@@ -180,7 +176,7 @@ void CMenus::CScrollRegion::End()
 	Slider.Draw(SliderColor, Slider.w/2.0f);
 }
 
-void CMenus::CScrollRegion::AddRect(CUIRect Rect)
+void CScrollRegion::AddRect(const CUIRect &Rect)
 {
 	vec2 ContentPos = vec2(m_ClipRect.x, m_ClipRect.y);
 	ContentPos.x += m_ContentScrollOff.x;
@@ -189,7 +185,7 @@ void CMenus::CScrollRegion::AddRect(CUIRect Rect)
 	m_ContentH = maximum(Rect.y + Rect.h - ContentPos.y, m_ContentH);
 }
 
-void CMenus::CScrollRegion::ScrollHere(int Option)
+void CScrollRegion::ScrollHere(int Option)
 {
 	const float MinHeight = minimum(m_ClipRect.h, m_LastAddedRect.h);
 	const float TopScroll = m_LastAddedRect.y - (m_ClipRect.y + m_ContentScrollOff.y);
@@ -216,7 +212,7 @@ void CMenus::CScrollRegion::ScrollHere(int Option)
 	}
 }
 
-bool CMenus::CScrollRegion::IsRectClipped(const CUIRect& Rect) const
+bool CScrollRegion::IsRectClipped(const CUIRect &Rect) const
 {
 	return (m_ClipRect.x > (Rect.x + Rect.w)
 		|| (m_ClipRect.x + m_ClipRect.w) < Rect.x
@@ -224,12 +220,12 @@ bool CMenus::CScrollRegion::IsRectClipped(const CUIRect& Rect) const
 		|| (m_ClipRect.y + m_ClipRect.h) < Rect.y);
 }
 
-bool CMenus::CScrollRegion::IsScrollbarShown() const
+bool CScrollRegion::IsScrollbarShown() const
 {
 	return m_ContentH > m_ClipRect.h;
 }
 
-bool CMenus::CScrollRegion::IsAnimating() const
+bool CScrollRegion::IsAnimating() const
 {
 	return m_AnimTime > 0;
 }

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -1,0 +1,106 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_CLIENT_UI_SCROLLREGION_H
+#define GAME_CLIENT_UI_SCROLLREGION_H
+
+#include "ui.h"
+
+struct CScrollRegionParams
+{
+	float m_ScrollbarWidth;
+	float m_ScrollbarMargin;
+	float m_SliderMinHeight;
+	float m_ScrollUnit;
+	vec4 m_ClipBgColor;
+	vec4 m_ScrollbarBgColor;
+	vec4 m_RailBgColor;
+	vec4 m_SliderColor;
+	vec4 m_SliderColorHover;
+	vec4 m_SliderColorGrabbed;
+	int m_Flags;
+
+	enum
+	{
+		FLAG_CONTENT_STATIC_WIDTH = 0x1
+	};
+
+	CScrollRegionParams()
+	{
+		m_ScrollbarWidth = 20;
+		m_ScrollbarMargin = 5;
+		m_SliderMinHeight = 25;
+		m_ScrollUnit = 10;
+		m_ClipBgColor = vec4(0.0f, 0.0f, 0.0f, 0.25f);
+		m_ScrollbarBgColor = vec4(0.0f, 0.0f, 0.0f, 0.25f);
+		m_RailBgColor = vec4(1.0f, 1.0f, 1.0f, 0.25f);
+		m_SliderColor = vec4(0.8f, 0.8f, 0.8f, 1.0f);
+		m_SliderColorHover = vec4(1.0f, 1.0f, 1.0f, 1.0f);
+		m_SliderColorGrabbed = vec4(0.9f, 0.9f, 0.9f, 1.0f);
+		m_Flags = 0;
+	}
+};
+
+/*
+Usage:
+	-- Initialization --
+	static CScrollRegion s_ScrollRegion;
+	vec2 ScrollOffset(0, 0);
+	s_ScrollRegion.Begin(&ScrollRegionRect, &ScrollOffset);
+	Content = ScrollRegionRect;
+	Content.y += ScrollOffset.y;
+
+	-- "Register" your content rects --
+	CUIRect Rect;
+	Content.HSplitTop(SomeValue, &Rect, &Content);
+	s_ScrollRegion.AddRect(Rect);
+
+	-- [Optional] Knowing if a rect is clipped --
+	s_ScrollRegion.IsRectClipped(Rect);
+
+	-- [Optional] Scroll to a rect (to the last added rect)--
+	...
+	s_ScrollRegion.AddRect(Rect);
+	s_ScrollRegion.ScrollHere(Option);
+
+	-- End --
+	s_ScrollRegion.End();
+*/
+
+// Instances of CScrollRegion must be static, as member addresses are used as UI item IDs
+class CScrollRegion : private CUIElementBase
+{
+private:
+	float m_ScrollY;
+	float m_ContentH;
+	float m_RequestScrollY; // [0, ContentHeight]
+
+	float m_AnimTime;
+	float m_AnimInitScrollY;
+	float m_AnimTargetScrollY;
+
+	CUIRect m_ClipRect;
+	CUIRect m_RailRect;
+	CUIRect m_LastAddedRect; // saved for ScrollHere()
+	vec2 m_SliderGrabPos; // where did user grab the slider
+	vec2 m_ContentScrollOff;
+	CScrollRegionParams m_Params;
+
+public:
+	enum
+	{
+		SCROLLHERE_KEEP_IN_VIEW = 0,
+		SCROLLHERE_TOP,
+		SCROLLHERE_BOTTOM,
+	};
+
+	CScrollRegion();
+	void Begin(CUIRect *pClipRect, vec2 *pOutOffset, CScrollRegionParams *pParams = 0);
+	void End();
+	void AddRect(const CUIRect &Rect);
+	void ScrollHere(int Option = CScrollRegion::SCROLLHERE_KEEP_IN_VIEW);
+	bool IsRectClipped(const CUIRect &Rect) const;
+	bool IsScrollbarShown() const;
+	bool IsAnimating() const;
+};
+
+#endif

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2545,69 +2545,39 @@ void CEditor::SortImages()
 
 void CEditor::RenderImagesList(CUIRect ToolBox)
 {
-	static float s_ScrollValue = 0.0f;
-	const float RowHeight = 14.0f;
-	const float HeaderHeight = RowHeight + 1.0f;
-	const float HeaderSeparatorHeight = 5.0f;
-	const float AddButtonHeight = 17.0f;
-	const float ImagesHeight = 2 * (HeaderHeight + HeaderSeparatorHeight) + RowHeight * m_Map.m_lImages.size() + AddButtonHeight;
-	const float ScrollDifference = maximum(ImagesHeight - ToolBox.h, 0.0f);
+	const float RowHeight = 12.0f;
 
-	if(ScrollDifference > 0) // Do we even need a scrollbar?
-	{
-		CUIRect Scroll;
-		ToolBox.VSplitRight(15.0f, &ToolBox, &Scroll);
-		ToolBox.VSplitRight(3.0f, &ToolBox, 0);	// extra spacing
-		s_ScrollValue = UI()->DoScrollbarV(&s_ScrollValue, &Scroll, s_ScrollValue);
-		if(UI()->MouseInside(&Scroll) || UI()->MouseInside(&ToolBox))
-		{
-			int ScrollNum = (int)((ImagesHeight-ToolBox.h)/RowHeight)+1;
-			if(ScrollNum > 0)
-			{
-				if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP))
-					s_ScrollValue = clamp(s_ScrollValue - 1.0f/ScrollNum, 0.0f, 1.0f);
-				if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
-					s_ScrollValue = clamp(s_ScrollValue + 1.0f/ScrollNum, 0.0f, 1.0f);
-			}
-		}
-	}
-	else
-		s_ScrollValue = 0.0f;
-
-	const float ImageStartAt = ScrollDifference * s_ScrollValue;
-	const float ImageStopAt = ImagesHeight + ScrollDifference * (s_ScrollValue - 1.0f);
-	float ImageCur = 0.0f;
+	static CScrollRegion s_ScrollRegion;
+	vec2 ScrollOffset(0.0f, 0.0f);
+	CScrollRegionParams ScrollParams;
+	ScrollParams.m_ClipBgColor = vec4(0.0f, 0.0f, 0.0f, 0.0f);
+	ScrollParams.m_ScrollbarBgColor = vec4(0.0f, 0.0f, 0.0f, 0.0f);
+	ScrollParams.m_ScrollbarWidth = 10.0f;
+	ScrollParams.m_ScrollbarMargin = 3.0f;
+	ScrollParams.m_ScrollUnit = RowHeight * 5;
+	s_ScrollRegion.Begin(&ToolBox, &ScrollOffset, &ScrollParams);
+	ToolBox.y += ScrollOffset.y;
 
 	for(int e = 0; e < 2; e++) // two passes, first embedded, then external
 	{
-		if(ImageCur + HeaderHeight > ImageStopAt)
-			return;
-
 		CUIRect Slot;
-		if(ImageCur >= ImageStartAt)
-		{
-			ToolBox.HSplitTop(HeaderHeight, &Slot, &ToolBox);
+		ToolBox.HSplitTop(RowHeight+3.0f, &Slot, &ToolBox);
+		s_ScrollRegion.AddRect(Slot);
+		if(!s_ScrollRegion.IsRectClipped(Slot))
 			UI()->DoLabel(&Slot, e == 0 ? "Embedded" : "External", 12.0f, TEXTALIGN_CENTER);
-		}
-		ImageCur += HeaderHeight;
 
 		for(int i = 0; i < m_Map.m_lImages.size(); i++)
 		{
 			if((e && !m_Map.m_lImages[i]->m_External) || (!e && m_Map.m_lImages[i]->m_External))
 				continue;
 
-			if(ImageCur + RowHeight > ImageStopAt)
-				return;
-			else if(ImageCur < ImageStartAt)
-			{
-				ImageCur += RowHeight;
+			ToolBox.HSplitTop(RowHeight+2.0f, &Slot, &ToolBox);
+			s_ScrollRegion.AddRect(Slot);
+			if(s_ScrollRegion.IsRectClipped(Slot))
 				continue;
-			}
-			ImageCur += RowHeight;
+			Slot.HSplitTop(RowHeight, &Slot, 0);
 
-			ToolBox.HSplitTop(12.0f, &Slot, &ToolBox);
-
-			// check if images is used
+			// check if image is used
 			bool Used = false;
 			for(int g = 0; !Used && (g < m_Map.m_lGroups.size()); g++)
 			{
@@ -2616,14 +2586,12 @@ void CEditor::RenderImagesList(CUIRect ToolBox)
 				{
 					if(pGroup->m_lLayers[l]->m_Type == LAYERTYPE_TILES)
 					{
-						CLayerTiles *pLayer = static_cast<CLayerTiles *>(pGroup->m_lLayers[l]);
-						if(pLayer->m_Image == i)
+						if(static_cast<CLayerTiles *>(pGroup->m_lLayers[l])->m_Image == i)
 							Used = true;
 					}
 					else if(pGroup->m_lLayers[l]->m_Type == LAYERTYPE_QUADS)
 					{
-						CLayerQuads *pLayer = static_cast<CLayerQuads *>(pGroup->m_lLayers[l]);
-						if(pLayer->m_Image == i)
+						if(static_cast<CLayerQuads *>(pGroup->m_lLayers[l])->m_Image == i)
 							Used = true;
 					}
 				}
@@ -2636,32 +2604,33 @@ void CEditor::RenderImagesList(CUIRect ToolBox)
 				if(Result == 2)
 					UI()->DoPopupMenu(UI()->MouseX(), UI()->MouseY(), 120, 80, this, PopupImage);
 			}
-
-			ToolBox.HSplitTop(2.0f, 0, &ToolBox);
 		}
 
 		// separator
-		if(ImageCur + HeaderSeparatorHeight > ImageStopAt)
-			return;
-		ToolBox.HSplitTop(HeaderSeparatorHeight, &Slot, &ToolBox);
-		ImageCur += HeaderSeparatorHeight;
-		IGraphics::CLineItem LineItem(Slot.x, Slot.y+Slot.h/2, Slot.x+Slot.w, Slot.y+Slot.h/2);
-		Graphics()->TextureClear();
-		Graphics()->LinesBegin();
-		Graphics()->LinesDraw(&LineItem, 1);
-		Graphics()->LinesEnd();
+		ToolBox.HSplitTop(5.0f, &Slot, &ToolBox);
+		s_ScrollRegion.AddRect(Slot);
+		if(!s_ScrollRegion.IsRectClipped(Slot))
+		{
+			IGraphics::CLineItem LineItem(Slot.x, Slot.y+Slot.h/2, Slot.x+Slot.w, Slot.y+Slot.h/2);
+			Graphics()->TextureClear();
+			Graphics()->LinesBegin();
+			Graphics()->LinesDraw(&LineItem, 1);
+			Graphics()->LinesEnd();
+		}
 	}
 
-	if(ImageCur + AddButtonHeight > ImageStopAt)
-		return;
-
 	// new image
-	static int s_NewImageButton = 0;
-	CUIRect Slot;
-	ToolBox.HSplitTop(5.0f, &Slot, &ToolBox);
-	ToolBox.HSplitTop(12.0f, &Slot, &ToolBox);
-	if(DoButton_Editor(&s_NewImageButton, "Add", 0, &Slot, 0, "Load a new image to use in the map"))
-		InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_IMG, "Add Image", "Add", "mapres", "", AddImage, this);
+	static int s_AddImageButton = 0;
+	CUIRect AddImageButton;
+	ToolBox.HSplitTop(17.0f, &AddImageButton, &ToolBox);
+	s_ScrollRegion.AddRect(AddImageButton);
+	if(!s_ScrollRegion.IsRectClipped(AddImageButton))
+	{
+		AddImageButton.HSplitTop(5.0f, 0, &AddImageButton);
+		if(DoButton_Editor(&s_AddImageButton, "Add", 0, &AddImageButton, 0, "Load a new image to use in the map"))
+			InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_IMG, "Add Image", "Add", "mapres", "", AddImage, this);
+	}
+	s_ScrollRegion.End();
 }
 
 void CEditor::RenderSelectedImage(CUIRect View)

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -771,7 +771,6 @@ public:
 	int DoButton_ButtonDec(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
 	int DoButton_ButtonInc(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
 
-	int DoButton_File(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
 	int DoButton_Image(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip, bool Used);
 
 	int DoButton_Menu(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
@@ -836,7 +835,6 @@ public:
 	void RenderMenubar(CUIRect Menubar);
 	void RenderFileDialog();
 
-	void AddFileDialogEntry(int Index, CUIRect *pView);
 	void SortImages();
 	static void ExtractName(const char *pFileName, char *pName, int BufferSize)
 	{

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -545,21 +545,18 @@ public:
 		m_PopupEventWasActivated = false;
 
 		m_FileDialogStorageType = 0;
+		m_aFileDialogFileName[0] = '\0';
+		m_FileDialogFileNameInput.SetBuffer(m_aFileDialogFileName, sizeof(m_aFileDialogFileName));
 		m_aFileDialogFilterString[0] = '\0';
 		m_FileDialogFilterInput.SetBuffer(m_aFileDialogFilterString, sizeof(m_aFileDialogFilterString));
 		m_pFileDialogTitle = 0;
 		m_pFileDialogButtonText = 0;
 		m_pFileDialogUser = 0;
-		m_aFileDialogFileName[0] = 0;
 		m_aFileDialogCurrentFolder[0] = 0;
 		m_aFileDialogCurrentLink[0] = 0;
 		m_pFileDialogPath = m_aFileDialogCurrentFolder;
-		m_aFileDialogActivate = false;
-		m_FileDialogScrollValue = 0.0f;
 		m_FilesSelectedIndex = -1;
-		m_FilesStartAt = 0;
-		m_FilesCur = 0;
-		m_FilesStopAt = 999;
+		m_aFilesSelectedName[0] = '\0';
 
 		m_WorldOffsetX = 0;
 		m_WorldOffsetY = 0;
@@ -602,6 +599,7 @@ public:
 	virtual void UpdateAndRender();
 	virtual bool HasUnsavedData() const { return m_Map.m_Modified; }
 
+	void RefreshFilteredFileList();
 	void FilelistPopulate(int StorageType);
 	void InvokeFileDialog(int StorageType, int FileType, const char *pTitle, const char *pButtonText,
 		const char *pBasepath, const char *pDefaultName,
@@ -665,14 +663,14 @@ public:
 	const char *m_pFileDialogButtonText;
 	void (*m_pfnFileDialogFunc)(const char *pFileName, int StorageType, void *pUser);
 	void *m_pFileDialogUser;
+	CLineInput m_FileDialogFileNameInput;
 	char m_aFileDialogFileName[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogCurrentFolder[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogCurrentLink[IO_MAX_PATH_LENGTH];
 	char *m_pFileDialogPath;
-	bool m_aFileDialogActivate;
 	int m_FileDialogFileType;
-	float m_FileDialogScrollValue;
 	int m_FilesSelectedIndex;
+	char m_aFilesSelectedName[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogFilterString[64];
 	CLineInput m_FileDialogFilterInput;
 	char m_aFileDialogNewFolderName[64];
@@ -694,10 +692,8 @@ public:
 														m_IsDir && !Other.m_IsDir ? true : !m_IsDir && Other.m_IsDir ? false :
 														str_comp_filenames(m_aFilename, Other.m_aFilename) < 0; }
 	};
-	sorted_array<CFilelistItem> m_FileList;
-	int m_FilesStartAt;
-	int m_FilesCur;
-	int m_FilesStopAt;
+	sorted_array<CFilelistItem> m_CompleteFileList;
+	sorted_array<CFilelistItem *> m_FilteredFileList;
 
 	float m_WorldOffsetX;
 	float m_WorldOffsetY;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -827,7 +827,7 @@ public:
 
 	void RenderImagesList(CUIRect Toolbox);
 	void RenderSelectedImage(CUIRect View);
-	void RenderLayers(CUIRect Toolbox, CUIRect View);
+	void RenderLayers(CUIRect LayersBox);
 	void RenderModebar(CUIRect View);
 	void RenderStatusbar(CUIRect View);
 	void RenderEnvelopeEditor(CUIRect View);


### PR DESCRIPTION
# Text selection and input

![grafik](https://user-images.githubusercontent.com/23437060/102012211-5a310100-3d49-11eb-9249-18139eecaa48.png)

![grafik](https://user-images.githubusercontent.com/23437060/102012874-fa3c5980-3d4c-11eb-8ebc-341f494f61d4.png)

Implement keyboard-based text selection for console, chat and editboxes. Implement mouse-based selection for editboxes.
Basically does everything that #2521 does (paste, cut, select all etc.) but with the new text render and with rendering of multi-line selections for chat and console. Closes #12. Closes #1851. Closes #2521. Some code by @Learath2 could live on, but I did most things different in the end.

Word skipping (holding ctrl) is overhauled to be consistent with the Windows / Firefox experience that I took as reference.

Fixes various problems with UTF8 input. Closes #2809. Closes #2662.

Thanks to @TsFreddie, there is also [IME support](https://github.com/Robyt3/teeworlds/pull/1).

# Tooltips

![grafik](https://user-images.githubusercontent.com/23437060/102012228-72088500-3d49-11eb-9be2-7bd098ec8e01.png)

![grafik](https://user-images.githubusercontent.com/23437060/102012444-a2045800-3d4a-11eb-8043-ac5e69e5224d.png)

Implement tooltips which start to appear after 0.75 seconds when hovering and then fade to full alpha in another 0.25 seconds.
Tooltips are rendered below the rect that activates them, aligned with the mouse cursor x position. If the tooltip would go beyond the screen, it instead is rendered to the top and/or left instead.

Closes #1834. Tooltips are implemented for all cases listed in that issue. Also for the delete friend "x" in order to avoid showing the other tooltip when hovering over the "x".

# Editor

Use scroll region for lists of layers and images:

<img width="80%" src="https://user-images.githubusercontent.com/23437060/128561055-67071c89-ba75-4e53-95ff-0956e1f56c9a.png">

<img width="80%" src="https://user-images.githubusercontent.com/23437060/128561038-aa162806-5d83-415a-90ca-ca4bb0c3ba40.png">

Use list box for file browser:

<img width="80%" src="https://user-images.githubusercontent.com/23437060/128561024-3890ee98-31aa-4b5d-895c-26b020531577.png">

Fix editor file browser selection and filter not being synced. Typing a filter text will restore the previous selection if possible and always scroll to make it visible. Closes #2290.

# Refactoring, various

- Change DoLabel to support vertical centering and use that instead of Button.y += 2.0f.
- Properly dispatch events to CUI, which then get dispatched to the CLineInput of an active editbox. Consolidate selection and caret rendering in CLineInput. Closes #2706.

# TODO

- Stack of active line inputs might be unnecessary. Currently it's messy, as having chat and console opens keeps activating different inputs every frame. Destructor of CLineInput also does not properly remove the line input from the stack.