### PR TITLE
Fix add image button in editor not being scrollable to sometimes, improve image buttons, fix selected image not being rendered sometimes

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2855,7 +2855,7 @@ void CEditor::SortImages()
 }
 
 
-void CEditor::RenderImages(CUIRect ToolBox, CUIRect ToolBar, CUIRect View)
+void CEditor::RenderImagesList(CUIRect ToolBox, CUIRect ToolBar)
 {
 	static float s_ScrollValue = 0.0f;
 	const float RowHeight = 14.0f;
@@ -2953,28 +2953,6 @@ void CEditor::RenderImages(CUIRect ToolBox, CUIRect ToolBar, CUIRect View)
 			}
 
 			ToolBox.HSplitTop(2.0f, 0, &ToolBox);
-
-			// render image
-			if(m_SelectedImage == i)
-			{
-				CUIRect r;
-				View.Margin(10.0f, &r);
-				if(r.h < r.w)
-					r.w = r.h;
-				else
-					r.h = r.w;
-				float Max = (float)(max(m_Map.m_lImages[i]->m_Width, m_Map.m_lImages[i]->m_Height));
-				r.w *= m_Map.m_lImages[i]->m_Width/Max;
-				r.h *= m_Map.m_lImages[i]->m_Height/Max;
-				Graphics()->TextureSet(m_Map.m_lImages[i]->m_Texture);
-				Graphics()->BlendNormal();
-				Graphics()->WrapClamp();
-				Graphics()->QuadsBegin();
-				IGraphics::CQuadItem QuadItem(r.x, r.y, r.w, r.h);
-				Graphics()->QuadsDrawTL(&QuadItem, 1);
-				Graphics()->QuadsEnd();
-				Graphics()->WrapNormal();
-			}
 		}
 
 		// separator
@@ -2999,6 +2977,29 @@ void CEditor::RenderImages(CUIRect ToolBox, CUIRect ToolBar, CUIRect View)
 	ToolBox.HSplitTop(12.0f, &Slot, &ToolBox);
 	if(DoButton_Editor(&s_NewImageButton, "Add", 0, &Slot, 0, "Load a new image to use in the map"))
 		InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_IMG, "Add Image", "Add", "mapres", "", AddImage, this);
+}
+
+void CEditor::RenderSelectedImage(CUIRect View)
+{
+	if(m_SelectedImage < 0 || m_SelectedImage >= m_Map.m_lImages.size())
+		return;
+
+	View.Margin(10.0f, &View);
+	if(View.h < View.w)
+		View.w = View.h;
+	else
+		View.h = View.w;
+	float Max = (float)(max(m_Map.m_lImages[m_SelectedImage]->m_Width, m_Map.m_lImages[m_SelectedImage]->m_Height));
+	View.w *= m_Map.m_lImages[m_SelectedImage]->m_Width/Max;
+	View.h *= m_Map.m_lImages[m_SelectedImage]->m_Height/Max;
+	Graphics()->TextureSet(m_Map.m_lImages[m_SelectedImage]->m_Texture);
+	Graphics()->BlendNormal();
+	Graphics()->WrapClamp();
+	Graphics()->QuadsBegin();
+	IGraphics::CQuadItem QuadItem(View.x, View.y, View.w, View.h);
+	Graphics()->QuadsDrawTL(&QuadItem, 1);
+	Graphics()->QuadsEnd();
+	Graphics()->WrapNormal();
 }
 
 
@@ -4237,7 +4238,10 @@ void CEditor::Render()
 	if(m_Mode == MODE_LAYERS)
 		RenderLayers(ToolBox, ToolBar, View);
 	else if(m_Mode == MODE_IMAGES)
-		RenderImages(ToolBox, ToolBar, View);
+	{
+		RenderImagesList(ToolBox, ToolBar);
+		RenderSelectedImage(View);
+	}
 
 	Graphics()->MapScreen(UI()->Screen()->x, UI()->Screen()->y, UI()->Screen()->w, UI()->Screen()->h);
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -564,13 +564,13 @@ int CEditor::DoButton_Image(const void *pID, const char *pText, int Checked, con
 		ButtonColor *= vec4(0.5f, 0.5f, 0.5f, 1.0f);
 
 	RenderTools()->DrawUIRect(pRect, ButtonColor, CUI::CORNER_ALL, 3.0f);
-	CUIRect NewRect = *pRect;
-	NewRect.y += NewRect.h/2.0f-7.0f;
-	float tw = min(TextRender()->TextWidth(10.0f, pText, -1), NewRect.w);
-	static CTextCursor s_Cursor(10.0f);
-	s_Cursor.MoveTo(NewRect.x + NewRect.w/2-tw/2, NewRect.y - 1.0f);
+	static CTextCursor s_Cursor;
+	s_Cursor.MoveTo(pRect->x + pRect->w/2, pRect->y + pRect->h/2);
 	s_Cursor.Reset();
-	s_Cursor.m_MaxWidth = NewRect.w;
+	s_Cursor.m_FontSize = clamp(8.0f * pRect->w / TextRender()->TextWidth(10.0f, pText, -1), 6.0f, 10.0f);
+	s_Cursor.m_MaxWidth = pRect->w;
+	s_Cursor.m_MaxLines = 1;
+	s_Cursor.m_Align = TEXTALIGN_MC;
 	TextRender()->TextOutlined(&s_Cursor, pText, -1);
 	return DoButton_Editor_Common(pID, pText, Checked, pRect, Flags, pToolTip);
 }

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -544,14 +544,13 @@ int CEditor::DoButton_Editor_Common(const void *pID, const char *pText, int Chec
 int CEditor::DoButton_Editor(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip)
 {
 	RenderTools()->DrawUIRect(pRect, GetButtonColor(pID, Checked), CUI::CORNER_ALL, 3.0f);
-	CUIRect NewRect = *pRect;
-	NewRect.y += NewRect.h/2.0f-7.0f;
 
-	float tw = min(TextRender()->TextWidth(10.0f, pText, -1), NewRect.w);
 	static CTextCursor s_Cursor(10.0f);
+	s_Cursor.MoveTo(pRect->x + pRect->w/2, pRect->y + pRect->h/2);
 	s_Cursor.Reset();
-	s_Cursor.MoveTo(NewRect.x + NewRect.w/2-tw/2, NewRect.y - 1.0f);
-	s_Cursor.m_MaxWidth = NewRect.w;
+	s_Cursor.m_MaxWidth = pRect->w;
+	s_Cursor.m_MaxLines = 1;
+	s_Cursor.m_Align = TEXTALIGN_MC;
 	TextRender()->TextOutlined(&s_Cursor, pText, -1);
 	return DoButton_Editor_Common(pID, pText, Checked, pRect, Flags, pToolTip);
 }

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -830,7 +830,8 @@ public:
 	static void ReplaceImage(const char *pFilename, int StorageType, void *pUser);
 	static void AddImage(const char *pFilename, int StorageType, void *pUser);
 
-	void RenderImages(CUIRect Toolbox, CUIRect Toolbar, CUIRect View);
+	void RenderImagesList(CUIRect Toolbox, CUIRect Toolbar);
+	void RenderSelectedImage(CUIRect View);
 	void RenderLayers(CUIRect Toolbox, CUIRect Toolbar, CUIRect View);
 	void RenderModebar(CUIRect View);
 	void RenderStatusbar(CUIRect View);


### PR DESCRIPTION
- Fix "Add" button not being shown sometimes.
  - While I could not reproduce the problem on master with the steps described in the issue, I think this closes #2895 by resetting the scrolling value when no scrollbar is shown and also fixing a bug where neither the add button nor the scrollbar where shown.
  - The scrolling should eventually be done more cleanly with a CListBox anyway. This is just a bandaid for the current implementation.
- Improve vertical alignment of image buttons and decrease font size dynamically instead of cutting off name:
![screenshot_2021-06-18_23-07-26](https://user-images.githubusercontent.com/23437060/122617270-39e15680-d08c-11eb-97cb-e6dfdc16a378.png)
- Also improve vertical alignment of generic menu buttons, because it was the same code anyway (no dynamic size for them):
![screenshot_2021-06-18_23-31-06](https://user-images.githubusercontent.com/23437060/122617906-78c3dc00-d08d-11eb-9921-f86f81df4923.png)
- Fix the selected image not being rendered when the list item was scrolled out of view at the bottom (closes #2902).

