### PR TITLE
Add period/comma hotkeys to demo player to advance a single tick forward/backward, more accurate seeking

### DIFF
--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -53,6 +53,7 @@ public:
 	~IDemoPlayer() {}
 	virtual void SetSpeed(float Speed) = 0;
 	virtual int SetPos(float Percent) = 0;
+	virtual int SetPos(int WantedTick) = 0;
 	virtual void Pause() = 0;
 	virtual void Unpause() = 0;
 	virtual const CInfo *BaseInfo() const = 0;

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -718,12 +718,6 @@ const char *CDemoPlayer::Load(const char *pFilename, int StorageType, const char
 	return 0;
 }
 
-int CDemoPlayer::NextFrame()
-{
-	DoTick();
-	return IsPlaying();
-}
-
 int CDemoPlayer::Play()
 {
 	// fill in previous and next tick

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -104,7 +104,6 @@ private:
 	int ReadChunkHeader(int *pType, int *pSize, int *pTick);
 	void DoTick();
 	void ScanFile();
-	int NextFrame();
 
 public:
 

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -118,6 +118,7 @@ public:
 	int Stop();
 	void SetSpeed(float Speed);
 	int SetPos(float Percent);
+	int SetPos(int WantedTick);
 	const CInfo *BaseInfo() const { return &m_Info.m_Info; }
 	void GetDemoName(char *pBuffer, int BufferSize) const;
 	bool GetDemoInfo(const char *pFilename, int StorageType, CDemoHeader *pDemoHeader) const;

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -31,6 +31,9 @@ void CInfoMessages::AddInfoMsg(int Type, CInfoMsg NewMsg)
 
 void CInfoMessages::OnMessage(int MsgType, void *pRawMsg)
 {
+	if(m_pClient->m_SuppressEvents)
+		return;
+
 	// hint TextRender to render text, deferred, with correct fontsize
 	float Width = 400*3.0f*Graphics()->ScreenAspect();
 	float Height = 400*3.0f;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -249,6 +249,23 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		m_SeekBarActivatedTime = Now;
 	}
 
+	// Advance single frame forward with period key
+	static bool s_ShouldPaused = false;
+	if(s_ShouldPaused)
+	{
+		DemoPlayer()->Pause();
+		s_ShouldPaused = false;
+	}
+	if(PositionToSeek < 0.0f && UI()->KeyPress(KEY_PERIOD))
+	{
+		s_ShouldPaused = true;
+		DemoPlayer()->Unpause();
+
+		// Show the seek bar for a few seconds after skipping
+		m_SeekBarActive = true;
+		m_SeekBarActivatedTime = Now;
+	}
+
 	if(m_MenuActive)
 	{
 		// do buttons

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -249,17 +249,15 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		m_SeekBarActivatedTime = Now;
 	}
 
-	// Advance single frame forward with period key
-	static bool s_ShouldPaused = false;
-	if(s_ShouldPaused)
+	// Advance single frame forward/backward with period/comma key
+	const bool TickForwards = UI()->KeyPress(KEY_PERIOD);
+	const bool TickBackwards = UI()->KeyPress(KEY_COMMA);
+	if(PositionToSeek < 0.0f && (TickForwards || TickBackwards))
 	{
+		m_pClient->m_SuppressEvents = true;
+		DemoPlayer()->SetPos(pInfo->m_CurrentTick + (TickForwards ? 3 : 0));
+		m_pClient->m_SuppressEvents = false;
 		DemoPlayer()->Pause();
-		s_ShouldPaused = false;
-	}
-	if(PositionToSeek < 0.0f && UI()->KeyPress(KEY_PERIOD))
-	{
-		s_ShouldPaused = true;
-		DemoPlayer()->Unpause();
 
 		// Show the seek bar for a few seconds after skipping
 		m_SeekBarActive = true;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -175,6 +175,9 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			DemoPlayer()->Pause();
 		else
 			DemoPlayer()->Unpause();
+
+		m_SeekBarActive = true;
+		m_SeekBarActivatedTime = Now;
 	}
 
 	// skip forward/backward using left/right arrow keys

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -80,6 +80,9 @@ void CStats::OnConsoleInit()
 
 void CStats::OnMessage(int MsgType, void *pRawMsg)
 {
+	if(m_pClient->m_SuppressEvents)
+		return;
+
 	if(MsgType == NETMSGTYPE_SV_KILLMSG)
 	{
 		CNetMsg_Sv_KillMsg *pMsg = (CNetMsg_Sv_KillMsg *)pRawMsg;


### PR DESCRIPTION
- Add period `.` hotkey to demo player to advance a single tick forwards and comma `,` hotkey to go one tick backwards.
- Add `CDemoPlayer::SetPos(int)` to seek a specific tick, which will be the _next_ tick played. Also change the tick `-5` magic to only apply to the Keyframe calculation, which makes seeking with the mouse more accurate.
- Show seekbar on pause/unpause.
- Suppress infomessages and stats when seeking to prevent duplicate infomessages and invalid stats.
- Remove unused `CDemoPlayer::NextFrame` method.