### PR TITLE
Only show demo player stop error if using command

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -79,7 +79,7 @@ public:
 	virtual const char *DemoPlayer_Play(const char *pFilename, int StorageType) = 0;
 	virtual void DemoRecorder_Start(const char *pFilename, bool WithTimestamp) = 0;
 	virtual void DemoRecorder_HandleAutoStart() = 0;
-	virtual void DemoRecorder_Stop() = 0;
+	virtual void DemoRecorder_Stop(bool ErrorIfNotRecording = false) = 0;
 	virtual void RecordGameMessage(bool State) = 0;
 	virtual void AutoStatScreenshot_Start() = 0;
 	virtual void AutoScreenshot_Start() = 0;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -553,8 +553,7 @@ void CClient::Connect(const char *pAddress)
 	m_NetClient.Connect(&m_ServerAddress);
 	SetState(IClient::STATE_CONNECTING);
 
-	if(m_DemoRecorder.IsRecording())
-		DemoRecorder_Stop();
+	DemoRecorder_Stop();
 
 	m_InputtimeMarginGraph.Init(-150.0f, 150.0f);
 	m_GametimeMarginGraph.Init(-150.0f, 150.0f);
@@ -2367,9 +2366,10 @@ void CClient::DemoRecorder_HandleAutoStart()
 	}
 }
 
-void CClient::DemoRecorder_Stop()
+void CClient::DemoRecorder_Stop(bool ErrorIfNotRecording)
 {
-	m_DemoRecorder.Stop();
+	if(ErrorIfNotRecording || m_DemoRecorder.IsRecording())
+		m_DemoRecorder.Stop();
 }
 
 void CClient::DemoRecorder_AddDemoMarker()
@@ -2389,7 +2389,7 @@ void CClient::Con_Record(IConsole::IResult *pResult, void *pUserData)
 void CClient::Con_StopRecord(IConsole::IResult *pResult, void *pUserData)
 {
 	CClient *pSelf = (CClient *)pUserData;
-	pSelf->DemoRecorder_Stop();
+	pSelf->DemoRecorder_Stop(true);
 }
 
 void CClient::Con_AddDemoMarker(IConsole::IResult *pResult, void *pUserData)

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -317,7 +317,7 @@ public:
 	const char *DemoPlayer_Play(const char *pFilename, int StorageType);
 	void DemoRecorder_Start(const char *pFilename, bool WithTimestamp);
 	void DemoRecorder_HandleAutoStart();
-	void DemoRecorder_Stop();
+	void DemoRecorder_Stop(bool ErrorIfNotRecording = false);
 	void DemoRecorder_AddDemoMarker();
 	void RecordGameMessage(bool State) { m_RecordGameMessage = State; }
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1254,7 +1254,8 @@ int CServer::LoadMap(const char *pMapName)
 		return 0;
 
 	// stop recording when we change map
-	m_DemoRecorder.Stop();
+	if(m_DemoRecorder.IsRecording())
+		m_DemoRecorder.Stop();
 
 	// reinit snapshot ids
 	m_IDPool.TimeoutIDs();
@@ -1577,7 +1578,8 @@ void CServer::DemoRecorder_HandleAutoStart()
 {
 	if(Config()->m_SvAutoDemoRecord)
 	{
-		m_DemoRecorder.Stop();
+		if(m_DemoRecorder.IsRecording())
+			m_DemoRecorder.Stop();
 		char aFilename[128];
 		char aDate[20];
 		str_timestamp(aDate, sizeof(aDate));


### PR DESCRIPTION
Don't show the "No active demo recording to stop" message (#2873) on map change, disconnect, quit, etc.