### PR TITLE
Improve completion in console: render map candidates, enable for change_map, smooth scrolling

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -581,6 +581,7 @@ void CClient::DisconnectWithReason(const char *pReason)
 	m_RconAuthed = 0;
 	m_UseTempRconCommands = 0;
 	m_pConsole->DeregisterTempAll();
+	m_pConsole->DeregisterTempMapAll();
 	m_NetClient.Disconnect(pReason);
 	SetState(IClient::STATE_OFFLINE);
 	m_pMap->Unload();

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -25,6 +25,16 @@
 
 #include "console.h"
 
+static const char *s_apMapCommands[] = { "sv_map ", "change_map " };
+
+bool IsMapCommandPrefix(const char *pStr)
+{
+	for(unsigned i = 0; i < sizeof(s_apMapCommands)/sizeof(const char *); i++)
+		if(str_startswith_nocase(pStr, s_apMapCommands[i]))
+			return true;
+	return false;
+}
+
 enum
 {
 	CONSOLE_CLOSED,
@@ -185,7 +195,7 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 			}
 
 			// maplist completion
-			if(m_Type == CGameConsole::CONSOLETYPE_REMOTE && m_pGameConsole->Client()->RconAuthed() && str_startswith_nocase(GetString(), "sv_map "))
+			if(m_Type == CGameConsole::CONSOLETYPE_REMOTE && m_pGameConsole->Client()->RconAuthed() && IsMapCommandPrefix(GetString()))
 			{
 				m_CompletionMapEnumerationCount = m_pGameConsole->m_pConsole->PossibleMaps(m_aCompletionMapBuffer);
 				if(m_CompletionMapEnumerationCount)
@@ -219,10 +229,13 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 			m_CompletionChosen = -1;
 			str_copy(m_aCompletionBuffer, m_Input.GetString(), sizeof(m_aCompletionBuffer));
 
-			if(str_startswith_nocase(GetString(), "sv_map "))
+			for(unsigned i = 0; i < sizeof(s_apMapCommands)/sizeof(const char *); i++)
 			{
-				m_CompletionMapChosen = -1;
-				str_copy(m_aCompletionMapBuffer, &m_Input.GetString()[7], sizeof(m_aCompletionBuffer));
+				if(str_startswith_nocase(GetString(), s_apMapCommands[i]))
+				{
+					m_CompletionMapChosen = -1;
+					str_copy(m_aCompletionMapBuffer, &m_Input.GetString()[str_length(s_apMapCommands[i])], sizeof(m_aCompletionBuffer));
+				}
 			}
 		}
 

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -328,7 +328,7 @@ void CGameConsole::PossibleCommandsRenderCallback(int Index, const char *pStr, v
 
 	if(pInfo->m_EnumCount == pInfo->m_WantedCompletion)
 	{
-		pInfo->m_pSelf->TextRender()->TextColor(0.05f, 0.05f, 0.05f,1);
+		pInfo->m_pSelf->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 		const float BeginX = pInfo->m_pCursor->AdvancePosition().x - pInfo->m_Offset;
 		pInfo->m_pSelf->TextRender()->TextDeferred(pInfo->m_pCursor, pStr, -1);
 		CTextBoundingBox Box = pInfo->m_pCursor->BoundingBox();

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -607,60 +607,48 @@ void CGameConsole::OnRender()
 	TextRender()->DrawTextOutlined(&s_CompletionOptionsCursor);
 	TextRender()->DrawTextOutlined(&s_InfoCursor);
 
-	TextRender()->TextColor(1,1,1,1);
-
-	//	render log (actual page, wrap lines)
-
+	// render log (actual page, wrap lines)
 	CInstance::CBacklogEntry *pEntry = pConsole->m_Backlog.Last();
 	float OffsetY = 0.0f;
 	float LineOffset = 1.0f;
-	s_Cursor.m_MaxWidth = Screen.w-10;
-	for(int Page = 0; Page <= pConsole->m_BacklogActPage; ++Page, OffsetY = 0.0f)
+	s_Cursor.m_MaxWidth = Screen.w - 10.0f;
+	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+	static int s_LastActivePage = pConsole->m_BacklogActPage;
+	int TotalPages = 1;
+	for(int Page = 0; Page <= s_LastActivePage; ++Page, OffsetY = 0.0f)
 	{
 		while(pEntry)
 		{
 			s_Cursor.Reset();
 			if(pEntry->m_Highlighted)
-				TextRender()->TextColor(1,0.75,0.75,1);
+				TextRender()->TextColor(1.0f, 0.75f, 0.75f, 1.0f);
 			TextRender()->TextDeferred(&s_Cursor, pEntry->m_aText, -1);
-			TextRender()->TextColor(1,1,1,1);
+			TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 
 			// get y offset (calculate it if we haven't yet)
 			if(pEntry->m_YOffset < 0.0f)
-			{
-				pEntry->m_YOffset = s_Cursor.BaseLineY()+LineOffset;
-			}
+				pEntry->m_YOffset = s_Cursor.BaseLineY() + LineOffset;
 			OffsetY += pEntry->m_YOffset;
 
-			//	next page when lines reach the top
-			if(y-OffsetY <= RowHeight)
+			// next page when lines reach the top
+			if(y - OffsetY <= RowHeight)
 				break;
 
-			//	just render output from actual backlog page (render bottom up)
-			if(Page == pConsole->m_BacklogActPage)
+			// just render output from actual backlog page (render bottom up)
+			if(Page == s_LastActivePage)
 			{
-				s_Cursor.MoveTo(0.0f, y-OffsetY);
+				s_Cursor.MoveTo(0.0f, y - OffsetY);
 				TextRender()->DrawTextOutlined(&s_Cursor);
 			}
 			pEntry = pConsole->m_Backlog.Prev(pEntry);
 		}
 
-		//	actual backlog page number is too high, render last available page (current checked one, render top down)
-		if(!pEntry && Page < pConsole->m_BacklogActPage)
-		{
-			pConsole->m_BacklogActPage = Page;
-			pEntry = pConsole->m_Backlog.First();
-			while(OffsetY > 0.0f && pEntry)
-			{
-				s_Cursor.Reset();
-				s_Cursor.MoveTo(0.0f, y-OffsetY);
-				TextRender()->TextOutlined(&s_Cursor, pEntry->m_aText, -1);
-				OffsetY -= pEntry->m_YOffset;
-				pEntry = pConsole->m_Backlog.Next(pEntry);
-			}
+		if(!pEntry)
 			break;
-		}
+		TotalPages++;
 	}
+	pConsole->m_BacklogActPage = clamp(pConsole->m_BacklogActPage, 0, TotalPages - 1);
+	s_LastActivePage = pConsole->m_BacklogActPage;
 
 	s_Cursor.Reset();
 	s_Cursor.m_MaxWidth = -1;

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -185,7 +185,7 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 			}
 
 			// maplist completion
-			if(m_pGameConsole->Client()->RconAuthed() && str_startswith_nocase(GetString(), "sv_map "))
+			if(m_Type == CGameConsole::CONSOLETYPE_REMOTE && m_pGameConsole->Client()->RconAuthed() && str_startswith_nocase(GetString(), "sv_map "))
 			{
 				m_CompletionMapEnumerationCount = m_pGameConsole->m_pConsole->PossibleMaps(m_aCompletionMapBuffer);
 				if(m_CompletionMapEnumerationCount)

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -65,7 +65,7 @@ CGameConsole::CInstance::CInstance(int Type) : m_Input(m_aInputBuf, sizeof(m_aIn
 
 	m_aCompletionBuffer[0] = 0;
 	m_CompletionChosen = -1;
-	m_CompletionRenderOffset = 0.0f;
+	Reset();
 
 	m_IsCommand = false;
 }
@@ -184,27 +184,33 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 			if(m_Type == CGameConsole::CONSOLETYPE_LOCAL || m_pGameConsole->Client()->RconAuthed())
 			{
 				const bool UseTempCommands = m_Type == CGameConsole::CONSOLETYPE_REMOTE && m_pGameConsole->Client()->RconAuthed() && m_pGameConsole->Client()->UseTempRconCommands();
-				m_CompletionEnumerationCount = m_pGameConsole->m_pConsole->PossibleCommands(m_aCompletionBuffer, m_CompletionFlagmask, UseTempCommands);
-				if(m_CompletionEnumerationCount)
+				const int CompletionEnumerationCount = m_pGameConsole->m_pConsole->PossibleCommands(m_aCompletionBuffer, m_CompletionFlagmask, UseTempCommands);
+				if(CompletionEnumerationCount)
 				{
-					m_CompletionChosen = (m_CompletionChosen + Direction + m_CompletionEnumerationCount) % m_CompletionEnumerationCount;
+					m_CompletionChosen = (m_CompletionChosen + Direction + CompletionEnumerationCount) % CompletionEnumerationCount;
 					m_pGameConsole->m_pConsole->PossibleCommands(m_aCompletionBuffer, m_CompletionFlagmask, UseTempCommands, PossibleCommandsCompleteCallback, this);
 				}
-				else
+				else if(m_CompletionChosen != -1)
+				{
 					m_CompletionChosen = -1;
+					Reset();
+				}
 			}
 
 			// maplist completion
 			if(m_Type == CGameConsole::CONSOLETYPE_REMOTE && m_pGameConsole->Client()->RconAuthed() && IsMapCommandPrefix(GetString()))
 			{
-				m_CompletionMapEnumerationCount = m_pGameConsole->m_pConsole->PossibleMaps(m_aCompletionMapBuffer);
-				if(m_CompletionMapEnumerationCount)
+				const int CompletionMapEnumerationCount = m_pGameConsole->m_pConsole->PossibleMaps(m_aCompletionMapBuffer);
+				if(CompletionMapEnumerationCount)
 				{
-					m_CompletionMapChosen = (m_CompletionMapChosen + Direction + m_CompletionMapEnumerationCount) % m_CompletionMapEnumerationCount;
+					m_CompletionMapChosen = (m_CompletionMapChosen + Direction + CompletionMapEnumerationCount) % CompletionMapEnumerationCount;
 					m_pGameConsole->m_pConsole->PossibleMaps(m_aCompletionMapBuffer, PossibleMapsCompleteCallback, this);
 				}
-				else
+				else if(m_CompletionMapChosen != -1)
+				{
 					m_CompletionMapChosen = -1;
+					Reset();
+				}
 			}
 		}
 		else if(Event.m_Key == KEY_PAGEUP)
@@ -237,6 +243,8 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 					str_copy(m_aCompletionMapBuffer, &m_Input.GetString()[str_length(s_apMapCommands[i])], sizeof(m_aCompletionBuffer));
 				}
 			}
+			
+			Reset();
 		}
 
 		// find the current command
@@ -311,7 +319,7 @@ static float ConsoleScaleFunc(float t)
 	return sinf(acosf(1.0f-t));
 }
 
-struct CRenderInfo
+struct CCompletionOptionRenderInfo
 {
 	CGameConsole *m_pSelf;
 	CTextCursor *m_pCursor;
@@ -319,17 +327,19 @@ struct CRenderInfo
 	int m_WantedCompletion;
 	int m_EnumCount;
 	float m_Offset;
+	float *m_pOffsetChange;
 	float m_Width;
+	float m_TotalWidth;
 };
 
 void CGameConsole::PossibleCommandsRenderCallback(int Index, const char *pStr, void *pUser)
 {
-	CRenderInfo *pInfo = static_cast<CRenderInfo *>(pUser);
+	CCompletionOptionRenderInfo *pInfo = static_cast<CCompletionOptionRenderInfo *>(pUser);
 
 	if(pInfo->m_EnumCount == pInfo->m_WantedCompletion)
 	{
-		pInfo->m_pSelf->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 		const float BeginX = pInfo->m_pCursor->AdvancePosition().x - pInfo->m_Offset;
+		pInfo->m_pSelf->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 		pInfo->m_pSelf->TextRender()->TextDeferred(pInfo->m_pCursor, pStr, -1);
 		CTextBoundingBox Box = pInfo->m_pCursor->BoundingBox();
 		CUIRect Rect = {Box.x - 5 + BeginX, Box.y, Box.w + 8 - BeginX, Box.h};
@@ -337,15 +347,14 @@ void CGameConsole::PossibleCommandsRenderCallback(int Index, const char *pStr, v
 		Rect.Draw(vec4(229.0f/255.0f,185.0f/255.0f,4.0f/255.0f,0.85f), pInfo->m_pCursor->m_FontSize/3);
 
 		// scroll when out of sight
-		if(Rect.x < 0.0f)
-			pInfo->m_Offset += pInfo->m_Width/2;
-		else if(Rect.x + Rect.w > pInfo->m_Width)
-			pInfo->m_Offset -= pInfo->m_Width/2;
+		if(Rect.x + *pInfo->m_pOffsetChange < 0.0f)
+			*pInfo->m_pOffsetChange += -Rect.x + pInfo->m_Width/4.0f;
+		else if(Rect.x + Rect.w + *pInfo->m_pOffsetChange > pInfo->m_Width)
+			*pInfo->m_pOffsetChange -= Rect.x + Rect.w - pInfo->m_Width + pInfo->m_Width/4.0f;
 	}
 	else
 	{
 		const char *pMatchStart = str_find_nocase(pStr, pInfo->m_pCurrentCmd);
-
 		if(pMatchStart)
 		{
 			pInfo->m_pSelf->TextRender()->TextColor(0.5f,0.5f,0.5f,1);
@@ -364,6 +373,7 @@ void CGameConsole::PossibleCommandsRenderCallback(int Index, const char *pStr, v
 
 	pInfo->m_EnumCount++;
 	pInfo->m_pSelf->TextRender()->TextAdvance(pInfo->m_pCursor, 7.0f);
+	pInfo->m_TotalWidth = pInfo->m_pCursor->AdvancePosition().x - pInfo->m_Offset;
 }
 
 void CGameConsole::OnRender()
@@ -372,7 +382,8 @@ void CGameConsole::OnRender()
 	float ConsoleMaxHeight = Screen.h*3/5.0f;
 	float ConsoleHeight;
 
-	float Progress = (TimeNow()-(m_StateChangeEnd-m_StateChangeDuration))/float(m_StateChangeDuration);
+	const float Now = TimeNow();
+	float Progress = (Now-(m_StateChangeEnd-m_StateChangeDuration))/float(m_StateChangeDuration);
 
 	if(Progress >= 1.0f)
 	{
@@ -520,47 +531,71 @@ void CGameConsole::OnRender()
 		TextRender()->DrawTextOutlined(&s_MarkerCursor);
 
 		// render possible commands
-		if(m_ConsoleType == CONSOLETYPE_LOCAL || Client()->RconAuthed())
+		static float s_LastRender = Now;
+		if((m_ConsoleType == CONSOLETYPE_LOCAL || Client()->RconAuthed()) && pConsole->m_Input.GetString()[0])
 		{
-			if(pConsole->m_Input.GetString()[0] != 0)
+			CCompletionOptionRenderInfo Info;
+			Info.m_pSelf = this;
+			Info.m_WantedCompletion = pConsole->m_CompletionChosen;
+			Info.m_EnumCount = 0;
+			Info.m_Offset = pConsole->m_CompletionRenderOffset;
+			Info.m_pOffsetChange = &pConsole->m_CompletionRenderOffsetChange;
+			Info.m_Width = Screen.w;
+			Info.m_TotalWidth = 0.0f;
+			Info.m_pCurrentCmd = pConsole->m_aCompletionBuffer;
+			Info.m_pCursor = &s_InfoCursor;
+			m_pConsole->PossibleCommands(Info.m_pCurrentCmd, pConsole->m_CompletionFlagmask, m_ConsoleType != CGameConsole::CONSOLETYPE_LOCAL &&
+				Client()->RconAuthed() && Client()->UseTempRconCommands(), PossibleCommandsRenderCallback, &Info);
+
+			if(Info.m_EnumCount <= 0 && pConsole->m_IsCommand)
 			{
-				CRenderInfo Info;
-				Info.m_pSelf = this;
-				Info.m_WantedCompletion = pConsole->m_CompletionChosen;
-				Info.m_EnumCount = 0;
-				Info.m_Offset = pConsole->m_CompletionRenderOffset;
-				Info.m_Width = Screen.w;
-				Info.m_pCurrentCmd = pConsole->m_aCompletionBuffer;
-				Info.m_pCursor = &s_InfoCursor;
-				m_pConsole->PossibleCommands(Info.m_pCurrentCmd, pConsole->m_CompletionFlagmask, m_ConsoleType != CGameConsole::CONSOLETYPE_LOCAL &&
-					Client()->RconAuthed() && Client()->UseTempRconCommands(), PossibleCommandsRenderCallback, &Info);
-				pConsole->m_CompletionRenderOffset = Info.m_Offset;
+				if(IsMapCommandPrefix(Info.m_pCurrentCmd))
+				{
+					Info.m_WantedCompletion = pConsole->m_CompletionMapChosen;
+					Info.m_EnumCount = 0;
+					Info.m_TotalWidth = 0.0f;
+					Info.m_pCurrentCmd = pConsole->m_aCompletionMapBuffer;
+					m_pConsole->PossibleMaps(Info.m_pCurrentCmd, PossibleCommandsRenderCallback, &Info);
+				}
 
 				if(Info.m_EnumCount <= 0 && pConsole->m_IsCommand)
 				{
-					if(IsMapCommandPrefix(Info.m_pCurrentCmd))
-					{
-						Info.m_WantedCompletion = pConsole->m_CompletionMapChosen;
-						Info.m_EnumCount = 0;
-						Info.m_Offset = pConsole->m_CompletionRenderOffset;
-						Info.m_Width = Screen.w;
-						Info.m_pCurrentCmd = pConsole->m_aCompletionMapBuffer;
-						m_pConsole->PossibleMaps(Info.m_pCurrentCmd, PossibleCommandsRenderCallback, &Info);
-						pConsole->m_CompletionRenderOffset = Info.m_Offset;
-					}
-
-					if(Info.m_EnumCount <= 0 && pConsole->m_IsCommand)
-					{
-						char aBuf[512];
-						str_format(aBuf, sizeof(aBuf), "Help: %s ", pConsole->m_aCommandHelp);
-						TextRender()->TextDeferred(Info.m_pCursor, aBuf, -1);
-						TextRender()->TextColor(0.75f, 0.75f, 0.75f, 1);
-						str_format(aBuf, sizeof(aBuf), "Syntax: %s %s", pConsole->m_aCommandName, pConsole->m_aCommandParams);
-						TextRender()->TextDeferred(Info.m_pCursor, aBuf, -1);
-					}
+					char aBuf[512];
+					str_format(aBuf, sizeof(aBuf), "Help: %s ", pConsole->m_aCommandHelp);
+					TextRender()->TextDeferred(Info.m_pCursor, aBuf, -1);
+					TextRender()->TextColor(0.75f, 0.75f, 0.75f, 1);
+					str_format(aBuf, sizeof(aBuf), "Syntax: %s %s", pConsole->m_aCommandName, pConsole->m_aCommandParams);
+					TextRender()->TextDeferred(Info.m_pCursor, aBuf, -1);
 				}
 			}
+
+			// instant scrolling if distance too long
+			if(abs(pConsole->m_CompletionRenderOffsetChange) > Info.m_Width)
+			{
+				pConsole->m_CompletionRenderOffset += pConsole->m_CompletionRenderOffsetChange;
+				pConsole->m_CompletionRenderOffsetChange = 0.0f;
+			}
+			// smooth scrolling
+			if(pConsole->m_CompletionRenderOffsetChange)
+			{
+				const float Delta = pConsole->m_CompletionRenderOffsetChange * clamp((Now - s_LastRender)/0.1f, 0.0f, 1.0f);
+				pConsole->m_CompletionRenderOffset += Delta;
+				pConsole->m_CompletionRenderOffsetChange -= Delta;
+			}
+			// clamp to first item
+			if(pConsole->m_CompletionRenderOffset > 0.0f)
+			{
+				pConsole->m_CompletionRenderOffset = 0.0f;
+				pConsole->m_CompletionRenderOffsetChange = 0.0f;
+			}
+			// clamp to last item
+			if(Info.m_TotalWidth > Info.m_Width && pConsole->m_CompletionRenderOffset < Info.m_Width - Info.m_TotalWidth)
+			{
+				pConsole->m_CompletionRenderOffset = Info.m_Width - Info.m_TotalWidth;
+				pConsole->m_CompletionRenderOffsetChange = 0.0f;
+			}
 		}
+		s_LastRender = Now;
 
 		TextRender()->DrawTextOutlined(&s_InfoCursor);
 

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -187,6 +187,8 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 				const int CompletionEnumerationCount = m_pGameConsole->m_pConsole->PossibleCommands(m_aCompletionBuffer, m_CompletionFlagmask, UseTempCommands);
 				if(CompletionEnumerationCount)
 				{
+					if(m_CompletionChosen == -1 && Direction < 0)
+						m_CompletionChosen = 0;
 					m_CompletionChosen = (m_CompletionChosen + Direction + CompletionEnumerationCount) % CompletionEnumerationCount;
 					m_pGameConsole->m_pConsole->PossibleCommands(m_aCompletionBuffer, m_CompletionFlagmask, UseTempCommands, PossibleCommandsCompleteCallback, this);
 				}
@@ -203,6 +205,8 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 				const int CompletionMapEnumerationCount = m_pGameConsole->m_pConsole->PossibleMaps(m_aCompletionMapBuffer);
 				if(CompletionMapEnumerationCount)
 				{
+					if(m_CompletionMapChosen == -1 && Direction < 0)
+						m_CompletionMapChosen = 0;
 					m_CompletionMapChosen = (m_CompletionMapChosen + Direction + CompletionMapEnumerationCount) % CompletionMapEnumerationCount;
 					m_pGameConsole->m_pConsole->PossibleMaps(m_aCompletionMapBuffer, PossibleMapsCompleteCallback, this);
 				}

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -461,20 +461,11 @@ void CGameConsole::OnRender()
 		float x = 3;
 		float y = ConsoleHeight - RowHeight - 5.0f;
 
-		CRenderInfo Info;
-		Info.m_pSelf = this;
-		Info.m_WantedCompletion = pConsole->m_CompletionChosen;
-		Info.m_EnumCount = 0;
-		Info.m_Offset = pConsole->m_CompletionRenderOffset;
-		Info.m_Width = Screen.w;
-		Info.m_pCurrentCmd = pConsole->m_aCompletionBuffer;
-
 		static CTextCursor s_InfoCursor;
 		s_InfoCursor.Reset();
-		s_InfoCursor.MoveTo(x+Info.m_Offset, y+RowHeight+2.0f);
+		s_InfoCursor.MoveTo(x+pConsole->m_CompletionRenderOffset, y+RowHeight+2.0f);
 		s_InfoCursor.m_FontSize = FontSize;
 		s_InfoCursor.m_MaxWidth = -1.0f;
-		Info.m_pCursor = &s_InfoCursor;
 
 		// render prompt
 		static CTextCursor s_Cursor;
@@ -533,23 +524,45 @@ void CGameConsole::OnRender()
 		{
 			if(pConsole->m_Input.GetString()[0] != 0)
 			{
-				m_pConsole->PossibleCommands(pConsole->m_aCompletionBuffer, pConsole->m_CompletionFlagmask, m_ConsoleType != CGameConsole::CONSOLETYPE_LOCAL &&
+				CRenderInfo Info;
+				Info.m_pSelf = this;
+				Info.m_WantedCompletion = pConsole->m_CompletionChosen;
+				Info.m_EnumCount = 0;
+				Info.m_Offset = pConsole->m_CompletionRenderOffset;
+				Info.m_Width = Screen.w;
+				Info.m_pCurrentCmd = pConsole->m_aCompletionBuffer;
+				Info.m_pCursor = &s_InfoCursor;
+				m_pConsole->PossibleCommands(Info.m_pCurrentCmd, pConsole->m_CompletionFlagmask, m_ConsoleType != CGameConsole::CONSOLETYPE_LOCAL &&
 					Client()->RconAuthed() && Client()->UseTempRconCommands(), PossibleCommandsRenderCallback, &Info);
 				pConsole->m_CompletionRenderOffset = Info.m_Offset;
 
 				if(Info.m_EnumCount <= 0 && pConsole->m_IsCommand)
 				{
-					char aBuf[512];
-					str_format(aBuf, sizeof(aBuf), "Help: %s ", pConsole->m_aCommandHelp);
-					TextRender()->TextDeferred(Info.m_pCursor, aBuf, -1);
-					TextRender()->TextColor(0.75f, 0.75f, 0.75f, 1);
-					str_format(aBuf, sizeof(aBuf), "Syntax: %s %s", pConsole->m_aCommandName, pConsole->m_aCommandParams);
-					TextRender()->TextDeferred(Info.m_pCursor, aBuf, -1);
+					if(IsMapCommandPrefix(Info.m_pCurrentCmd))
+					{
+						Info.m_WantedCompletion = pConsole->m_CompletionMapChosen;
+						Info.m_EnumCount = 0;
+						Info.m_Offset = pConsole->m_CompletionRenderOffset;
+						Info.m_Width = Screen.w;
+						Info.m_pCurrentCmd = pConsole->m_aCompletionMapBuffer;
+						m_pConsole->PossibleMaps(Info.m_pCurrentCmd, PossibleCommandsRenderCallback, &Info);
+						pConsole->m_CompletionRenderOffset = Info.m_Offset;
+					}
+
+					if(Info.m_EnumCount <= 0 && pConsole->m_IsCommand)
+					{
+						char aBuf[512];
+						str_format(aBuf, sizeof(aBuf), "Help: %s ", pConsole->m_aCommandHelp);
+						TextRender()->TextDeferred(Info.m_pCursor, aBuf, -1);
+						TextRender()->TextColor(0.75f, 0.75f, 0.75f, 1);
+						str_format(aBuf, sizeof(aBuf), "Syntax: %s %s", pConsole->m_aCommandName, pConsole->m_aCommandParams);
+						TextRender()->TextDeferred(Info.m_pCursor, aBuf, -1);
+					}
 				}
 			}
 		}
 
-		TextRender()->DrawTextOutlined(Info.m_pCursor);
+		TextRender()->DrawTextOutlined(&s_InfoCursor);
 
 		TextRender()->TextColor(1,1,1,1);
 

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -31,13 +31,12 @@ class CGameConsole : public CComponent
 
 		char m_aCompletionMapBuffer[128];
 		int m_CompletionMapChosen;
-		int m_CompletionMapEnumerationCount;
 
 		char m_aCompletionBuffer[128];
 		int m_CompletionChosen;
 		int m_CompletionFlagmask;
-		int m_CompletionEnumerationCount;
 		float m_CompletionRenderOffset;
+		float m_CompletionRenderOffsetChange;
 
 		bool m_IsCommand;
 		char m_aCommandName[IConsole::TEMPCMD_NAME_LENGTH];
@@ -49,7 +48,7 @@ class CGameConsole : public CComponent
 
 		void ClearBacklog();
 		void ClearHistory();
-		void Reset() { m_CompletionRenderOffset = 0; }
+		void Reset() { m_CompletionRenderOffset = 0.0f; m_CompletionRenderOffsetChange = 0.0f; }
 
 		void ExecuteLine(const char *pLine);
 


### PR DESCRIPTION
I'll split this into multiple PRs.

- Enable completion for `change_map` command (was previously only enabled for `sv_map`)
- Render the map completion options exactly like the command completion options. Fixes the first part of #1972.
- Smooth completion option scrolling.
- Show command help and syntax during completion already.
- Change font color of selected completion option from black to white, to improve the readability.
- Only complete map commands in remote console (was previously also completing in local console when authed in remote).
- Deregister all maps on disconnect (fixes memory leak / duplicate map entries in the list after multiple reconnects).
- Fix page up scrolling in console sometimes flashing lines of text. Closes #2810.

Screenshots:

<img width="80%" src="https://user-images.githubusercontent.com/23437060/129474213-a8498c30-0f44-4c47-a783-348b25393c95.png">

<img width="80%" src="https://user-images.githubusercontent.com/23437060/129474212-2d21313d-70a7-4fc5-aa42-5ae1270939ca.png">

<img width="80%" src="https://user-images.githubusercontent.com/23437060/129474210-7521e3db-ee1a-4dbb-a8f1-676e33b25d89.png">


The help text and syntax is also shown during completion already:

<img width="80%" src="https://user-images.githubusercontent.com/23437060/130961611-4b4b1fc8-4431-4315-9bd7-1ad937341b5e.png">


For comparison, the old text color of the selected completion option:

<img width="80%" src="https://user-images.githubusercontent.com/23437060/129474208-5201f620-17da-4999-9221-3a0209019104.png">