### PR TITLE
Fix inconsistent key reader text

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -889,14 +889,14 @@ int CMenus::DoKeyReader(CButtonContainer *pBC, const CUIRect *pRect, int Key, in
 		DoButton_KeySelect(pBC, "???", pRect);
 		m_KeyReaderIsActive = true;
 	}
-	else if(Key == 0)
+	else if(NewKey == 0)
 	{
 		DoButton_KeySelect(pBC, "", pRect);
 	}
 	else
 	{
 		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), "%s%s", CBinds::GetModifierName(*pNewModifier), Input()->KeyName(Key));
+		str_format(aBuf, sizeof(aBuf), "%s%s", CBinds::GetModifierName(*pNewModifier), Input()->KeyName(NewKey));
 		DoButton_KeySelect(pBC, aBuf, pRect);
 	}
 	return NewKey;


### PR DESCRIPTION
The key reader was displaying the old selection (modifier+key) for a frame. It now shows the current selection immediately without flashing the old one after changing a bind.

This also changes how invalid key inputs (#1531) just flash the old selection. Now it properly flashes "unknown" for a frame.