### PR TITLE
Update comments of mem functions and remove obsolete code

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -275,24 +275,7 @@ void dbg_console_cleanup()
 #endif
 /* */
 
-typedef struct MEMHEADER
-{
-	const char *filename;
-	int line;
-	int size;
-	struct MEMHEADER *prev;
-	struct MEMHEADER *next;
-} MEMHEADER;
-
-typedef struct MEMTAIL
-{
-	int guard;
-} MEMTAIL;
-
-static struct MEMHEADER *first = 0;
-static const int MEM_GUARD_VAL = 0xbaadc0de;
-
-void *mem_alloc_debug(const char *filename, int line, unsigned size, unsigned alignment)
+void *mem_alloc(unsigned size, unsigned alignment)
 {
 	return malloc(size);
 }
@@ -315,23 +298,6 @@ void mem_move(void *dest, const void *source, unsigned size)
 void mem_zero(void *block,unsigned size)
 {
 	memset(block, 0, size);
-}
-
-int mem_check_imp()
-{
-	MEMHEADER *header = first;
-	while(header)
-	{
-		MEMTAIL *tail = (MEMTAIL *)(((char*)(header+1))+header->size);
-		if(tail->guard != MEM_GUARD_VAL)
-		{
-			dbg_msg("mem", "Memory check failed at %s(%d): %d", header->filename, header->line, header->size);
-			return 0;
-		}
-		header = header->next;
-	}
-
-	return 1;
 }
 
 IOHANDLE io_open(const char *filename, int flags)

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -275,7 +275,7 @@ void dbg_console_cleanup()
 #endif
 /* */
 
-void *mem_alloc(unsigned size, unsigned alignment)
+void *mem_alloc(unsigned size)
 {
 	return malloc(size);
 }
@@ -569,7 +569,7 @@ typedef CRITICAL_SECTION LOCKINTERNAL;
 
 LOCK lock_create()
 {
-	LOCKINTERNAL *lock = (LOCKINTERNAL*)mem_alloc(sizeof(LOCKINTERNAL), 4);
+	LOCKINTERNAL *lock = (LOCKINTERNAL*)mem_alloc(sizeof(LOCKINTERNAL));
 
 #if defined(CONF_FAMILY_UNIX)
 	pthread_mutex_init(lock, 0x0);

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -77,20 +77,18 @@ GNUC_ATTRIBUTE((format(printf, 2, 3)));
 
 	Parameters:
 		size - Size of the needed block.
-		alignment - Alignment for the block.
 
 	Returns:
 		Returns a pointer to the newly allocated block. Returns a
 		null pointer if the memory couldn't be allocated.
 
 	Remarks:
-		- Passing 0 to size will allocated the smallest amount possible
-		and return a unique pointer.
+		- The behavior when passing 0 as size is unspecified.
 
 	See Also:
 		<mem_free>
 */
-void *mem_alloc(unsigned size, unsigned alignment);
+void *mem_alloc(unsigned size);
 
 /*
 	Function: mem_free

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -31,9 +31,6 @@ extern "C" {
 		test - Result of the test.
 		msg - Message that should be printed if the test fails.
 
-	Remarks:
-		Does nothing in release version of the library.
-
 	See Also:
 		<dbg_break>
 */
@@ -52,9 +49,6 @@ void dbg_assert_imp(const char *filename, int line, int test, const char *msg);
 	Function: dbg_break
 		Breaks into the debugger.
 
-	Remarks:
-		Does nothing in release version of the library.
-
 	See Also:
 		<dbg_assert>
 */
@@ -68,9 +62,6 @@ void dbg_break();
 	Parameters:
 		sys - A string that describes what system the message belongs to
 		fmt - A printf styled format string.
-
-	Remarks:
-		Does nothing in release version of the library.
 
 	See Also:
 		<dbg_assert>
@@ -99,17 +90,11 @@ GNUC_ATTRIBUTE((format(printf, 2, 3)));
 	See Also:
 		<mem_free>
 */
-void *mem_alloc_debug(const char *filename, int line, unsigned size, unsigned alignment);
-#define mem_alloc(s,a) mem_alloc_debug(__FILE__, __LINE__, (s), (a))
+void *mem_alloc(unsigned size, unsigned alignment);
 
 /*
 	Function: mem_free
 		Frees a block allocated through <mem_alloc>.
-
-	Remarks:
-		- In the debug version of the library the function will assert if
-		a non-valid block is passed, like a null pointer or a block that
-		isn't allocated.
 
 	See Also:
 		<mem_alloc>

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -131,7 +131,7 @@ void *CCommandProcessorFragment_OpenGL::Rescale(int Width, int Height, int NewWi
 	if(Format == CCommandBuffer::TEXFORMAT_RGBA)
 		Bpp = 4;
 
-	unsigned char *pTmpData = (unsigned char *)mem_alloc(NewWidth*NewHeight*Bpp, 1);
+	unsigned char *pTmpData = (unsigned char *)mem_alloc(NewWidth*NewHeight*Bpp);
 
 	for(int y = 0; y < NewHeight; y++)
 		for(int x = 0; x < NewWidth; x++)
@@ -402,7 +402,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Create(const CCommandBuffer::
 
 		// copy and reorder texture data
 		int MemSize = Width*Height*IGraphics::NUMTILES_DIMENSION*IGraphics::NUMTILES_DIMENSION*pCommand->m_PixelSize;
-		char *pTmpData = (char *)mem_alloc(MemSize, sizeof(void*));
+		char *pTmpData = (char *)mem_alloc(MemSize);
 
 		const int TileSize = (Height * Width) * pCommand->m_PixelSize;
 		const int TileRowSize = Width * pCommand->m_PixelSize;
@@ -482,7 +482,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Screenshot(const CCommandBuffer::CScr
 	int y = aViewport[3] - pCommand->m_Y - 1 - (h - 1);
 
 	// we allocate one more row to use when we are flipping the texture
-	unsigned char *pPixelData = (unsigned char *)mem_alloc(w*(h+1)*3, 1);
+	unsigned char *pPixelData = (unsigned char *)mem_alloc(w*(h+1)*3);
 	unsigned char *pTempRow = pPixelData+w*h*3;
 
 	// fetch the pixels

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2527,7 +2527,7 @@ void CClient::RegisterCommands()
 
 static CClient *CreateClient()
 {
-	CClient *pClient = static_cast<CClient *>(mem_alloc(sizeof(CClient), 1));
+	CClient *pClient = static_cast<CClient *>(mem_alloc(sizeof(CClient)));
 	mem_zero(pClient, sizeof(CClient));
 	return new(pClient) CClient;
 }

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -320,7 +320,7 @@ int CGraphics_Threaded::LoadTextureRawSub(CTextureHandle TextureID, int x, int y
 	int MemSize = Width*Height*ImageFormatToPixelSize(Format);
 
 	// copy texture data
-	void *pTmpData = mem_alloc(MemSize, sizeof(void*));
+	void *pTmpData = mem_alloc(MemSize);
 	mem_copy(pTmpData, pData, MemSize);
 	Cmd.m_pData = pTmpData;
 
@@ -370,7 +370,7 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadTextureRaw(int Width, int Heig
 
 	// copy texture data
 	int MemSize = Width*Height*Cmd.m_PixelSize;
-	void *pTmpData = mem_alloc(MemSize, sizeof(void*));
+	void *pTmpData = mem_alloc(MemSize);
 	mem_copy(pTmpData, pData, MemSize);
 	Cmd.m_pData = pTmpData;
 
@@ -439,7 +439,7 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 		return 0;
 	}
 
-	pBuffer = (unsigned char *)mem_alloc(Png.width * Png.height * Png.bpp, 1); // ignore_convention
+	pBuffer = (unsigned char *)mem_alloc(Png.width * Png.height * Png.bpp); // ignore_convention
 	png_get_data(&Png, pBuffer); // ignore_convention
 	png_close_file(&Png); // ignore_convention
 

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -459,13 +459,13 @@ CServerEntry *CServerBrowser::Add(int ServerlistType, const NETADDR &Addr)
 		{
 			// alloc start size
 			m_aServerlist[ServerlistType].m_NumServerCapacity = 1000;
-			m_aServerlist[ServerlistType].m_ppServerlist = (CServerEntry **)mem_alloc(m_aServerlist[ServerlistType].m_NumServerCapacity*sizeof(CServerEntry*), 1);
+			m_aServerlist[ServerlistType].m_ppServerlist = (CServerEntry **)mem_alloc(m_aServerlist[ServerlistType].m_NumServerCapacity*sizeof(CServerEntry*));
 		}
 		else
 		{
 			// increase size
 			m_aServerlist[ServerlistType].m_NumServerCapacity += 100;
-			CServerEntry **ppNewlist = (CServerEntry **)mem_alloc(m_aServerlist[ServerlistType].m_NumServerCapacity*sizeof(CServerEntry*), 1);
+			CServerEntry **ppNewlist = (CServerEntry **)mem_alloc(m_aServerlist[ServerlistType].m_NumServerCapacity*sizeof(CServerEntry*));
 			mem_copy(ppNewlist, m_aServerlist[ServerlistType].m_ppServerlist, m_aServerlist[ServerlistType].m_NumServers*sizeof(CServerEntry*));
 			mem_free(m_aServerlist[ServerlistType].m_ppServerlist);
 			m_aServerlist[ServerlistType].m_ppServerlist = ppNewlist;
@@ -613,7 +613,7 @@ void CServerBrowser::LoadServerlist()
 	if(!File)
 		return;
 	int FileSize = (int)io_length(File);
-	char *pFileData = (char *)mem_alloc(FileSize, 1);
+	char *pFileData = (char *)mem_alloc(FileSize);
 	io_read(File, pFileData, FileSize);
 	io_close(File);
 

--- a/src/engine/client/serverbrowser_filter.cpp
+++ b/src/engine/client/serverbrowser_filter.cpp
@@ -79,7 +79,7 @@ CServerBrowserFilter::CServerFilter& CServerBrowserFilter::CServerFilter::operat
 		m_NumSortedServers = Other.m_NumSortedServers;
 		m_SortedServersCapacity = Other.m_SortedServersCapacity;
 
-		m_pSortedServerlist = (int *)mem_alloc(m_SortedServersCapacity * sizeof(int), 1);
+		m_pSortedServerlist = (int *)mem_alloc(m_SortedServersCapacity * sizeof(int));
 		for(int i = 0; i < m_SortedServersCapacity; ++i)
 			m_pSortedServerlist[i] = Other.m_pSortedServerlist[i];
 	}
@@ -98,7 +98,7 @@ void CServerBrowserFilter::CServerFilter::Filter()
 		if(m_pSortedServerlist)
 			mem_free(m_pSortedServerlist);
 		m_SortedServersCapacity = max(1000, NumServers+NumServers/2);
-		m_pSortedServerlist = (int *)mem_alloc(m_SortedServersCapacity*sizeof(int), 1);
+		m_pSortedServerlist = (int *)mem_alloc(m_SortedServersCapacity*sizeof(int));
 	}
 
 	// filter the servers

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -244,7 +244,7 @@ int CSound::Init()
 		dbg_msg("client/sound", "sound init successful");
 
 	m_MaxFrames = m_pConfig->m_SndBufferSize*2;
-	m_pMixBuffer = (int *)mem_alloc(m_MaxFrames*2*sizeof(int), 1);
+	m_pMixBuffer = (int *)mem_alloc(m_MaxFrames*2*sizeof(int));
 
 	SDL_PauseAudio(0);
 
@@ -308,7 +308,7 @@ void CSound::RateConvert(int SampleID)
 
 	// allocate new data
 	NumFrames = (int)((pSample->m_NumFrames/(float)pSample->m_Rate)*m_MixingRate);
-	pNewData = (short *)mem_alloc(NumFrames*pSample->m_Channels*sizeof(short), 1);
+	pNewData = (short *)mem_alloc(NumFrames*pSample->m_Channels*sizeof(short));
 
 	for(int i = 0; i < NumFrames; i++)
 	{
@@ -458,11 +458,11 @@ ISound::CSampleHandle CSound::LoadWV(const char *pFilename)
 			return CSampleHandle();
 		}
 
-		pData = (int *)mem_alloc(4*m_aSamples*m_aChannels, 1);
+		pData = (int *)mem_alloc(4*m_aSamples*m_aChannels);
 		WavpackUnpackSamples(pContext, pData, m_aSamples); // TODO: check return value
 		pSrc = pData;
 
-		pSample->m_pData = (short *)mem_alloc(2*m_aSamples*m_aChannels, 1);
+		pSample->m_pData = (short *)mem_alloc(2*m_aSamples*m_aChannels);
 		pDst = pSample->m_pData;
 
 		for (i = 0; i < m_aSamples*m_aChannels; i++)

--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -154,7 +154,7 @@ void CGlyphMap::InitTexture(int Width, int Height)
 
 	int TextureSize = Width*Height;
 
-	void *pMem = mem_alloc(TextureSize, 1);
+	void *pMem = mem_alloc(TextureSize);
 	mem_zero(pMem, TextureSize);
 
 	for(int i = 0; i < 2; i++)
@@ -208,7 +208,7 @@ int CGlyphMap::FitGlyph(int Width, int Height, ivec2 *pPosition)
 	int W = m_aAtlasPages[Atlas].m_Width;
 	int H = m_aAtlasPages[Atlas].m_Height;
 
-	unsigned char *pMem = (unsigned char *)mem_alloc(W*H, 1);
+	unsigned char *pMem = (unsigned char *)mem_alloc(W*H);
 	mem_zero(pMem, W*H);
 
 	UploadGlyph(0, X, Y, W, H, pMem);
@@ -764,7 +764,7 @@ void CTextRender::LoadFonts(IStorage *pStorage, IConsole *pConsole)
 		return;
 	}
 	int FileSize = (int)io_length(File);
-	char *pFileData = (char *)mem_alloc(FileSize, 1);
+	char *pFileData = (char *)mem_alloc(FileSize);
 	io_read(File, pFileData, FileSize);
 	io_close(File);
 
@@ -794,7 +794,7 @@ void CTextRender::LoadFonts(IStorage *pStorage, IConsole *pConsole)
 			if(File)
 			{
 				long FileSize = io_length(File);
-				m_apFontData[i] = mem_alloc(FileSize, 1);
+				m_apFontData[i] = mem_alloc(FileSize);
 				io_read(File, m_apFontData[i], FileSize);
 				io_close(File);
 				if(LoadFontCollection(aFilename, m_apFontData[i], FileSize))
@@ -830,7 +830,7 @@ void CTextRender::LoadFonts(IStorage *pStorage, IConsole *pConsole)
 	{
 		m_NumVariants = rVariant.u.object.length;
 		json_object_entry *Entries = rVariant.u.object.values;
-		m_paVariants = (CFontLanguageVariant *)mem_alloc(sizeof(CFontLanguageVariant)*m_NumVariants, 1);
+		m_paVariants = (CFontLanguageVariant *)mem_alloc(sizeof(CFontLanguageVariant)*m_NumVariants);
 		for(int i = 0; i < m_NumVariants; ++i)
 		{
 			char aFileName[128];

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1279,7 +1279,7 @@ int CServer::LoadMap(const char *pMapName)
 		m_CurrentMapSize = (int)io_length(File);
 		if(m_pCurrentMapData)
 			mem_free(m_pCurrentMapData);
-		m_pCurrentMapData = (unsigned char *)mem_alloc(m_CurrentMapSize, 1);
+		m_pCurrentMapData = (unsigned char *)mem_alloc(m_CurrentMapSize);
 		io_read(File, m_pCurrentMapData, m_CurrentMapSize);
 		io_close(File);
 	}

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -934,7 +934,7 @@ void CConsole::Register(const char *pName, const char *pParams,
 	bool DoAdd = false;
 	if(pCommand == 0)
 	{
-		pCommand = new(mem_alloc(sizeof(CCommand), sizeof(void*))) CCommand(Flags&CFGFLAG_BASICACCESS);
+		pCommand = new(mem_alloc(sizeof(CCommand))) CCommand(Flags&CFGFLAG_BASICACCESS);;
 		DoAdd = true;
 	}
 	pCommand->m_pfnCallback = pfnFunc;
@@ -1110,7 +1110,7 @@ void CConsole::Chain(const char *pName, FChainCommandCallback pfnChainFunc, void
 		return;
 	}
 
-	CChain *pChainInfo = (CChain *)mem_alloc(sizeof(CChain), sizeof(void*));
+	CChain *pChainInfo = (CChain *)mem_alloc(sizeof(CChain));
 
 	// store info
 	pChainInfo->m_pfnChainCallback = pfnChainFunc;

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -148,7 +148,7 @@ bool CDataFileReader::Open(class IStorage *pStorage, const char *pFilename, int 
 		return false;
 	}
 
-	CDatafile *pTmpDataFile = (CDatafile*)mem_alloc(AllocSize, 1);
+	CDatafile *pTmpDataFile = (CDatafile*)mem_alloc(AllocSize);
 	pTmpDataFile->m_Header = Header;
 	pTmpDataFile->m_DataStartOffset = sizeof(CDatafileHeader) + Size;
 	pTmpDataFile->m_ppDataPtrs = (char **)(pTmpDataFile+1);
@@ -295,12 +295,12 @@ void *CDataFileReader::GetDataImpl(int Index, int Swap)
 		if(m_pDataFile->m_Header.m_Version == 4)
 		{
 			// v4 has compressed data
-			void *pTemp = (char *)mem_alloc(DataSize, 1);
+			void *pTemp = (char *)mem_alloc(DataSize);
 			unsigned long UncompressedSize = m_pDataFile->m_Info.m_pDataSizes[Index];
 			unsigned long s;
 
 			dbg_msg("datafile", "loading data index=%d size=%d uncompressed=%lu", Index, DataSize, UncompressedSize);
-			m_pDataFile->m_ppDataPtrs[Index] = (char *)mem_alloc(UncompressedSize, 1);
+			m_pDataFile->m_ppDataPtrs[Index] = (char *)mem_alloc(UncompressedSize);
 			m_pDataFile->m_pDataSizes[Index] = UncompressedSize;
 
 			// read the compressed data
@@ -321,7 +321,7 @@ void *CDataFileReader::GetDataImpl(int Index, int Swap)
 		{
 			// load the data
 			dbg_msg("datafile", "loading data index=%d size=%d", Index, DataSize);
-			m_pDataFile->m_ppDataPtrs[Index] = (char *)mem_alloc(DataSize, 1);
+			m_pDataFile->m_ppDataPtrs[Index] = (char *)mem_alloc(DataSize);
 			m_pDataFile->m_pDataSizes[Index] = DataSize;
 			io_seek(m_pDataFile->m_File, m_pDataFile->m_DataStartOffset+m_pDataFile->m_Info.m_pDataOffsets[Index], IOSEEK_START);
 			io_read(m_pDataFile->m_File, m_pDataFile->m_ppDataPtrs[Index], DataSize);
@@ -504,9 +504,9 @@ bool CDataFileReader::CheckSha256(IOHANDLE Handle, const void *pSha256)
 CDataFileWriter::CDataFileWriter()
 {
 	m_File = 0;
-	m_pItemTypes = static_cast<CItemTypeInfo *>(mem_alloc(sizeof(CItemTypeInfo) * MAX_ITEM_TYPES, 1));
-	m_pItems = static_cast<CItemInfo *>(mem_alloc(sizeof(CItemInfo) * MAX_ITEMS, 1));
-	m_pDatas = static_cast<CDataInfo *>(mem_alloc(sizeof(CDataInfo) * MAX_DATAS, 1));
+	m_pItemTypes = static_cast<CItemTypeInfo *>(mem_alloc(sizeof(CItemTypeInfo) * MAX_ITEM_TYPES));
+	m_pItems = static_cast<CItemInfo *>(mem_alloc(sizeof(CItemInfo) * MAX_ITEMS));
+	m_pDatas = static_cast<CDataInfo *>(mem_alloc(sizeof(CDataInfo) * MAX_DATAS));
 }
 
 CDataFileWriter::~CDataFileWriter()
@@ -553,7 +553,7 @@ int CDataFileWriter::AddItem(int Type, int ID, int Size, const void *pData)
 	m_pItems[m_NumItems].m_Size = Size;
 
 	// copy data
-	m_pItems[m_NumItems].m_pData = mem_alloc(Size, 1);
+	m_pItems[m_NumItems].m_pData = mem_alloc(Size);
 	mem_copy(m_pItems[m_NumItems].m_pData, pData, Size);
 
 	if(!m_pItemTypes[Type].m_Num) // count item types
@@ -584,7 +584,7 @@ int CDataFileWriter::AddData(int Size, const void *pData)
 
 	CDataInfo *pInfo = &m_pDatas[m_NumDatas];
 	unsigned long s = compressBound(Size);
-	void *pCompData = mem_alloc(s, 1); // temporary buffer that we use during compression
+	void *pCompData = mem_alloc(s); // temporary buffer that we use during compression
 
 	int Result = compress((Bytef*)pCompData, &s, (Bytef*)pData, Size); // ignore_convention
 	if(Result != Z_OK)
@@ -595,7 +595,7 @@ int CDataFileWriter::AddData(int Size, const void *pData)
 
 	pInfo->m_UncompressedSize = Size;
 	pInfo->m_CompressedSize = (int)s;
-	pInfo->m_pCompressedData = mem_alloc(pInfo->m_CompressedSize, 1);
+	pInfo->m_pCompressedData = mem_alloc(pInfo->m_CompressedSize);
 	mem_copy(pInfo->m_pCompressedData, pCompData, pInfo->m_CompressedSize);
 	mem_free(pCompData);
 
@@ -608,7 +608,7 @@ int CDataFileWriter::AddDataSwapped(int Size, const void *pData)
 	dbg_assert(Size%sizeof(int) == 0, "incorrect boundary");
 
 #if defined(CONF_ARCH_ENDIAN_BIG)
-	void *pSwapped = mem_alloc(Size, 1); // temporary buffer that we use during compression
+	void *pSwapped = mem_alloc(Size); // temporary buffer that we use during compression
 	mem_copy(pSwapped, pData, Size);
 	swap_endian(pSwapped, sizeof(int), Size/sizeof(int));
 	int Index = AddData(Size, pSwapped);

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -461,7 +461,7 @@ void CDemoPlayer::ScanFile()
 
 	// copy all the frames to an array instead for fast access
 	int i;
-	m_pKeyFrames = (CKeyFrame*)mem_alloc(m_Info.m_SeekablePoints*sizeof(CKeyFrame), 1);
+	m_pKeyFrames = (CKeyFrame*)mem_alloc(m_Info.m_SeekablePoints*sizeof(CKeyFrame));
 	for(pCurrentKey = pFirstKey, i = 0; pCurrentKey; pCurrentKey = pCurrentKey->m_pNext, i++)
 		m_pKeyFrames[i] = pCurrentKey->m_Frame;
 
@@ -692,7 +692,7 @@ const char *CDemoPlayer::Load(const char *pFilename, int StorageType, const char
 	else if(MapSize > 0)
 	{
 		// get map data
-		unsigned char *pMapData = (unsigned char *)mem_alloc(MapSize, 1);
+		unsigned char *pMapData = (unsigned char *)mem_alloc(MapSize);
 		io_read(m_File, pMapData, MapSize);
 
 		// save map

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -63,7 +63,7 @@ public:
 							dbg_msg("engine", "map layer too big (%d * %d * %u causes an integer overflow)", pTilemap->m_Width, pTilemap->m_Height, unsigned(sizeof(CTile)));
 							return false;
 						}
-						CTile *pTiles = static_cast<CTile *>(mem_alloc(TilemapSize, 1));
+						CTile *pTiles = static_cast<CTile *>(mem_alloc(TilemapSize));
 						if(!pTiles)
 							return false;
 

--- a/src/engine/shared/memheap.cpp
+++ b/src/engine/shared/memheap.cpp
@@ -8,7 +8,7 @@
 void CHeap::NewChunk()
 {
 	// allocate memory
-	char *pMem = (char*)mem_alloc(sizeof(CChunk)+CHUNK_SIZE, 1);
+	char *pMem = (char*)mem_alloc(sizeof(CChunk)+CHUNK_SIZE);
 	if(!pMem)
 		return;
 

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -464,7 +464,7 @@ void CSnapshotStorage::Add(int Tick, int64 Tagtime, int DataSize, void *pData, i
 	if(CreateAlt)
 		TotalSize += DataSize;
 
-	CHolder *pHolder = (CHolder *)mem_alloc(TotalSize, 1);
+	CHolder *pHolder = (CHolder *)mem_alloc(TotalSize);
 
 	// set data
 	pHolder->m_Tick = Tick;

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -25,7 +25,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 		return;
 	}
 	int FileSize = (int)io_length(File);
-	char *pFileData = (char *)mem_alloc(FileSize, 1);
+	char *pFileData = (char *)mem_alloc(FileSize);
 	io_read(File, pFileData, FileSize);
 	io_close(File);
 

--- a/src/game/client/components/flow.cpp
+++ b/src/game/client/components/flow.cpp
@@ -53,7 +53,7 @@ void CFlow::Init()
 	m_Height = pTilemap->m_Height*32/m_Spacing;
 
 	// allocate and clear
-	m_pCells = (CCell *)mem_alloc(sizeof(CCell)*m_Width*m_Height, 1);
+	m_pCells = (CCell *)mem_alloc(sizeof(CCell)*m_Width*m_Height);
 	for(int y = 0; y < m_Height; y++)
 		for(int x = 0; x < m_Width; x++)
 			m_pCells[y*m_Width+x].m_Vel = vec2(0.0f, 0.0f);

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -480,15 +480,16 @@ static void PlaceEggDoodads(int LayerWidth, int LayerHeight, CTile* aOutTiles, C
 
 void CMapLayers::PlaceEasterEggs(const CLayers *pLayers)
 {
-	CMapItemLayerTilemap* pGameLayer = pLayers->GameLayer();
+	CMapItemLayerTilemap *pGameLayer = pLayers->GameLayer();
 	if(m_pEggTiles)
 		mem_free(m_pEggTiles);
 
 	m_EggLayerWidth = pGameLayer->m_Width;
 	m_EggLayerHeight = pGameLayer->m_Height;
-	m_pEggTiles = (CTile*)mem_alloc(sizeof(CTile) * m_EggLayerWidth * m_EggLayerHeight,1);
-	mem_zero(m_pEggTiles, sizeof(CTile) * m_EggLayerWidth * m_EggLayerHeight);
-	CTile* aGameLayerTiles = (CTile*)pLayers->Map()->GetData(pGameLayer->m_Data);
+	int DataSize = sizeof(CTile) * m_EggLayerWidth * m_EggLayerHeight;
+	m_pEggTiles = (CTile *)mem_alloc(DataSize);
+	mem_zero(m_pEggTiles, DataSize);
+	CTile *pGameLayerTiles = (CTile *)pLayers->Map()->GetData(pGameLayer->m_Data);
 
 	// first pass: baskets
 	static const int s_aBasketIDs[] = {
@@ -497,7 +498,7 @@ void CMapLayers::PlaceEasterEggs(const CLayers *pLayers)
 	};
 
 	static const int s_BasketCount = sizeof(s_aBasketIDs)/sizeof(s_aBasketIDs[0]);
-	PlaceEggDoodads(m_EggLayerWidth, m_EggLayerHeight, m_pEggTiles, aGameLayerTiles, 3, 2, s_aBasketIDs, s_BasketCount, 250);
+	PlaceEggDoodads(m_EggLayerWidth, m_EggLayerHeight, m_pEggTiles, pGameLayerTiles, 3, 2, s_aBasketIDs, s_BasketCount, 250);
 
 	// second pass: double eggs
 	static const int s_aDoubleEggIDs[] = {
@@ -510,7 +511,7 @@ void CMapLayers::PlaceEasterEggs(const CLayers *pLayers)
 	};
 
 	static const int s_DoubleEggCount = sizeof(s_aDoubleEggIDs)/sizeof(s_aDoubleEggIDs[0]);
-	PlaceEggDoodads(m_EggLayerWidth, m_EggLayerHeight, m_pEggTiles, aGameLayerTiles, 2, 1, s_aDoubleEggIDs, s_DoubleEggCount, 100);
+	PlaceEggDoodads(m_EggLayerWidth, m_EggLayerHeight, m_pEggTiles, pGameLayerTiles, 2, 1, s_aDoubleEggIDs, s_DoubleEggCount, 100);
 
 	// third pass: eggs
 	static const int s_aEggIDs[] = {
@@ -524,5 +525,5 @@ void CMapLayers::PlaceEasterEggs(const CLayers *pLayers)
 	};
 
 	static const int s_EggCount = sizeof(s_aEggIDs)/sizeof(s_aEggIDs[0]);
-	PlaceEggDoodads(m_EggLayerWidth, m_EggLayerHeight, m_pEggTiles, aGameLayerTiles, 1, 1, s_aEggIDs, s_EggCount, 30);
+	PlaceEggDoodads(m_EggLayerWidth, m_EggLayerHeight, m_pEggTiles, pGameLayerTiles, 1, 1, s_aEggIDs, s_EggCount, 30);
 }

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -145,7 +145,7 @@ void CMenus::LoadFilters()
 	if(!File)
 		return;
 	int FileSize = (int)io_length(File);
-	char *pFileData = (char *)mem_alloc(FileSize, 1);
+	char *pFileData = (char *)mem_alloc(FileSize);
 	io_read(File, pFileData, FileSize);
 	io_close(File);
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -672,7 +672,7 @@ void LoadLanguageIndexfile(IStorage *pStorage, IConsole *pConsole, sorted_array<
 		return;
 	}
 	int FileSize = (int)io_length(File);
-	char *pFileData = (char *)mem_alloc(FileSize, 1);
+	char *pFileData = (char *)mem_alloc(FileSize);
 	io_read(File, pFileData, FileSize);
 	io_close(File);
 

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -117,7 +117,7 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 	if(!File)
 		return 0;
 	int FileSize = (int)io_length(File);
-	char *pFileData = (char *)mem_alloc(FileSize, 1);
+	char *pFileData = (char *)mem_alloc(FileSize);
 	io_read(File, pFileData, FileSize);
 	io_close(File);
 

--- a/src/game/client/localization.cpp
+++ b/src/game/client/localization.cpp
@@ -61,7 +61,7 @@ bool CLocalizationDatabase::Load(const char *pFilename, IStorage *pStorage, ICon
 	if(!File)
 		return false;
 	int FileSize = (int)io_length(File);
-	char *pFileData = (char *)mem_alloc(FileSize, 1);
+	char *pFileData = (char *)mem_alloc(FileSize);
 	io_read(File, pFileData, FileSize);
 	io_close(File);
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -217,7 +217,7 @@ void CEditorImage::LoadAutoMapper()
 	if(!File)
 		return;
 	int FileSize = (int)io_length(File);
-	char *pFileData = (char *)mem_alloc(FileSize, 1);
+	char *pFileData = (char *)mem_alloc(FileSize);
 	io_read(File, pFileData, FileSize);
 	io_close(File);
 

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -215,7 +215,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 
 	// save points
 	int TotalSize = Size * PointCount;
-	unsigned char *pPoints = (unsigned char *)mem_alloc(TotalSize, 1);
+	unsigned char *pPoints = (unsigned char *)mem_alloc(TotalSize);
 	int Offset = 0;
 	for(int e = 0; e < m_lEnvelopes.size(); e++)
 	{
@@ -326,9 +326,10 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 					int PixelSize = pImg->m_Format == CImageInfo::FORMAT_RGB ? 3 : 4;
 
 					// copy image data
+					int DataSize = pImg->m_Width * pImg->m_Height * PixelSize;
 					void *pData = DataFile.GetData(pItem->m_ImageData);
-					pImg->m_pData = mem_alloc(pImg->m_Width*pImg->m_Height*PixelSize, 1);
-					mem_copy(pImg->m_pData, pData, pImg->m_Width*pImg->m_Height*PixelSize);
+					pImg->m_pData = mem_alloc(DataSize);
+					mem_copy(pImg->m_pData, pData, DataSize);
 					pImg->m_Texture = m_pEditor->Graphics()->LoadTextureRaw(pImg->m_Width, pImg->m_Height, pImg->m_Format, pImg->m_pData, CImageInfo::FORMAT_AUTO, IGraphics::TEXLOAD_MULTI_DIMENSION);
 				}
 

--- a/src/game/server/alloc.h
+++ b/src/game/server/alloc.h
@@ -11,7 +11,7 @@
 	public: \
 	void *operator new(size_t Size) \
 	{ \
-		void *p = mem_alloc(Size, 1); \
+		void *p = mem_alloc(Size); \
 		/*dbg_msg("", "++ %p %d", p, size);*/ \
 		mem_zero(p, Size); \
 		return p; \

--- a/src/test/datafile.cpp
+++ b/src/test/datafile.cpp
@@ -32,9 +32,9 @@ TEST(Datafile, RoundtripItemDataAndSize)
 	EXPECT_TRUE(mem_comp(Reader.GetData(Index), TEST_DATA, 4) == 0);
 
 	static const char REPL_DATA[] = "Replacement";
-	char *pReplace4 = (char *)mem_alloc(4, 1);
+	char *pReplace4 = (char *)mem_alloc(4);
 	mem_copy(pReplace4, REPL_DATA, 4);
-	char *pReplace = (char *)mem_alloc(sizeof(REPL_DATA), 1);
+	char *pReplace = (char *)mem_alloc(sizeof(REPL_DATA));
 	mem_copy(pReplace, REPL_DATA, sizeof(REPL_DATA));
 	Reader.ReplaceData(Index, pReplace4, 4);
 	Reader.ReplaceData(Index4, pReplace, sizeof(REPL_DATA));

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -79,7 +79,7 @@ void Run(unsigned short Port, NETADDR Dest)
 			}
 
 			// create new packet
-			CPacket *p = (CPacket *)mem_alloc(sizeof(CPacket)+Bytes, 1);
+			CPacket *p = (CPacket *)mem_alloc(sizeof(CPacket)+Bytes);
 
 			if(net_addr_comp(&From, &Dest, true) == 0)
 				p->m_SendTo = Src; // from the server


### PR DESCRIPTION
- Remove obsolete comments of `mem` functions. Closes #2894.
- Remove obsolete `mem_alloc_debug` and other remains of old memory management.
- Remove the unused `alignment` parameter of `mem_alloc`. According to what I have read, any memory returned by `malloc` is always aligned correctly for all variables, so there should never have been any need for this.