### PR TITLE
Server: Implement a 'reason' argument for Console Shutdown

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -157,6 +157,7 @@ public:
 	int m_RconClientID;
 	int m_RconAuthLevel;
 	int m_PrintCBIndex;
+	char m_aShutdownReason[128];
 
 	// map
 	enum

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -470,7 +470,7 @@ public:
 	//
 	bool Open(NETADDR BindAddr, class CConfig *pConfig, class IConsole *pConsole, class IEngine *pEngine, class CNetBan *pNetBan,
 		int MaxClients, int MaxClientsPerIP, NETFUNC_NEWCLIENT pfnNewClient, NETFUNC_DELCLIENT pfnDelClient, void *pUser);
-	void Close();
+	void Close(const char *pReason);
 
 	// the token parameter is only used for connless packets
 	int Recv(CNetChunk *pChunk, TOKEN *pResponseToken = 0);

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -41,10 +41,10 @@ bool CNetServer::Open(NETADDR BindAddr, CConfig *pConfig, IConsole *pConsole, IE
 	return true;
 }
 
-void CNetServer::Close()
+void CNetServer::Close(const char *pReason)
 {
 	for(int i = 0; i < NET_MAX_CLIENTS; i++)
-		Drop(i, "Server shutdown");
+		Drop(i, pReason);
 
 	Shutdown();
 }


### PR DESCRIPTION
In a case of urgent update I found it useful to inform the players about what is going on:
`shutdown An update installed. Please reconnect.`