### PR TITLE
Add eval_if_cmd console command

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -725,6 +725,19 @@ void CConsole::Con_EvalIf(IResult *pResult, void *pUserData)
 		pConsole->ExecuteLine(pResult->GetString(5));
 }
 
+void CConsole::Con_EvalIfCmd(IResult *pResult, void *pUserData)
+{
+	CConsole *pConsole = static_cast<CConsole *>(pUserData);
+	CCommand *pCommand = pConsole->FindCommand(pResult->GetString(0), pConsole->m_FlagMask);
+	if(pResult->NumArguments() > 2 && str_comp(pResult->GetString(2), "else"))
+		pConsole->Print(OUTPUT_LEVEL_STANDARD, "console", "Error: expected else");
+
+	if(pCommand)
+		pConsole->ExecuteLine(pResult->GetString(1));
+	else if(pResult->NumArguments() == 4)
+		pConsole->ExecuteLine(pResult->GetString(3));
+}
+
 void CConsole::ConToggle(IConsole::IResult *pResult, void *pUser)
 {
 	CConsole* pConsole = static_cast<CConsole *>(pUser);
@@ -819,6 +832,7 @@ CConsole::CConsole(int FlagMask)
 	Register("echo", "r[text]", CFGFLAG_SERVER|CFGFLAG_CLIENT, Con_Echo, this, "Echo the text");
 	Register("exec", "r[file]", CFGFLAG_SERVER|CFGFLAG_CLIENT, Con_Exec, this, "Execute the specified file");
 	Register("eval_if", "s[config] s[comparison] s[value] s[command] ?s[else] ?s[command]", CFGFLAG_SERVER|CFGFLAG_CLIENT|CFGFLAG_STORE, Con_EvalIf, this, "Execute command if condition is true");
+	Register("eval_if_cmd", "s[check_command] s[command] ?s[else] ?s[command]", CFGFLAG_SERVER|CFGFLAG_CLIENT|CFGFLAG_STORE, Con_EvalIfCmd, this, "Execute command if check_command exists");
 
 	Register("toggle", "s[config-option] i[value1] i[value2]", CFGFLAG_SERVER|CFGFLAG_CLIENT, ConToggle, this, "Toggle config value");
 	Register("+toggle", "s[config-option] i[value1] i[value2]", CFGFLAG_CLIENT, ConToggleStroke, this, "Toggle config value via keypress");

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -58,6 +58,7 @@ class CConsole : public IConsole
 	static void Con_Echo(IResult *pResult, void *pUserData);
 	static void Con_Exec(IResult *pResult, void *pUserData);
 	static void Con_EvalIf(IResult *pResult, void *pUserData);
+	static void Con_EvalIfCmd(IResult *pResult, void *pUserData);
 	static void ConToggle(IResult *pResult, void *pUser);
 	static void ConToggleStroke(IResult *pResult, void *pUser);
 	static void ConModCommandAccess(IResult *pResult, void *pUser);


### PR DESCRIPTION
# SYNOPSIS

eval_if_cmd

s[check_command] s[command] ?s[else] ?s[command]

# DESCRIPTION

**eval_if_cmd** executes a command based on the existence of a command or config. So it can be used to write backwards and custom client compatible configs. 

# EXAMPLE

eval_if_cmd "say_self" "say_self hello" else "echo hello"