### PR TITLE
Always check map SHA256 when the server sends it

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -907,7 +907,7 @@ const char *CClient::LoadMapSearch(const char *pMapName, const SHA256_DIGEST *pW
 	if(pWantedSha256)
 	{
 		FormatMapDownloadFilename(pMapName, 0, WantedCrc, false, aBuf, sizeof(aBuf));
-		pError = LoadMap(pMapName, aBuf, 0, WantedCrc);
+		pError = LoadMap(pMapName, aBuf, pWantedSha256, WantedCrc);
 		if(!pError)
 			return pError;
 	}


### PR DESCRIPTION
Previously, the check was erronously omitted when trying an old-style
map CRC name. This meant that a server could send such a map to a client
(by omitting the SHA256) and affect another server that does send the
SHA256.