### PR TITLE
Various minor refactorings

### DIFF
--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -174,6 +174,7 @@ public:
 	};
 	virtual void SetColorVertex(const CColorVertex *pArray, int Num) = 0;
 	virtual void SetColor(float r, float g, float b, float a) = 0;
+	inline void SetColor(const vec4 &Color) { SetColor(Color.r, Color.g, Color.b, Color.a); }
 	virtual void SetColor4(const vec4 &TopLeft, const vec4 &TopRight, const vec4 &BottomLeft, const vec4 &BottomRight) = 0;
 
 	virtual void ReadBackbuffer(unsigned char **ppPixels, int x, int y, int w, int h) = 0;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -106,7 +106,7 @@ CMenus::CMenus()
 
 float CMenus::CButtonContainer::GetFade(bool Checked, float Seconds)
 {
-	if(m_pUI->HotItem() == GetID() || Checked)
+	if(m_pUI->HotItem() == this || Checked)
 	{
 		m_FadeStartTime = m_pClient->LocalTime();
 		return 1.0f;
@@ -203,7 +203,7 @@ bool CMenus::DoButton_Menu(CButtonContainer *pBC, const char *pText, bool Checke
 		TextRender()->TextColor(CUI::ms_DefaultTextColor);
 		TextRender()->TextSecondaryColor(CUI::ms_DefaultTextOutlineColor);
 	}
-	return UI()->DoButtonLogic(pBC->GetID(), pRect);
+	return UI()->DoButtonLogic(pBC, pRect);
 }
 
 void CMenus::DoButton_KeySelect(CButtonContainer *pBC, const char *pText, const CUIRect *pRect)
@@ -236,7 +236,7 @@ bool CMenus::DoButton_MenuTabTop(CButtonContainer *pBC, const char *pText, bool 
 	UI()->DoLabel(&Label, pText, Label.h*ms_FontmodHeight, CUI::ALIGN_CENTER);
 	TextRender()->TextColor(CUI::ms_DefaultTextColor);
 	TextRender()->TextSecondaryColor(CUI::ms_DefaultTextOutlineColor);
-	return UI()->DoButtonLogic(pBC->GetID(), pRect);
+	return UI()->DoButtonLogic(pBC, pRect);
 }
 
 bool CMenus::DoButton_GridHeader(const void *pID, const char *pText, bool Checked, CUI::EAlignment Align, const CUIRect *pRect, int Corners)
@@ -340,7 +340,7 @@ bool CMenus::DoButton_SpriteID(CButtonContainer *pBC, int ImageID, int SpriteID,
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();
 
-	return UI()->DoButtonLogic(pBC->GetID(), pRect);
+	return UI()->DoButtonLogic(pBC, pRect);
 }
 
 bool CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden, int Corners)
@@ -834,10 +834,10 @@ int CMenus::DoKeyReader(CButtonContainer *pBC, const CUIRect *pRect, int Key, in
 	int NewKey = Key;
 	*pNewModifier = Modifier;
 
-	if(!UI()->MouseButton(0) && !UI()->MouseButton(1) && s_pGrabbedID == pBC->GetID())
+	if(!UI()->MouseButton(0) && !UI()->MouseButton(1) && s_pGrabbedID == pBC)
 		s_MouseReleased = true;
 
-	if(UI()->CheckActiveItem(pBC->GetID()))
+	if(UI()->CheckActiveItem(pBC))
 	{
 		if(m_Binder.m_GotKey)
 		{
@@ -850,7 +850,7 @@ int CMenus::DoKeyReader(CButtonContainer *pBC, const CUIRect *pRect, int Key, in
 			m_Binder.m_GotKey = false;
 			UI()->SetActiveItem(0);
 			s_MouseReleased = false;
-			s_pGrabbedID = pBC->GetID();
+			s_pGrabbedID = pBC;
 		}
 
 		if(s_ButtonUsed == 1 && !UI()->MouseButton(1))
@@ -860,7 +860,7 @@ int CMenus::DoKeyReader(CButtonContainer *pBC, const CUIRect *pRect, int Key, in
 			UI()->SetActiveItem(0);
 		}
 	}
-	else if(UI()->HotItem() == pBC->GetID())
+	else if(UI()->HotItem() == pBC)
 	{
 		if(s_MouseReleased)
 		{
@@ -868,23 +868,23 @@ int CMenus::DoKeyReader(CButtonContainer *pBC, const CUIRect *pRect, int Key, in
 			{
 				m_Binder.m_TakeKey = true;
 				m_Binder.m_GotKey = false;
-				UI()->SetActiveItem(pBC->GetID());
+				UI()->SetActiveItem(pBC);
 				s_ButtonUsed = 0;
 			}
 
 			if(UI()->MouseButton(1))
 			{
-				UI()->SetActiveItem(pBC->GetID());
+				UI()->SetActiveItem(pBC);
 				s_ButtonUsed = 1;
 			}
 		}
 	}
 
 	if(Hovered)
-		UI()->SetHotItem(pBC->GetID());
+		UI()->SetHotItem(pBC);
 
 	// draw
-	if(UI()->CheckActiveItem(pBC->GetID()) && s_ButtonUsed == 0)
+	if(UI()->CheckActiveItem(pBC) && s_ButtonUsed == 0)
 	{
 		DoButton_KeySelect(pBC, "???", pRect);
 		m_KeyReaderIsActive = true;
@@ -1527,10 +1527,8 @@ void CMenus::Render()
 				RenderTools()->DrawUIRect(&Button, Color, CUI::CORNER_BL, 5.0f);
 
 				// draw non-blending X
-				CUIRect XText = Button;
-
-				UI()->DoLabel(&XText, "\xE2\x9C\x95", XText.h*ms_FontmodHeight, CUI::ALIGN_CENTER);
-				if(UI()->DoButtonLogic(s_QuitButton.GetID(), &Button))
+				UI()->DoLabel(&Button, "\xE2\x9C\x95", Button.h*ms_FontmodHeight, CUI::ALIGN_CENTER);
+				if(UI()->DoButtonLogic(&s_QuitButton, &Button))
 					m_Popup = POPUP_QUIT;
 
 				// settings button

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -105,7 +105,6 @@ public:
 		float m_FadeStartTime;
 	public:
 		CButtonContainer(bool CleanBackground = false) : m_FadeStartTime(0.0f) { m_CleanBackground = CleanBackground; }
-		const void *GetID() const { return &m_FadeStartTime; }
 		float GetFade(bool Checked = false, float Seconds = 0.6f);
 		bool IsCleanBackground() const { return m_CleanBackground; }
 	};

--- a/src/game/client/components/menus_scrollregion.cpp
+++ b/src/game/client/components/menus_scrollregion.cpp
@@ -114,7 +114,7 @@ void CMenus::CScrollRegion::End()
 
 	if(m_AnimTime > 0)
 	{
-		m_AnimTime -= m_pMenus->Client()->RenderFrameTime();
+		m_AnimTime -= m_pClient->RenderFrameTime();
 		float AnimProgress = (1 - pow(m_AnimTime / AnimationDuration, 3)); // cubic ease out
 		m_ScrollY = m_AnimInitScrollY + (m_AnimTargetScrollY - m_AnimInitScrollY) * AnimProgress;
 	}


### PR DESCRIPTION
- Remove unnecessary usage of `m_pMenus` from implementation of `CUIElementBase`, to eventually remove the member completely.
- Add a convenience method `SetColor(vec4)` to the `IGraphics` interface.
- Minor refactoring of CChat:
  - Reduce unnecessary string concat.
  - Remove unnecessary variables.
  - Adjust some variable names.
  - Move variable declaration closer to its usage.
- Remove unnecessary indiretion of `CButtonContainer.GetID` with equivalent usage of the pointer to the object itself (`this`).