### PR TITLE
Add chat_command

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -199,6 +199,12 @@ void CChat::ConShowChat(IConsole::IResult *pResult, void *pUserData)
 	((CChat *)pUserData)->m_Show = pResult->GetInteger(0) != 0;
 }
 
+void CChat::ConChatCommand(IConsole::IResult *pResult, void *pUserData)
+{
+	CChat *pChat = (CChat *)pUserData;
+	pChat->m_CommandManager.OnCommand(pResult->GetString(0), pResult->GetString(1), -1);
+}
+
 void CChat::OnInit()
 {
 	m_CommandManager.Init(Console());
@@ -213,6 +219,7 @@ void CChat::OnConsoleInit()
 	Console()->Register("whisper", "i[target] r[text]", CFGFLAG_CLIENT, ConWhisper, this, "Whisper to a client in chat");
 	Console()->Register("chat", "s[text] ?i[whisper-target]", CFGFLAG_CLIENT, ConChat, this, "Enable chat with all/team/whisper mode");
 	Console()->Register("+show_chat", "", CFGFLAG_CLIENT, ConShowChat, this, "Show chat");
+	Console()->Register("chat_command", "s[command] ?r[args]", CFGFLAG_CLIENT, ConChatCommand, this, "Execute a chat command with arguments");
 }
 
 void CChat::ClearChatBuffer()

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -113,6 +113,7 @@ class CChat : public CComponent
 	static void ConWhisper(IConsole::IResult *pResult, void *pUserData);
 	static void ConChat(IConsole::IResult *pResult, void *pUserData);
 	static void ConShowChat(IConsole::IResult *pResult, void *pUserData);
+	static void ConChatCommand(IConsole::IResult *pResult, void *pUserData);
 	static void ServerCommandCallback(IConsole::IResult *pResult, void *pContext);
 
 public:


### PR DESCRIPTION
Tested this on a DDNet server, both with names with spaces and commands without arguments.
One issue with this is as @heinrich5991 mentioned arguments containing `"`. I'm not completely sure how best to handle this. I think `r` should just do no further processing and give the rest of the string, but I think we should talk about it before making a change like that.

Close #2858