### PR TITLE
Individual Damage Effect Timer for each Client

### DIFF
--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -22,8 +22,8 @@ CEffects::CEffects()
 {
 	m_Add50hz = false;
 	m_Add100hz = false;
-	m_DamageTaken = 0;
-	m_DamageTakenTick = 0;
+	mem_zero(m_aDamageTaken, sizeof(m_aDamageTaken));
+	mem_zero(m_aDamageTakenTick, sizeof(m_aDamageTakenTick));
 }
 
 void CEffects::AirJump(vec2 Pos)
@@ -49,23 +49,29 @@ void CEffects::AirJump(vec2 Pos)
 	m_pClient->m_pSounds->PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_AIRJUMP, 1.0f, Pos);
 }
 
-void CEffects::DamageIndicator(vec2 Pos, int Amount)
+void CEffects::DamageIndicator(vec2 Pos, int Amount, float Angle, int ClientID)
 {
 	// ignore if there is no damage
 	if(Amount == 0)
 		return;
 
-	m_DamageTaken++;
-	float Angle;
+	if (ClientID < 0 || ClientID >= MAX_CLIENTS)
+	{
+		m_pClient->m_pDamageind->Create(vec2(Pos.x, Pos.y), direction(Angle));
+		return;
+	}
+
+	m_aDamageTaken[ClientID]++;
+
 	// create healthmod indicator
-	if(Client()->LocalTime() < m_DamageTakenTick+0.5f)
+	if(Client()->LocalTime() < m_aDamageTakenTick[ClientID]+0.5f)
 	{
 		// make sure that the damage indicators don't group together
-		Angle = m_DamageTaken*0.25f;
+		Angle = m_aDamageTaken[ClientID]*0.25f;
 	}
 	else
 	{
-		m_DamageTaken = 0;
+		m_aDamageTaken[ClientID] = 0;
 		Angle = 0;
 	}
 
@@ -78,7 +84,7 @@ void CEffects::DamageIndicator(vec2 Pos, int Amount)
 		m_pClient->m_pDamageind->Create(vec2(Pos.x, Pos.y), direction(f));
 	}
 
-	m_DamageTakenTick = Client()->LocalTime();
+	m_aDamageTakenTick[ClientID] = Client()->LocalTime();
 }
 
 void CEffects::PowerupShine(vec2 Pos, vec2 size)

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -9,13 +9,13 @@ class CEffects : public CComponent
 	bool m_Add50hz;
 	bool m_Add100hz;
 
-	int m_DamageTaken;
-	float m_DamageTakenTick;
+	int m_aDamageTaken[MAX_CLIENTS];
+	float m_aDamageTakenTick[MAX_CLIENTS];
 public:
 	CEffects();
 
 	void AirJump(vec2 Pos);
-	void DamageIndicator(vec2 Pos, int Amount);
+	void DamageIndicator(vec2 Pos, int Amount, float Angle, int ClientID);
 	void PowerupShine(vec2 Pos, vec2 Size);
 	void SmokeTrail(vec2 Pos, vec2 Vel);
 	void SkidTrail(vec2 Pos, vec2 Vel);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1062,7 +1062,7 @@ void CGameClient::ProcessEvents()
 		if(Item.m_Type == NETEVENTTYPE_DAMAGE)
 		{
 			CNetEvent_Damage *ev = (CNetEvent_Damage *)pData;
-			m_pEffects->DamageIndicator(vec2(ev->m_X, ev->m_Y), ev->m_HealthAmount + ev->m_ArmorAmount);
+			m_pEffects->DamageIndicator(vec2(ev->m_X, ev->m_Y), ev->m_HealthAmount + ev->m_ArmorAmount, ev->m_Angle / 256.0f, ev->m_ClientID);
 		}
 		else if(Item.m_Type == NETEVENTTYPE_EXPLOSION)
 		{


### PR DESCRIPTION
This is a non-gameplay changing fix for an oversight found while dealing with #2798.

Prevents damage indicators from visually going everywhere on each tee when multiple tees are taking damages within a certain time-frame.

If ClientID is out of range, use the Angle sent by server directly since it is a clean "fire and return" rather than tracking for an extra ClientID and dealing with +1 everywhere. Our server doesn't send out of range clientid anyway.