### PR TITLE
Fix unused incorrect range limitation on `CPlayerInput::m_WantedWeapon`

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -96,6 +96,8 @@ Objects = [
 
 		NetFlag("m_PlayerFlags", PlayerFlags),
 
+		# 0 means "no wanted weapon", `1+weapon` means that `weapon` is wanted,
+		# and ninja is not a valid wanted weapon.
 		NetIntRange("m_WantedWeapon", 0, 'NUM_WEAPONS-1'),
 		NetIntAny("m_NextWeapon"),
 		NetIntAny("m_PrevWeapon"),


### PR DESCRIPTION
The code uses 0 to mean "no weapon change wanted" and (1 + weapon) to
select a specific weapon.

Since the checking code isn't used on the server side anyway, this
doesn't really matter.