### PR TITLE
Engine Input: Fix undefined behaviour with invalid key inputs, refactoring and style fixes

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -420,7 +420,14 @@ int CInput::Update()
 
 				// fall through
 			case SDL_MOUSEBUTTONDOWN:
-				if(Event.button.button == SDL_BUTTON_LEFT) Key = KEY_MOUSE_1; // ignore_convention
+				if(Event.button.button == SDL_BUTTON_LEFT) // ignore_convention
+				{
+					Key = KEY_MOUSE_1;
+					if(Event.button.clicks%2 == 0)
+						m_MouseDoubleClick = true;
+					else if(Event.button.clicks == 1)
+						m_MouseDoubleClick = false;
+				}
 				if(Event.button.button == SDL_BUTTON_RIGHT) Key = KEY_MOUSE_2; // ignore_convention
 				if(Event.button.button == SDL_BUTTON_MIDDLE) Key = KEY_MOUSE_3; // ignore_convention
 				if(Event.button.button == SDL_BUTTON_X1) Key = KEY_MOUSE_4; // ignore_convention
@@ -429,13 +436,6 @@ int CInput::Update()
 				if(Event.button.button == 7) Key = KEY_MOUSE_7; // ignore_convention
 				if(Event.button.button == 8) Key = KEY_MOUSE_8; // ignore_convention
 				if(Event.button.button == 9) Key = KEY_MOUSE_9; // ignore_convention
-				if(Event.button.button == SDL_BUTTON_LEFT)
-				{
-					if(Event.button.clicks%2 == 0)
-						m_MouseDoubleClick = true;
-					if(Event.button.clicks == 1)
-						m_MouseDoubleClick = false;
-				}
 				Scancode = Key;
 				break;
 

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -66,9 +66,7 @@ CInput::CInput()
 CInput::~CInput()
 {
 	if(m_pClipboardText)
-	{
 		SDL_free(m_pClipboardText);
-	}
 	CloseJoysticks();
 }
 
@@ -123,12 +121,10 @@ void CInput::InitJoysticks()
 	}
 }
 
-SDL_Joystick* CInput::GetActiveJoystick()
+SDL_Joystick *CInput::GetActiveJoystick()
 {
 	if(m_apJoysticks.size() == 0)
-	{
 		return NULL;
-	}
 	if(m_aSelectedJoystickGUID[0] && str_comp(m_aSelectedJoystickGUID, m_pConfig->m_JoystickGUID) != 0)
 	{
 		// Refresh if cached GUID differs from configured GUID
@@ -161,12 +157,8 @@ SDL_Joystick* CInput::GetActiveJoystick()
 void CInput::CloseJoysticks()
 {
 	for(sorted_array<SDL_Joystick*>::range r = m_apJoysticks.all(); !r.empty(); r.pop_front())
-	{
-		if (SDL_JoystickGetAttached(r.front()))
-		{
+		if(SDL_JoystickGetAttached(r.front()))
 			SDL_JoystickClose(r.front());
-		}
-	}
 	m_apJoysticks.clear();
 }
 
@@ -180,23 +172,23 @@ void CInput::SelectNextJoystick()
 	}
 }
 
-const char* CInput::GetJoystickName()
+const char *CInput::GetJoystickName()
 {
-	SDL_Joystick* pJoystick = GetActiveJoystick();
+	SDL_Joystick *pJoystick = GetActiveJoystick();
 	dbg_assert((bool)pJoystick, "Requesting joystick name, but no joysticks were initialized");
 	return SDL_JoystickName(pJoystick);
 }
 
 float CInput::GetJoystickAxisValue(int Axis)
 {
-	SDL_Joystick* pJoystick = GetActiveJoystick();
+	SDL_Joystick *pJoystick = GetActiveJoystick();
 	dbg_assert((bool)pJoystick, "Requesting joystick axis value, but no joysticks were initialized");
 	return (SDL_JoystickGetAxis(pJoystick, Axis)-SDL_JOYSTICK_AXIS_MIN)/float(SDL_JOYSTICK_AXIS_MAX-SDL_JOYSTICK_AXIS_MIN)*2.0f - 1.0f;
 }
 
 int CInput::GetJoystickNumAxes()
 {
-	SDL_Joystick* pJoystick = GetActiveJoystick();
+	SDL_Joystick *pJoystick = GetActiveJoystick();
 	dbg_assert((bool)pJoystick, "Requesting joystick axes count, but no joysticks were initialized");
 	return SDL_JoystickNumAxes(pJoystick);
 }
@@ -292,9 +284,7 @@ bool CInput::MouseDoubleClick()
 const char *CInput::GetClipboardText()
 {
 	if(m_pClipboardText)
-	{
 		SDL_free(m_pClipboardText);
-	}
 	m_pClipboardText = SDL_GetClipboardText();
 	if(m_pClipboardText)
 		str_sanitize_cc(m_pClipboardText);

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -423,8 +423,8 @@ int CInput::Update()
 				if(Event.button.button == SDL_BUTTON_LEFT) Key = KEY_MOUSE_1; // ignore_convention
 				if(Event.button.button == SDL_BUTTON_RIGHT) Key = KEY_MOUSE_2; // ignore_convention
 				if(Event.button.button == SDL_BUTTON_MIDDLE) Key = KEY_MOUSE_3; // ignore_convention
-				if(Event.button.button == 4) Key = KEY_MOUSE_4; // ignore_convention
-				if(Event.button.button == 5) Key = KEY_MOUSE_5; // ignore_convention
+				if(Event.button.button == SDL_BUTTON_X1) Key = KEY_MOUSE_4; // ignore_convention
+				if(Event.button.button == SDL_BUTTON_X2) Key = KEY_MOUSE_5; // ignore_convention
 				if(Event.button.button == 6) Key = KEY_MOUSE_6; // ignore_convention
 				if(Event.button.button == 7) Key = KEY_MOUSE_7; // ignore_convention
 				if(Event.button.button == 8) Key = KEY_MOUSE_8; // ignore_convention

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -331,43 +331,41 @@ int CInput::Update()
 	if(MouseState&SDL_BUTTON(8)) m_aInputState[KEY_MOUSE_8] = 1;
 	if(MouseState&SDL_BUTTON(9)) m_aInputState[KEY_MOUSE_9] = 1;
 
+	SDL_Event Event;
+	while(SDL_PollEvent(&Event))
 	{
-		SDL_Event Event;
-
-		while(SDL_PollEvent(&Event))
+		int Key = -1;
+		int Scancode = 0;
+		int Action = IInput::FLAG_PRESS;
+		switch(Event.type)
 		{
-			int Key = -1;
-			int Scancode = 0;
-			int Action = IInput::FLAG_PRESS;
-			switch (Event.type)
-			{
-				case SDL_TEXTINPUT:
-					AddEvent(Event.text.text, 0, IInput::FLAG_TEXT);
-					break;
+			case SDL_TEXTINPUT:
+				AddEvent(Event.text.text, 0, IInput::FLAG_TEXT);
+				break;
 
-				// handle keys
-				case SDL_KEYDOWN:
-					Key = KeycodeToKey(Event.key.keysym.sym);
-					Scancode = Event.key.keysym.scancode;
-					break;
-				case SDL_KEYUP:
-					Action = IInput::FLAG_RELEASE;
-					Key = KeycodeToKey(Event.key.keysym.sym);
-					Scancode = Event.key.keysym.scancode;
-					break;
+			// handle keys
+			case SDL_KEYDOWN:
+				Key = KeycodeToKey(Event.key.keysym.sym);
+				Scancode = Event.key.keysym.scancode;
+				break;
+			case SDL_KEYUP:
+				Action = IInput::FLAG_RELEASE;
+				Key = KeycodeToKey(Event.key.keysym.sym);
+				Scancode = Event.key.keysym.scancode;
+				break;
 
-				// handle the joystick events
-				case SDL_JOYBUTTONUP:
-					Action = IInput::FLAG_RELEASE;
+			// handle the joystick events
+			case SDL_JOYBUTTONUP:
+				Action = IInput::FLAG_RELEASE;
 
-					// fall through
-				case SDL_JOYBUTTONDOWN:
-					Key = Event.jbutton.button + KEY_JOYSTICK_BUTTON_0;
-					Scancode = Key;
-					break;
+				// fall through
+			case SDL_JOYBUTTONDOWN:
+				Key = Event.jbutton.button + KEY_JOYSTICK_BUTTON_0;
+				Scancode = Key;
+				break;
 
-				case SDL_JOYHATMOTION:
-					switch (Event.jhat.value) {
+			case SDL_JOYHATMOTION:
+				switch(Event.jhat.value) {
 					case SDL_HAT_LEFTUP:
 						Key = KEY_JOY_HAT_LEFTUP;
 						Scancode = Key;
@@ -414,66 +412,63 @@ int CInput::Update()
 						Scancode = Key;
 						m_PreviousHat = Key;
 						break;
-					}
-					break;
+				}
+				break;
 
-				// handle mouse buttons
-				case SDL_MOUSEBUTTONUP:
-					Action = IInput::FLAG_RELEASE;
+			// handle mouse buttons
+			case SDL_MOUSEBUTTONUP:
+				Action = IInput::FLAG_RELEASE;
 
-					// fall through
-				case SDL_MOUSEBUTTONDOWN:
-					if(Event.button.button == SDL_BUTTON_LEFT) Key = KEY_MOUSE_1; // ignore_convention
-					if(Event.button.button == SDL_BUTTON_RIGHT) Key = KEY_MOUSE_2; // ignore_convention
-					if(Event.button.button == SDL_BUTTON_MIDDLE) Key = KEY_MOUSE_3; // ignore_convention
-					if(Event.button.button == 4) Key = KEY_MOUSE_4; // ignore_convention
-					if(Event.button.button == 5) Key = KEY_MOUSE_5; // ignore_convention
-					if(Event.button.button == 6) Key = KEY_MOUSE_6; // ignore_convention
-					if(Event.button.button == 7) Key = KEY_MOUSE_7; // ignore_convention
-					if(Event.button.button == 8) Key = KEY_MOUSE_8; // ignore_convention
-					if(Event.button.button == 9) Key = KEY_MOUSE_9; // ignore_convention
-					if(Event.button.button == SDL_BUTTON_LEFT)
-					{
-						if(Event.button.clicks%2 == 0)
-							m_MouseDoubleClick = true;
-						if(Event.button.clicks == 1)
-							m_MouseDoubleClick = false;
-					}
-					Scancode = Key;
-					break;
+				// fall through
+			case SDL_MOUSEBUTTONDOWN:
+				if(Event.button.button == SDL_BUTTON_LEFT) Key = KEY_MOUSE_1; // ignore_convention
+				if(Event.button.button == SDL_BUTTON_RIGHT) Key = KEY_MOUSE_2; // ignore_convention
+				if(Event.button.button == SDL_BUTTON_MIDDLE) Key = KEY_MOUSE_3; // ignore_convention
+				if(Event.button.button == 4) Key = KEY_MOUSE_4; // ignore_convention
+				if(Event.button.button == 5) Key = KEY_MOUSE_5; // ignore_convention
+				if(Event.button.button == 6) Key = KEY_MOUSE_6; // ignore_convention
+				if(Event.button.button == 7) Key = KEY_MOUSE_7; // ignore_convention
+				if(Event.button.button == 8) Key = KEY_MOUSE_8; // ignore_convention
+				if(Event.button.button == 9) Key = KEY_MOUSE_9; // ignore_convention
+				if(Event.button.button == SDL_BUTTON_LEFT)
+				{
+					if(Event.button.clicks%2 == 0)
+						m_MouseDoubleClick = true;
+					if(Event.button.clicks == 1)
+						m_MouseDoubleClick = false;
+				}
+				Scancode = Key;
+				break;
 
-				case SDL_MOUSEWHEEL:
-					if(Event.wheel.y > 0) Key = KEY_MOUSE_WHEEL_UP; // ignore_convention
-					if(Event.wheel.y < 0) Key = KEY_MOUSE_WHEEL_DOWN; // ignore_convention
-					Action |= IInput::FLAG_RELEASE;
-					break;
+			case SDL_MOUSEWHEEL:
+				if(Event.wheel.y > 0) Key = KEY_MOUSE_WHEEL_UP; // ignore_convention
+				if(Event.wheel.y < 0) Key = KEY_MOUSE_WHEEL_DOWN; // ignore_convention
+				Action |= IInput::FLAG_RELEASE;
+				break;
 
 #if defined(CONF_PLATFORM_MACOSX)	// Todo SDL: remove this when fixed (mouse state is faulty on start)
-				case SDL_WINDOWEVENT:
-					if(Event.window.event == SDL_WINDOWEVENT_MAXIMIZED)
-					{
-						MouseModeAbsolute();
-						MouseModeRelative();
-					}
-					break;
+			case SDL_WINDOWEVENT:
+				if(Event.window.event == SDL_WINDOWEVENT_MAXIMIZED)
+				{
+					MouseModeAbsolute();
+					MouseModeRelative();
+				}
+				break;
 #endif
 
-				// other messages
-				case SDL_QUIT:
-					return 1;
-			}
+			// other messages
+			case SDL_QUIT:
+				return 1;
+		}
 
-			//
-			if(Key != -1)
+		if(Key != -1)
+		{
+			if(Action&IInput::FLAG_PRESS)
 			{
-				if(Action&IInput::FLAG_PRESS)
-				{
-					m_aInputState[Scancode] = 1;
-					m_aInputCount[Key] = m_InputCounter;
-				}
-				AddEvent(0, Key, Action);
+				m_aInputState[Scancode] = 1;
+				m_aInputCount[Key] = m_InputCounter;
 			}
-
+			AddEvent(0, Key, Action);
 		}
 	}
 

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -315,9 +315,10 @@ int CInput::Update()
 
 	int NumKeyStates;
 	const Uint8 *pState = SDL_GetKeyboardState(&NumKeyStates);
-	if(NumKeyStates >= KEY_LAST)
-		NumKeyStates = KEY_LAST-1;
+	if(NumKeyStates >= KEY_MOUSE_1)
+		NumKeyStates = KEY_MOUSE_1;
 	mem_copy(m_aInputState, pState, NumKeyStates);
+	mem_zero(m_aInputState+NumKeyStates, KEY_LAST-NumKeyStates);
 
 	// these states must always be updated manually because they are not in the GetKeyState from SDL
 	int MouseState = SDL_GetMouseState(NULL, NULL);

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -344,12 +344,11 @@ int CInput::Update()
 				break;
 
 			// handle keys
-			case SDL_KEYDOWN:
-				Key = KeycodeToKey(Event.key.keysym.sym);
-				Scancode = Event.key.keysym.scancode;
-				break;
 			case SDL_KEYUP:
 				Action = IInput::FLAG_RELEASE;
+
+				// fall through
+			case SDL_KEYDOWN:
 				Key = KeycodeToKey(Event.key.keysym.sym);
 				Scancode = Event.key.keysym.scancode;
 				break;

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -321,11 +321,11 @@ int CInput::Update()
 
 	// these states must always be updated manually because they are not in the GetKeyState from SDL
 	int MouseState = SDL_GetMouseState(NULL, NULL);
-	if(MouseState&SDL_BUTTON(1)) m_aInputState[KEY_MOUSE_1] = 1; // 1 is left
-	if(MouseState&SDL_BUTTON(3)) m_aInputState[KEY_MOUSE_2] = 1; // 3 is right
-	if(MouseState&SDL_BUTTON(2)) m_aInputState[KEY_MOUSE_3] = 1; // 2 is middle
-	if(MouseState&SDL_BUTTON(4)) m_aInputState[KEY_MOUSE_4] = 1;
-	if(MouseState&SDL_BUTTON(5)) m_aInputState[KEY_MOUSE_5] = 1;
+	if(MouseState&SDL_BUTTON(SDL_BUTTON_LEFT)) m_aInputState[KEY_MOUSE_1] = 1;
+	if(MouseState&SDL_BUTTON(SDL_BUTTON_RIGHT)) m_aInputState[KEY_MOUSE_2] = 1;
+	if(MouseState&SDL_BUTTON(SDL_BUTTON_MIDDLE)) m_aInputState[KEY_MOUSE_3] = 1;
+	if(MouseState&SDL_BUTTON(SDL_BUTTON_X1)) m_aInputState[KEY_MOUSE_4] = 1;
+	if(MouseState&SDL_BUTTON(SDL_BUTTON_X2)) m_aInputState[KEY_MOUSE_5] = 1;
 	if(MouseState&SDL_BUTTON(6)) m_aInputState[KEY_MOUSE_6] = 1;
 	if(MouseState&SDL_BUTTON(7)) m_aInputState[KEY_MOUSE_7] = 1;
 	if(MouseState&SDL_BUTTON(8)) m_aInputState[KEY_MOUSE_8] = 1;

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -313,25 +313,23 @@ int CInput::Update()
 	// keep the counter between 1..0xFFFF, 0 means not pressed
 	m_InputCounter = (m_InputCounter%0xFFFF)+1;
 
-	{
-		int i;
-		const Uint8 *pState = SDL_GetKeyboardState(&i);
-		if(i >= KEY_LAST)
-			i = KEY_LAST-1;
-		mem_copy(m_aInputState, pState, i);
-	}
+	int NumKeyStates;
+	const Uint8 *pState = SDL_GetKeyboardState(&NumKeyStates);
+	if(NumKeyStates >= KEY_LAST)
+		NumKeyStates = KEY_LAST-1;
+	mem_copy(m_aInputState, pState, NumKeyStates);
 
 	// these states must always be updated manually because they are not in the GetKeyState from SDL
-	int i = SDL_GetMouseState(NULL, NULL);
-	if(i&SDL_BUTTON(1)) m_aInputState[KEY_MOUSE_1] = 1; // 1 is left
-	if(i&SDL_BUTTON(3)) m_aInputState[KEY_MOUSE_2] = 1; // 3 is right
-	if(i&SDL_BUTTON(2)) m_aInputState[KEY_MOUSE_3] = 1; // 2 is middle
-	if(i&SDL_BUTTON(4)) m_aInputState[KEY_MOUSE_4] = 1;
-	if(i&SDL_BUTTON(5)) m_aInputState[KEY_MOUSE_5] = 1;
-	if(i&SDL_BUTTON(6)) m_aInputState[KEY_MOUSE_6] = 1;
-	if(i&SDL_BUTTON(7)) m_aInputState[KEY_MOUSE_7] = 1;
-	if(i&SDL_BUTTON(8)) m_aInputState[KEY_MOUSE_8] = 1;
-	if(i&SDL_BUTTON(9)) m_aInputState[KEY_MOUSE_9] = 1;
+	int MouseState = SDL_GetMouseState(NULL, NULL);
+	if(MouseState&SDL_BUTTON(1)) m_aInputState[KEY_MOUSE_1] = 1; // 1 is left
+	if(MouseState&SDL_BUTTON(3)) m_aInputState[KEY_MOUSE_2] = 1; // 3 is right
+	if(MouseState&SDL_BUTTON(2)) m_aInputState[KEY_MOUSE_3] = 1; // 2 is middle
+	if(MouseState&SDL_BUTTON(4)) m_aInputState[KEY_MOUSE_4] = 1;
+	if(MouseState&SDL_BUTTON(5)) m_aInputState[KEY_MOUSE_5] = 1;
+	if(MouseState&SDL_BUTTON(6)) m_aInputState[KEY_MOUSE_6] = 1;
+	if(MouseState&SDL_BUTTON(7)) m_aInputState[KEY_MOUSE_7] = 1;
+	if(MouseState&SDL_BUTTON(8)) m_aInputState[KEY_MOUSE_8] = 1;
+	if(MouseState&SDL_BUTTON(9)) m_aInputState[KEY_MOUSE_9] = 1;
 
 	{
 		SDL_Event Event;

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -279,14 +279,14 @@ void CInput::MouseModeRelative()
 	}
 }
 
-int CInput::MouseDoubleClick()
+bool CInput::MouseDoubleClick()
 {
 	if(m_MouseDoubleClick)
 	{
 		m_MouseDoubleClick = false;
-		return 1;
+		return true;
 	}
-	return 0;
+	return false;
 }
 
 const char *CInput::GetClipboardText()

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -14,7 +14,7 @@ class CInput : public IEngineInput
 	sorted_array<SDL_Joystick*> m_apJoysticks;
 	int m_SelectedJoystickIndex;
 	char m_aSelectedJoystickGUID[34];
-	SDL_Joystick* GetActiveJoystick();
+	SDL_Joystick *GetActiveJoystick();
 	void InitJoysticks();
 	void CloseJoysticks();
 
@@ -52,7 +52,7 @@ public:
 	int NumJoysticks() const { return m_apJoysticks.size(); }
 	int GetJoystickIndex() const { return m_SelectedJoystickIndex; }
 	void SelectNextJoystick();
-	const char* GetJoystickName();
+	const char *GetJoystickName();
 	int GetJoystickNumAxes();
 	float GetJoystickAxisValue(int Axis);
 	bool JoystickRelative(float *pX, float *pY);

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -60,7 +60,7 @@ public:
 
 	void MouseModeRelative();
 	void MouseModeAbsolute();
-	int MouseDoubleClick();
+	bool MouseDoubleClick();
 	bool MouseRelative(float *pX, float *pY);
 
 	const char *GetClipboardText();

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -68,7 +68,7 @@ public:
 	virtual int NumJoysticks() const = 0;
 	virtual int GetJoystickIndex() const = 0;
 	virtual void SelectNextJoystick() = 0;
-	virtual const char* GetJoystickName() = 0;
+	virtual const char *GetJoystickName() = 0;
 	virtual int GetJoystickNumAxes() = 0;
 	virtual float GetJoystickAxisValue(int Axis) = 0;
 	virtual bool JoystickRelative(float *pX, float *pY) = 0;
@@ -81,7 +81,7 @@ public:
 	virtual bool MouseRelative(float *pX, float *pY) = 0;
 
 	// clipboard
-	virtual const char* GetClipboardText() = 0;
+	virtual const char *GetClipboardText() = 0;
 	virtual void SetClipboardText(const char *pText) = 0;
 
 	int CursorRelative(float *pX, float *pY)

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -77,7 +77,7 @@ public:
 	// mouse
 	virtual void MouseModeRelative() = 0;
 	virtual void MouseModeAbsolute() = 0;
-	virtual int MouseDoubleClick() = 0;
+	virtual bool MouseDoubleClick() = 0;
 	virtual bool MouseRelative(float *pX, float *pY) = 0;
 
 	// clipboard


### PR DESCRIPTION
The last two commits fix issues with invalid key inputs:

- Adjust size on mem_copy to only copy the valid keyboard state from the SDL array, mem_zero the remaining mouse and joystick state at the beginning.
- Make sure keys and scancodes are within array bounds to prevent out of bound writes. Add missing scancode assignment to mouse wheel events and ignore scrolling in x direction.

This should at least prevent random segmentation faults when using currently unsupported keyboard layouts, like russian/arabic AZERTY. The mouse wheel was also overlapping with some keys, so scrolling wouldn't work under some circumscances.

The other commits are refactorings and code style fixes.