### PR TITLE
Add str_utf8_stats to base system

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2739,6 +2739,23 @@ void str_utf8_copy_num(char *dst, const char *src, int dst_size, int num)
 	str_copy(dst, src, cursor < dst_size ? cursor+1 : dst_size);
 }
 
+void str_utf8_stats(const char *str, int max_size, int *size, int *count)
+{
+	*size = 0;
+	*count = 0;
+	while(str[*size] && *size < max_size)
+	{
+		int new_size = str_utf8_forward(str, *size);
+		if(new_size != *size)
+		{
+			if(new_size >= max_size)
+				break;
+			*size = new_size;
+			++(*count);
+		}
+	}
+}
+
 unsigned str_quickhash(const char *str)
 {
 	unsigned hash = 5381;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1764,6 +1764,22 @@ int str_utf8_check(const char *str);
 void str_utf8_copy_num(char *dst, const char *src, int dst_size, int num);
 
 /*
+	Function: str_utf8_stats
+		Determines the byte size and utf8 character count of a string.
+
+	Parameters:
+		str - Pointer to the string.
+		max_size - Maximum number of bytes to count.
+		size - Pointer to store size (number of non-zero bytes) of the string.
+		count - Pointer to store count of utf8 characters of the string.
+
+	Remarks:
+		- Assumes nothing about the encoding of the string.
+		  It's the users responsibility to make sure the bounds are aligned.
+*/
+void str_utf8_stats(const char *str, int max_size, int *size, int *count);
+
+/*
 	Function: secure_random_init
 		Initializes the secure random module.
 		You *MUST* check the return value of this function.

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -124,3 +124,36 @@ TEST(Str, PathUnsafe)
 	EXPECT_FALSE(str_path_unsafe("abc/def\\ghi.txt"));
 	EXPECT_FALSE(str_path_unsafe("любовь"));
 }
+
+TEST(Str, Utf8Stats)
+{
+	int Size, Count;
+
+	str_utf8_stats("abc", 4, &Size, &Count);
+	EXPECT_EQ(Size, 3);
+	EXPECT_EQ(Count, 3);
+
+	str_utf8_stats("abc", 2, &Size, &Count);
+	EXPECT_EQ(Size, 1);
+	EXPECT_EQ(Count, 1);
+
+	str_utf8_stats("", 1, &Size, &Count);
+	EXPECT_EQ(Size, 0);
+	EXPECT_EQ(Count, 0);
+
+	str_utf8_stats("abcde", 6, &Size, &Count);
+	EXPECT_EQ(Size, 5);
+	EXPECT_EQ(Count, 5);
+
+	str_utf8_stats("любовь", 13, &Size, &Count);
+	EXPECT_EQ(Size, 12);
+	EXPECT_EQ(Count, 6);
+
+	str_utf8_stats("abc愛", 7, &Size, &Count);
+	EXPECT_EQ(Size, 6);
+	EXPECT_EQ(Count, 4);
+
+	str_utf8_stats("abc愛", 6, &Size, &Count);
+	EXPECT_EQ(Size, 3);
+	EXPECT_EQ(Count, 3);
+}


### PR DESCRIPTION
Add `void str_utf8_stats(const char *str, int max_size, int *size, int *count)` to base system for later use with text selection etc.

Calculates size in bytes and count of utf8 characters of a string at the same time, while not exceeding the max size and not breaking multi-byte characters.