### PR TITLE
Use american english

### DIFF
--- a/src/engine/client/serverbrowser_fav.cpp
+++ b/src/engine/client/serverbrowser_fav.cpp
@@ -173,10 +173,10 @@ const NETADDR *CServerBrowserFavorites::UpdateFavorites()
 {
 	NETADDR *pResult = 0;
 
-	// check if hostname lookup for favourites is done
+	// check if hostname lookup for favorites is done
 	if(m_FavLookup.m_Active && m_FavLookup.m_HostLookup.m_Job.Status() == CJob::STATE_DONE)
 	{
-		// check if favourite has not been removed in the meanwhile
+		// check if favorite has not been removed in the meanwhile
 		if(m_FavLookup.m_FavoriteIndex != -1)
 		{
 			if(m_FavLookup.m_HostLookup.m_Job.Result() == 0)
@@ -224,7 +224,7 @@ const NETADDR *CServerBrowserFavorites::UpdateFavorites()
 		m_FavLookup.m_Active = false;
 	}
 
-	// add hostname lookup for favourites
+	// add hostname lookup for favorites
 	if(m_FavLookup.m_LookupCount > 0 && !m_FavLookup.m_Active)
 	{
 		for(int i = 0; i < m_NumFavoriteServers; i++)

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -162,11 +162,11 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 
 			// use custom colors
 			bool UseCustomColors = false;
-			const json_value &rColour = rPart["custom_colors"];
-			if(rColour.type == json_string)
-				UseCustomColors = str_comp((const char *)rColour, "true") == 0;
-			else if(rColour.type == json_boolean)
-				UseCustomColors = rColour.u.boolean;
+			const json_value &rColor = rPart["custom_colors"];
+			if(rColor.type == json_string)
+				UseCustomColors = str_comp((const char *)rColor, "true") == 0;
+			else if(rColor.type == json_boolean)
+				UseCustomColors = rColor.u.boolean;
 			Skin.m_aUseCustomColors[PartIndex] = UseCustomColors;
 
 			// color components

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -165,7 +165,7 @@ int CLayerGroup::SwapLayers(int Index0, int Index1)
 	return Index1;
 }
 
-void CEditorImage::AnalyseTileFlags()
+void CEditorImage::AnalyzeTileFlags()
 {
 	if(m_Format == CImageInfo::FORMAT_RGB)
 	{
@@ -1613,7 +1613,7 @@ void CEditor::DoQuadEnvelopes(const array<CQuad> &lQuads, IGraphics::CTextureHan
 			float OffsetY = fx2f(apEnvelope[j]->m_lPoints[i].m_aValues[1]);
 			float Rot = fx2f(apEnvelope[j]->m_lPoints[i].m_aValues[2])/360.0f*pi*2;
 
-			//Set Colours
+			//Set Colors
 			float Alpha = (m_SelectedQuadEnvelope == lQuads[j].m_PosEnv && m_SelectedEnvelopePoint == i) ? 0.65f : 0.35f;
 			IGraphics::CColorVertex aArray[4] = {
 				IGraphics::CColorVertex(0, lQuads[j].m_aColors[0].r, lQuads[j].m_aColors[0].g, lQuads[j].m_aColors[0].b, Alpha),

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -278,7 +278,7 @@ public:
 
 	~CEditorImage();
 
-	void AnalyseTileFlags();
+	void AnalyzeTileFlags();
 	void LoadAutoMapper();
 
 	IGraphics::CTextureHandle m_Texture;

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -66,9 +66,9 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 	{
 		CEditorImage *pImg = m_lImages[i];
 
-		// analyse the image for when saving (should be done when we load the image)
+		// analyze the image for when saving (should be done when we load the image)
 		// TODO!
-		pImg->AnalyseTileFlags();
+		pImg->AnalyzeTileFlags();
 
 		CMapItemImage Item;
 		Item.m_Version = CMapItemImage::CURRENT_VERSION;


### PR DESCRIPTION
If think changing to AE would be easier to review than changing to BE 😉 

Statistics before this PR:

```
$ grep -r -i -e "favorite" src | wc -l
174
$ grep -r -i -e "favourite" src | wc -l
3

$ grep -r -i -e "color" src | wc -l
1216
$ grep -r -i -e "colour" src | wc -l
6

$ grep -r -i -e "analyze" src | wc -l
5
$ grep -r -i -e "analyse" src | wc -l
4

$ grep -r -i -e "dialog" src | wc -l
137
$ grep -r -i -e "dialogue" src | wc -l
0
```

All other words with different spellings do not occur (in the src folder).

Closes #1141.