### PR TITLE
Extract RenderCursor method, simplify menus render methods

### DIFF
--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -163,14 +163,7 @@ void CEmoticon::OnRender()
 
 	Graphics()->QuadsEnd();
 
-	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_CURSOR].m_Id);
-	Graphics()->WrapClamp();
-	Graphics()->QuadsBegin();
-	Graphics()->SetColor(1,1,1,1);
-	IGraphics::CQuadItem QuadItem(m_SelectorMouse.x+Screen.w/2,m_SelectorMouse.y+Screen.h/2,24,24);
-	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	Graphics()->QuadsEnd();
-	Graphics()->WrapNormal();
+	RenderTools()->RenderCursor(m_SelectorMouse.x + Screen.w/2, m_SelectorMouse.y + Screen.h/2, 24.0f);
 }
 
 void CEmoticon::Emote(int Emoticon)

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1457,11 +1457,8 @@ void CMenus::PopupCountry(int Selection, FPopupButtonCallback pfnOkButtonCallbac
 }
 
 
-void CMenus::Render()
+void CMenus::RenderMenu(CUIRect Screen)
 {
-	CUIRect Screen = *UI()->Screen();
-	Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
-
 	static int s_InitTick = 5;
 	if(s_InitTick > 0)
 	{
@@ -2220,13 +2217,6 @@ void CMenus::OnRender()
 	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		SetActive(true);
 
-	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
-	{
-		CUIRect Screen = *UI()->Screen();
-		Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
-		RenderDemoPlayer(Screen);
-	}
-
 	if(Client()->State() == IClient::STATE_ONLINE && m_pClient->m_ServerMode == m_pClient->SERVERMODE_PUREMOD)
 	{
 		Client()->Disconnect();
@@ -2234,50 +2224,39 @@ void CMenus::OnRender()
 		PopupMessage(Localize("Disconnected"), Localize("The server is running a non-standard tuning on a pure game type."), Localize("Ok"));
 	}
 
-	if(!IsActive())
+	if(Client()->State() == IClient::STATE_DEMOPLAYBACK || IsActive())
 	{
-		m_EscapePressed = false;
-		m_EnterPressed = false;
-		m_TabPressed = false;
-		m_DeletePressed = false;
-		m_UpArrowPressed = false;
-		m_DownArrowPressed = false;
-		return;
-	}
+		// update the ui
+		const CUIRect *pScreen = UI()->Screen();
+		float MouseX = (m_MousePos.x/(float)Graphics()->ScreenWidth())*pScreen->w;
+		float MouseY = (m_MousePos.y/(float)Graphics()->ScreenHeight())*pScreen->h;
+		UI()->Update(MouseX, MouseY, MouseX*3.0f, MouseY*3.0f);
 
-	// update the ui
-	const CUIRect *pScreen = UI()->Screen();
-	float MouseX = (m_MousePos.x/(float)Graphics()->ScreenWidth())*pScreen->w;
-	float MouseY = (m_MousePos.y/(float)Graphics()->ScreenHeight())*pScreen->h;
-	UI()->Update(MouseX, MouseY, MouseX*3.0f, MouseY*3.0f);
-
-	// render
-	if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
-		Render();
-
-	// render cursor
-	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_CURSOR].m_Id);
-	Graphics()->WrapClamp();
-	Graphics()->QuadsBegin();
-	Graphics()->SetColor(1,1,1,1);
-	IGraphics::CQuadItem QuadItem(MouseX, MouseY, 24, 24);
-	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	Graphics()->QuadsEnd();
-	Graphics()->WrapNormal();
-
-	// render debug information
-	if(Config()->m_Debug)
-	{
+		// render demo player or main menu
 		Graphics()->MapScreen(pScreen->x, pScreen->y, pScreen->w, pScreen->h);
+		if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
+			RenderDemoPlayer(*pScreen);
+		else
+			RenderMenu(*pScreen);
 
-		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), "%p %p %p", UI()->HotItem(), UI()->GetActiveItem(), UI()->LastActiveItem());
-		static CTextCursor s_Cursor(10, 10, 10);
-		s_Cursor.Reset();
-		TextRender()->TextOutlined(&s_Cursor, aBuf, -1);
+		if(IsActive())
+		{
+			RenderTools()->RenderCursor(MouseX, MouseY, 24.0f);
+
+			// render debug information
+			if(Config()->m_Debug)
+			{
+				char aBuf[64];
+				str_format(aBuf, sizeof(aBuf), "%p %p %p", UI()->HotItem(), UI()->GetActiveItem(), UI()->LastActiveItem());
+				static CTextCursor s_Cursor(10, 10, 10);
+				s_Cursor.Reset();
+				TextRender()->TextOutlined(&s_Cursor, aBuf, -1);
+			}
+
+			UI()->FinishCheck();
+		}
 	}
 
-	UI()->FinishCheck();
 	m_EscapePressed = false;
 	m_EnterPressed = false;
 	m_TabPressed = false;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -770,7 +770,7 @@ private:
 	void UpdateVideoModeSettings();
 
 	// found in menus.cpp
-	void Render();
+	void RenderMenu(CUIRect Screen);
 	void RenderMenubar(CUIRect r);
 	void RenderNews(CUIRect MainView);
 	void RenderBackButton(CUIRect MainView);
@@ -781,7 +781,7 @@ private:
 
 	// found in menus_demo.cpp
 	bool FetchHeader(CDemoItem *pItem);
-	void RenderDemoPlayer(CUIRect MainView);
+	void RenderDemoPlayer(CUIRect Screen);
 	void RenderDemoList(CUIRect MainView);
 	float RenderDemoDetails(CUIRect View);
 	void PopupConfirmDeleteDemo();

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -349,15 +349,7 @@ void CSpectator::OnRender()
 	}
 	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 
-	// draw cursor
-	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_CURSOR].m_Id);
-	Graphics()->WrapClamp();
-	Graphics()->QuadsBegin();
-	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-	IGraphics::CQuadItem QuadItem(m_SelectorMouse.x+Width/2.0f, m_SelectorMouse.y+Height/2.0f, 48.0f, 48.0f);
-	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	Graphics()->QuadsEnd();
-	Graphics()->WrapNormal();
+	RenderTools()->RenderCursor(m_SelectorMouse.x + Width/2.0f, m_SelectorMouse.y + Height/2.0f, 48.0f);
 }
 
 void CSpectator::OnReset()

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -73,6 +73,18 @@ void CRenderTools::DrawSprite(float x, float y, float Size)
 	Graphics()->QuadsDraw(&QuadItem, 1);
 }
 
+void CRenderTools::RenderCursor(float CenterX, float CenterY, float Size)
+{
+	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_CURSOR].m_Id);
+	Graphics()->WrapClamp();
+	Graphics()->QuadsBegin();
+	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+	IGraphics::CQuadItem QuadItem(CenterX, CenterY, Size, Size);
+	Graphics()->QuadsDrawTL(&QuadItem, 1);
+	Graphics()->QuadsEnd();
+	Graphics()->WrapNormal();
+}
+
 void CRenderTools::DrawRoundRectExt(float x, float y, float w, float h, float r, int Corners)
 {
 	IGraphics::CFreeformItem ArrayF[32];

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -66,6 +66,7 @@ public:
 	void SelectSprite(int id, int Flags=0, int sx=0, int sy=0);
 
 	void DrawSprite(float x, float y, float size);
+	void RenderCursor(float CenterX, float CenterY, float Size);
 
 	// rects
 	void DrawRoundRect(const CUIRect *r, vec4 Color, float Rounding);


### PR DESCRIPTION
- Extract `RenderCursor` method to reduce duplicate code in menu, emote selector and spectator mode.
- Simplify menu rendering: only call `MapScreen` once and call `RenderDemoPlayer` and `RenderMenu` in the same if-else.