### PR TITLE
Refactor usage of MapScreen, fix mouse when seeking in demo

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2225,7 +2225,7 @@ void CMenus::OnRender()
 		UI()->Update(MouseX, MouseY, MouseX*3.0f, MouseY*3.0f);
 
 		// render demo player or main menu
-		Graphics()->MapScreen(pScreen->x, pScreen->y, pScreen->w, pScreen->h);
+		UI()->MapScreen();
 		if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 			RenderDemoPlayer(*pScreen);
 		else
@@ -2273,8 +2273,8 @@ bool CMenus::IsBackgroundNeeded() const
 
 void CMenus::RenderBackground(float Time)
 {
-	float ScreenHeight = 300;
-	float ScreenWidth = ScreenHeight*Graphics()->ScreenAspect();
+	const float ScreenHeight = 300.0f;
+	const float ScreenWidth = ScreenHeight * Graphics()->ScreenAspect();
 	Graphics()->MapScreen(0, 0, ScreenWidth, ScreenHeight);
 
 	// render the tiles
@@ -2300,9 +2300,7 @@ void CMenus::RenderBackground(float Time)
 		Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();
 
-	// restore screen
-	{CUIRect Screen = *UI()->Screen();
-	Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);}
+	UI()->MapScreen();
 }
 
 void CMenus::RenderBackgroundShadow(const CUIRect *pRect, bool TopToBottom, float Rounding)

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -347,6 +347,8 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		DemoPlayer()->SetPos(PositionToSeek);
 		m_pClient->m_SuppressEvents = false;
 	}
+
+	UI()->MapScreen();
 }
 
 int CMenus::DemolistFetchCallback(const CFsFileInfo* pFileInfo, int IsDir, int StorageType, void *pUser)

--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -36,8 +36,8 @@ void CMotd::OnRender()
 	if(!IsActive())
 		return;
 
-	const float Width = 400*3.0f*Graphics()->ScreenAspect();
-	const float Height = 400*3.0f;
+	const float Height = 400.0f * 3.0f;
+	const float Width = Height * Graphics()->ScreenAspect();
 
 	Graphics()->MapScreen(0, 0, Width, Height);
 

--- a/src/game/client/components/notifications.cpp
+++ b/src/game/client/components/notifications.cpp
@@ -33,7 +33,7 @@ void CNotifications::Con_SndToggle(IConsole::IResult *pResult, void *pUserData)
 void CNotifications::RenderSoundNotification()
 {
 	const float Height = 300.0f;
-	const float Width = Height*Graphics()->ScreenAspect();
+	const float Width = Height * Graphics()->ScreenAspect();
 	const float ItemHeight = 20.f;
 	const float ItemWidth = 20.f;
 	const float DisplayTime = 1.5f; // includes FadeTime

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -799,10 +799,9 @@ void CScoreboard::OnRender()
 	if(!IsActive())
 		return;
 
-	CUIRect Screen = *UI()->Screen();
-	Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
+	UI()->MapScreen();
 
-	float Width = Screen.w;
+	float Width = UI()->Screen()->w;
 	float y = 85.f;
 	float w = 364.0f;
 	float FontSize = 86.0f;
@@ -843,8 +842,9 @@ void CScoreboard::OnRender()
 		}
 	}
 
-	Width = 400*3.0f*Graphics()->ScreenAspect();
-	Graphics()->MapScreen(0, 0, Width, 400*3.0f);
+	const float Height = 400.0f * 3.0f;
+	Width = Height * Graphics()->ScreenAspect();
+	Graphics()->MapScreen(0, 0, Width, Height);
 	static CTextCursor s_Cursor(FontSize);
 	s_Cursor.m_Align = TEXTALIGN_TC;
 	s_Cursor.MoveTo(Width/2, 39);

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -192,8 +192,8 @@ void CSpectator::OnRender()
 		ScaleX = 1.5f;
 
 	// draw background
-	float Width = 400*3.0f*Graphics()->ScreenAspect();
-	float Height = 400*3.0f;
+	const float Height = 400.0f * 3.0f;
+	const float Width = Height * Graphics()->ScreenAspect();
 
 	Graphics()->MapScreen(0, 0, Width, Height);
 

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -141,8 +141,8 @@ void CStats::OnRender()
 	if(!IsActive())
 		return;
 
-	float Width = 400*3.0f*Graphics()->ScreenAspect();
-	float Height = 400*3.0f;
+	const float Height = 400.0f * 3.0f;
+	const float Width = Height * Graphics()->ScreenAspect();
 	float w = 250.0f;
 	float h = 750.0f;
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -585,15 +585,15 @@ void CGameClient::StartRendering()
 	else if(m_pMenus->IsBackgroundNeeded())
 	{
 		// render background color
-		float sw = 300 * Graphics()->ScreenAspect();
-		float sh = 300;
-		Graphics()->MapScreen(0, 0, sw, sh);
+		const float ScreenHeight = 300.0f;
+		const float ScreenWidth = ScreenHeight * Graphics()->ScreenAspect();
+		const vec4 Bottom(0.45f, 0.45f, 0.45f, 1.0f);
+		const vec4 Top(0.45f, 0.45f, 0.45f, 1.0f);
+		Graphics()->MapScreen(0, 0, ScreenWidth, ScreenHeight);
 		Graphics()->TextureClear();
 		Graphics()->QuadsBegin();
-		vec4 Bottom(0.45f, 0.45f, 0.45f, 1.0f);
-		vec4 Top(0.45f, 0.45f, 0.45f, 1.0f);
 		Graphics()->SetColor4(Top, Top, Bottom, Bottom);
-		IGraphics::CQuadItem QuadItem(0, 0, sw, sh);
+		IGraphics::CQuadItem QuadItem(0, 0, ScreenWidth, ScreenHeight);
 		Graphics()->QuadsDrawTL(&QuadItem, 1);
 		Graphics()->QuadsEnd();
 	}

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -454,5 +454,4 @@ void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 
 		}
 
 	Graphics()->QuadsEnd();
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -91,13 +91,19 @@ void CUI::ConvertCursorMove(float *pX, float *pY, int CursorType) const
 const CUIRect *CUI::Screen()
 {
 	m_Screen.h = 600;
-	m_Screen.w = Graphics()->ScreenAspect()*m_Screen.h;
+	m_Screen.w = Graphics()->ScreenAspect() * m_Screen.h;
 	return &m_Screen;
 }
 
 float CUI::PixelSize()
 {
 	return Screen()->w/Graphics()->ScreenWidth();
+}
+
+void CUI::MapScreen()
+{
+	const CUIRect *pScreen = Screen();
+	Graphics()->MapScreen(pScreen->x, pScreen->y, pScreen->w, pScreen->h);
 }
 
 void CUI::ClipEnable(const CUIRect *pRect)

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -135,6 +135,7 @@ public:
 
 	const CUIRect *Screen();
 	float PixelSize();
+	void MapScreen();
 
 	void ClipEnable(const CUIRect *pRect);
 	void ClipDisable();

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2024,7 +2024,7 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 							{
 								for(int k = 0; k < NumEditLayers; k++)
 									pEditLayers[k]->BrushSelecting(r);
-								Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
+								UI()->MapScreen();
 							}
 						}
 						else if(s_Operation == OP_BRUSH_PAINT)
@@ -2038,7 +2038,7 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 							{
 								for(int k = 0; k < NumEditLayers; k++)
 									pEditLayers[k]->BrushSelecting(r);
-								Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
+								UI()->MapScreen();
 							}
 						}
 					}
@@ -2185,7 +2185,7 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 							}
 						}
 
-						Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
+						UI()->MapScreen();
 					}
 				}
 			} break;
@@ -2384,7 +2384,7 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 		m_ShowEnvelopePreview = SHOWENV_NONE;
 	}
 
-	Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
+	UI()->MapScreen();
 	//UI()->ClipDisable();
 }
 
@@ -4247,7 +4247,7 @@ void CEditor::Render()
 	else if(m_Mode == MODE_IMAGES)
 		RenderImages(ToolBox, ToolBar, View);
 
-	Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
+	UI()->MapScreen();
 
 	if(m_GuiActive)
 	{
@@ -4282,7 +4282,7 @@ void CEditor::Render()
 	// todo: fix this
 	if(Config()->m_EdShowkeys)
 	{
-		Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
+		UI()->MapScreen();
 		static CTextCursor s_Cursor(24.0f);
 		s_Cursor.Reset();
 		s_Cursor.MoveTo(View.x+10, View.y+View.h-24-10);

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -512,7 +512,6 @@ void CLayerTiles::ShowInfo()
 		}
 
 	Graphics()->QuadsEnd();
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
 int CLayerTiles::RenderProperties(CUIRect *pToolBox)


### PR DESCRIPTION
- Extract method `CUI::MapScreen()` to call `Graphics()->MapScreen` with the UI Screen rectangle and replace usages with this convenience method.
- Add `UI()->MapScreen()` in `menus_demo` to fix mouse being rendered at wrong position when clicking and holding down on the seekbar in the demo player.
- Remove `MapScreen` in `render_map` and `layer_tiles`, which are redundant as the function never changes the screen.
- Consistent code style for declaration of Height and Width variables for MapScreen-calls.