### PR TITLE
Display DrawSize instead of WindowSize in Resolution List

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -806,6 +806,8 @@ int CGraphics_Threaded::Init()
 	if(InitWindow() != 0)
 		return -1;
 
+	m_ScreenHiDPIScale = m_ScreenWidth / (float)m_pConfig->m_GfxScreenWidth;
+
 	// create command buffers
 	for(int i = 0; i < NUM_CMDBUFFERS; i++)
 		m_apCommandBuffers[i] = new CCommandBuffer(128*1024, 2*1024*1024);

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -56,6 +56,7 @@ protected:
 	int m_ScreenHeight;
 	int m_DesktopScreenWidth;
 	int m_DesktopScreenHeight;
+	float m_ScreenHiDPIScale;
 public:
 	/* Constants: Texture Loading Flags
 		TEXLOAD_NORESAMPLE - Prevents the texture from any resampling
@@ -98,6 +99,7 @@ public:
 	int ScreenWidth() const { return m_ScreenWidth; }
 	int ScreenHeight() const { return m_ScreenHeight; }
 	float ScreenAspect() const { return (float)ScreenWidth()/(float)ScreenHeight(); }
+	float ScreenHiDPIScale() const { return m_ScreenHiDPIScale; }
 	int DesktopWidth() const { return m_DesktopScreenWidth; }
 	int DesktopHeight() const { return m_DesktopScreenHeight; }
 	float DesktopAspect() const { return m_DesktopScreenWidth/(float)m_DesktopScreenHeight; }

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1348,7 +1348,9 @@ void CMenus::UpdatedFilteredVideoModes()
 	{
 		const int G = gcd(m_aModes[i].m_Width, m_aModes[i].m_Height);
 		if(m_aModes[i].m_Width/G == DesktopWidthG &&
-		   m_aModes[i].m_Height/G == DesktopHeightG)
+			m_aModes[i].m_Height/G == DesktopHeightG &&
+			m_aModes[i].m_Width <= Graphics()->DesktopWidth() &&
+			m_aModes[i].m_Height <= Graphics()->DesktopHeight())
 		{
 			m_lRecommendedVideoModes.add(m_aModes[i]);
 		}

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1629,6 +1629,8 @@ bool CMenus::DoResolutionList(CUIRect* pRect, CListBox* pListBox,
 	int OldSelected = -1;
 	char aBuf[32];
 
+	float HiDPIScale = Graphics()->ScreenHiDPIScale();
+
 	pListBox->DoStart(20.0f, lModes.size(), 1, 3, OldSelected, pRect);
 
 	for(int i = 0; i < lModes.size(); ++i)
@@ -1645,8 +1647,8 @@ bool CMenus::DoResolutionList(CUIRect* pRect, CListBox* pListBox,
 			int G = gcd(lModes[i].m_Width, lModes[i].m_Height);
 
 			str_format(aBuf, sizeof(aBuf), "%dx%d (%d:%d)",
-					   lModes[i].m_Width,
-					   lModes[i].m_Height,
+					   (int)(lModes[i].m_Width * HiDPIScale),
+					   (int)(lModes[i].m_Height * HiDPIScale),
 					   lModes[i].m_Width/G,
 					   lModes[i].m_Height/G);
 
@@ -1894,7 +1896,8 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		ListRec.HSplitBottom(Spacing, &ListRec, 0);
 		RenderTools()->DrawUIRect(&Button, vec4(0.0f, 0.0f, 0.0f, 0.5f), CUI::CORNER_B, 5.0f);
 		int g = gcd(s_GfxScreenWidth, s_GfxScreenHeight);
-		str_format(aBuf, sizeof(aBuf), Localize("Current: %dx%d (%d:%d)"), s_GfxScreenWidth, s_GfxScreenHeight, s_GfxScreenWidth/g, s_GfxScreenHeight/g);
+		const float HiDPIScale = Graphics()->ScreenHiDPIScale();
+		str_format(aBuf, sizeof(aBuf), Localize("Current: %dx%d (%d:%d)"), (int)(s_GfxScreenWidth*HiDPIScale), (int)(s_GfxScreenHeight*HiDPIScale), s_GfxScreenWidth/g, s_GfxScreenHeight/g);
 		Button.y += 2;
 		UI()->DoLabel(&Button, aBuf, Button.h*ms_FontmodHeight*0.8f, CUI::ALIGN_CENTER);
 


### PR DESCRIPTION
Maybe addresses #1659. And I hope this make sense.

I think it is not because @ChillerDragon cannot change to a higher resolution, it is just that SDL reports video modes in canvas resolution, and we create window with window size which can have a high resolution within a smaller window (due to how HiDPI works on mac). Therefore, the selected resolution is actually the max resolution you can get with HiDPI mode enabled on mac, which is rendering in the native resolution as well.

Luckly, mac reports desktop resolution in windows size, so I moved any resolution that are larger than the desktop out of "Recommended" list. I also calculated the HiDPI scale on init, then show the scaled resolution in the resolution list which is hopefully more representative about the canvas.

You still probably can't use some of the higher resolution in the "Other" list in fullscreen mode because macos will stop you from doing that. But at least you can look at the "Recommended" list and be confident that the top one is the best one to use.

My resolution list (13-inch Macbook Pro 2017, 1440x900 "desktop size", 2880x1800 screen resolution):
![image](https://user-images.githubusercontent.com/3797859/102246609-eefa5100-3f39-11eb-97bf-4e9f2622dbd1.png)
