### PR TITLE
No score for self in the scoretable

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -986,9 +986,17 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	// right side
 	GameRight.HSplitTop(Spacing, 0, &GameRight);
 	GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);
+
+	CUIRect CheckBoxShowHud, CheckBoxHideScore;
+	Button.VSplitMid(&CheckBoxShowHud, &CheckBoxHideScore);
+
 	static int s_Showhud = 0;
-	if(DoButton_CheckBox(&s_Showhud, Localize("Show ingame HUD"), Config()->m_ClShowhud, &Button))
+	if(DoButton_CheckBox(&s_Showhud, Localize("Show ingame HUD"), Config()->m_ClShowhud, &CheckBoxShowHud))
 		Config()->m_ClShowhud ^= 1;
+
+	static int s_Hidescore = 0;
+	if(DoButton_CheckBox(&s_Hidescore, Localize("Hide player's score"), Config()->m_ClHideSelfScore, &CheckBoxHideScore))
+		Config()->m_ClHideSelfScore ^= 1;
 
 	GameRight.HSplitTop(Spacing, 0, &GameRight);
 	GameRight.HSplitTop(ButtonHeight, &Button, &GameRight);

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -522,6 +522,21 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 		}
 	}
 
+	if (Config()->m_ClHideSelfScore)
+	{
+		// Move local player to the bottom of the scoreboard
+		for (int i = 0; i < NumRenderScoreIDs - 1 && RenderScoreIDs[i + 1] >= 0; i++)
+		{
+			const CGameClient::CPlayerInfoItem *pInfo = &m_pClient->m_Snap.m_aInfoByScore[RenderScoreIDs[i]];
+			if (m_pClient->m_LocalClientID == pInfo->m_ClientID)
+			{
+				const int temp = RenderScoreIDs[i + 1];
+				RenderScoreIDs[i + 1] = RenderScoreIDs[i];
+				RenderScoreIDs[i] = temp;
+			}
+		}
+	}
+
 	s_Cursor.m_MaxLines = 1;
 	s_Cursor.m_FontSize = FontSize;
 	for(int i = 0 ; i < NumRenderScoreIDs ; i++)
@@ -536,7 +551,8 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 			// color for text
 			vec3 TextColor = vec3(1.0f, 1.0f, 1.0f);
 			vec4 OutlineColor(0.0f, 0.0f, 0.0f, 0.3f);
-			const bool HighlightedLine = m_pClient->m_LocalClientID == pInfo->m_ClientID || (Snap.m_SpecInfo.m_Active && pInfo->m_ClientID == Snap.m_SpecInfo.m_SpectatorID);
+			const bool HighlightedLine = m_pClient->m_LocalClientID == pInfo->m_ClientID ||
+				(Snap.m_SpecInfo.m_Active && pInfo->m_ClientID == Snap.m_SpecInfo.m_SpectatorID);
 
 			// background so it's easy to find the local player or the followed one in spectator mode
 			if(HighlightedLine)
@@ -645,7 +661,7 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 			s_Cursor.m_MaxWidth = ClanLength;
 			TextRender()->TextOutlined(&s_Cursor, m_pClient->m_aClients[pInfo->m_ClientID].m_aClan, -1);
 
-			if(!Race)
+			if(!Race && !(m_pClient->m_LocalClientID == pInfo->m_ClientID && Config()->m_ClHideSelfScore))
 			{
 				// K
 				TextRender()->TextColor(TextColor.r, TextColor.g, TextColor.b, 0.5f*ColorAlpha);
@@ -680,7 +696,10 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 			s_Cursor.MoveTo(ScoreOffset+(Race ? ScoreLength-3.f : ScoreLength/2), y+Spacing);
 			s_Cursor.m_MaxWidth = ScoreLength;
 			TextRender()->TextColor(TextColor.r, TextColor.g, TextColor.b, ColorAlpha);
-			TextRender()->TextOutlined(&s_Cursor, aBuf, -1);
+			if (!Race && !(m_pClient->m_LocalClientID == pInfo->m_ClientID && Config()->m_ClHideSelfScore))
+			{
+				TextRender()->TextOutlined(&s_Cursor, aBuf, -1);
+			}
 
 			y += LineHeight;
 		}

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -103,6 +103,7 @@ MACRO_CONFIG_INT(ClCameraSpeed, cl_camera_speed, 5, 1, 10, CFGFLAG_CLIENT|CFGFLA
 MACRO_CONFIG_INT(ClShowStartMenuImages, cl_show_start_menu_images, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show start menu images")
 MACRO_CONFIG_INT(ClSkipStartMenu, cl_skip_start_menu, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Skip the start menu")
 
+MACRO_CONFIG_INT(ClHideSelfScore, cl_hide_self_score, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Hide player's score in the scoreboard")
 MACRO_CONFIG_INT(ClStatboardInfos, cl_statboard_infos, 1259, 1, 2047, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Mask of info to display on the global statboard")
 MACRO_CONFIG_INT(ClShowLocalTimeAlways, cl_show_local_time_always, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Always show local time")
 


### PR DESCRIPTION
Adds an option to remove the display of k/d and score of the local player from the score table. Also keeps the local player at the bottom of the score table so that the relative position to others is unknown. Also includes a menu option.
![autoscreen_2021-01-20_23-14-41](https://user-images.githubusercontent.com/4072673/105252925-b96f0600-5b7e-11eb-8f6c-f10f8d32dc45.png)
![screenshot_2021-01-21_00-35-27](https://user-images.githubusercontent.com/4072673/105253883-a78e6280-5b80-11eb-9efe-11b3b38b2eb9.png)

In the competitive ctf scene the score is a false indicator of an individual success -- it matters more how one plays in a team and whether he helps to make the team win. This is not always reflected by the score, and in certain settings might be unrelated to it.

Yet, the score table serves as the single most visible comparison point to other players. Comparing themselves to others turns into an obsession for some people, then leads into a distraction from the team-based game, a worry about one's performance, and as the result a decrease in this performance.

This PR provides a tool for such people to free themselves from the score obsession and focus entirely on the ongoing game. The stattable is left untouched.