### PR TITLE
Fix filesystem/IO with unicode filenames on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2121,6 +2121,10 @@ foreach(target ${TARGETS_OWN})
     target_compile_options(${target} PRIVATE /wd4267) # Possible loss of data (size_t - int on win64).
     target_compile_options(${target} PRIVATE /wd4800) # Implicit conversion of int to bool.
   endif()
+  if(TARGET_OS STREQUAL "windows")
+    target_compile_definitions(${target} PRIVATE UNICODE) # Windows headers
+    target_compile_definitions(${target} PRIVATE _UNICODE) # C-runtime
+  endif()
   if(OUR_FLAGS_OWN)
     target_compile_options(${target} PRIVATE ${OUR_FLAGS_OWN})
   endif()

--- a/bam.lua
+++ b/bam.lua
@@ -240,6 +240,10 @@ function GenerateWindowsSettings(settings, conf, target_arch, compiler)
 		settings.cc.defines:Add("_WIN32_WINNT=0x0501")
 	end
 
+	-- Unicode support
+	settings.cc.defines:Add("UNICODE") -- Windows headers
+	settings.cc.defines:Add("_UNICODE") -- C-runtime
+
 	local icons = SharedIcons(compiler)
 	local manifests = SharedManifests(compiler)
 

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -210,16 +210,15 @@ static void logger_stdout(const char *line)
 	fflush(stdout);
 }
 
-static void logger_debugger(const char *line)
-{
 #if defined(CONF_FAMILY_WINDOWS)
+static void logger_win_debugger(const char *line)
+{
 	WCHAR wBuffer[512];
 	MultiByteToWideChar(CP_UTF8, 0, line, -1, wBuffer, sizeof(wBuffer));
 	OutputDebugStringW(wBuffer);
 	OutputDebugStringW(L"\n");
-#endif
 }
-
+#endif
 
 static IOHANDLE logfile = 0;
 static void logger_file(const char *line)
@@ -241,7 +240,13 @@ void dbg_logger_stdout()
 	dbg_logger(logger_stdout);
 }
 
-void dbg_logger_debugger() { dbg_logger(logger_debugger); }
+void dbg_logger_debugger()
+{
+#if defined(CONF_FAMILY_WINDOWS)
+	dbg_logger(logger_win_debugger);
+#endif
+}
+
 void dbg_logger_file(const char *filename)
 {
 	IOHANDLE handle = io_open(filename, IOFLAG_WRITE);

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1802,9 +1802,19 @@ int fs_remove(const char *filename)
 
 int fs_rename(const char *oldname, const char *newname)
 {
-	if(rename(oldname, newname) != 0)
+#if defined(CONF_FAMILY_WINDOWS)
+	WCHAR wOldname[IO_MAX_PATH_LENGTH];
+	WCHAR wNewname[IO_MAX_PATH_LENGTH];
+	MultiByteToWideChar(CP_UTF8, 0, oldname, IO_MAX_PATH_LENGTH, wOldname, IO_MAX_PATH_LENGTH);
+	MultiByteToWideChar(CP_UTF8, 0, newname, IO_MAX_PATH_LENGTH, wNewname, IO_MAX_PATH_LENGTH);
+	if(MoveFileExW(wOldname, wNewname, MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED) == 0)
 		return 1;
 	return 0;
+#else
+	if(rename(oldname, newname))
+		return 1;
+	return 0;
+#endif
 }
 
 int fs_read(const char *name, void **result, unsigned *result_len)

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1626,10 +1626,12 @@ void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int t
 int fs_storage_path(const char *appname, char *path, int max)
 {
 #if defined(CONF_FAMILY_WINDOWS)
-	char *home = getenv("APPDATA");
+	WCHAR *home = _wgetenv(L"APPDATA");
+	char buffer[IO_MAX_PATH_LENGTH];
 	if(!home)
 		return -1;
-	str_format(path, max, "%s/%s", home, appname);
+	WideCharToMultiByte(CP_UTF8, 0, home, -1, buffer, IO_MAX_PATH_LENGTH, NULL, NULL);
+	str_format(path, max, "%s/%s", buffer, appname);
 	return 0;
 #else
 	char *home = getenv("HOME");

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1483,15 +1483,18 @@ static inline time_t filetime_to_unixtime(LPFILETIME filetime)
 void fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user)
 {
 #if defined(CONF_FAMILY_WINDOWS)
-	WIN32_FIND_DATA finddata;
+	WIN32_FIND_DATAW finddata;
 	HANDLE handle;
-	char buffer[1024*2];
+	char buffer[IO_MAX_PATH_LENGTH];
+	char buffer2[IO_MAX_PATH_LENGTH];
+	WCHAR wBuffer[IO_MAX_PATH_LENGTH];
 	int length;
+
 	str_format(buffer, sizeof(buffer), "%s/*", dir);
+	MultiByteToWideChar(CP_UTF8, 0, buffer, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
 
-	handle = FindFirstFileA(buffer, &finddata);
-
-	if (handle == INVALID_HANDLE_VALUE)
+	handle = FindFirstFileW(wBuffer, &finddata);
+	if(handle == INVALID_HANDLE_VALUE)
 		return;
 
 	str_format(buffer, sizeof(buffer), "%s/", dir);
@@ -1500,17 +1503,17 @@ void fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user)
 	/* add all the entries */
 	do
 	{
-		str_copy(buffer+length, finddata.cFileName, (int)sizeof(buffer)-length);
-		if(cb(finddata.cFileName, fs_is_dir(buffer), type, user))
+		WideCharToMultiByte(CP_UTF8, 0, finddata.cFileName, -1, buffer2, IO_MAX_PATH_LENGTH, NULL, NULL);
+		str_copy(buffer+length, buffer2, (int)sizeof(buffer)-length);
+		if(cb(buffer2, fs_is_dir(buffer), type, user))
 			break;
 	}
-	while (FindNextFileA(handle, &finddata));
+	while(FindNextFileW(handle, &finddata));
 
 	FindClose(handle);
-	return;
 #else
 	struct dirent *entry;
-	char buffer[1024*2];
+	char buffer[IO_MAX_PATH_LENGTH];
 	int length;
 	DIR *d = opendir(dir);
 
@@ -1529,22 +1532,24 @@ void fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user)
 
 	/* close the directory and return */
 	closedir(d);
-	return;
 #endif
 }
 
-void fs_listdir_fileinfo(const char* dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int type, void* user)
+void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int type, void *user)
 {
 #if defined(CONF_FAMILY_WINDOWS)
-	WIN32_FIND_DATA finddata;
+	WIN32_FIND_DATAW finddata;
 	HANDLE handle;
-	char buffer[1024*2];
+	char buffer[IO_MAX_PATH_LENGTH];
+	char buffer2[IO_MAX_PATH_LENGTH];
+	WCHAR wBuffer[IO_MAX_PATH_LENGTH];
 	int length;
+
 	str_format(buffer, sizeof(buffer), "%s/*", dir);
+	MultiByteToWideChar(CP_UTF8, 0, buffer, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
 
-	handle = FindFirstFileA(buffer, &finddata);
-
-	if (handle == INVALID_HANDLE_VALUE)
+	handle = FindFirstFileW(wBuffer, &finddata);
+	if(handle == INVALID_HANDLE_VALUE)
 		return;
 
 	str_format(buffer, sizeof(buffer), "%s/", dir);
@@ -1553,24 +1558,24 @@ void fs_listdir_fileinfo(const char* dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int t
 	/* add all the entries */
 	do
 	{
-		str_copy(buffer+length, finddata.cFileName, (int)sizeof(buffer)-length);
+		WideCharToMultiByte(CP_UTF8, 0, finddata.cFileName, -1, buffer2, IO_MAX_PATH_LENGTH, NULL, NULL);
+		str_copy(buffer+length, buffer2, (int)sizeof(buffer)-length);
 
 		CFsFileInfo info;
-		info.m_pName = finddata.cFileName;
+		info.m_pName = buffer2;
 		info.m_TimeCreated = filetime_to_unixtime(&finddata.ftCreationTime);
 		info.m_TimeModified = filetime_to_unixtime(&finddata.ftLastWriteTime);
 
 		if(cb(&info, fs_is_dir(buffer), type, user))
 			break;
 	}
-	while (FindNextFileA(handle, &finddata));
+	while(FindNextFileW(handle, &finddata));
 
 	FindClose(handle);
-	return;
 #else
 	struct dirent *entry;
 	time_t created = -1, modified = -1;
-	char buffer[1024*2];
+	char buffer[IO_MAX_PATH_LENGTH];
 	int length;
 	DIR *d = opendir(dir);
 
@@ -1597,7 +1602,6 @@ void fs_listdir_fileinfo(const char* dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int t
 
 	/* close the directory and return */
 	closedir(d);
-	return;
 #endif
 }
 

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1724,25 +1724,22 @@ int fs_is_dir(const char *path)
 {
 #if defined(CONF_FAMILY_WINDOWS)
 	/* TODO: do this smarter */
-	WIN32_FIND_DATA finddata;
+	WIN32_FIND_DATAW finddata;
 	HANDLE handle;
-	char buffer[1024*2];
+	char buffer[IO_MAX_PATH_LENGTH];
+	WCHAR wBuffer[IO_MAX_PATH_LENGTH];
 	str_format(buffer, sizeof(buffer), "%s/*", path);
+	MultiByteToWideChar(CP_UTF8, 0, buffer, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
 
-	if ((handle = FindFirstFileA(buffer, &finddata)) == INVALID_HANDLE_VALUE)
+	if((handle = FindFirstFileW(wBuffer, &finddata)) == INVALID_HANDLE_VALUE)
 		return 0;
-
 	FindClose(handle);
 	return 1;
 #else
 	struct stat sb;
-	if (stat(path, &sb) == -1)
+	if(stat(path, &sb) == -1)
 		return 0;
-
-	if (S_ISDIR(sb.st_mode))
-		return 1;
-	else
-		return 0;
+	return S_ISDIR(sb.st_mode) ? 1 : 0;
 #endif
 }
 

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1750,15 +1750,6 @@ int fs_is_dir(const char *path)
 #endif
 }
 
-time_t fs_getmtime(const char *path)
-{
-	struct stat sb;
-	if(stat(path, &sb) == -1)
-		return 0;
-
-	return sb.st_mtime;
-}
-
 int fs_chdir(const char *path)
 {
 	if(fs_is_dir(path))

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1774,7 +1774,11 @@ char *fs_getcwd(char *buffer, int buffer_size)
 	if(buffer == 0)
 		return 0;
 #if defined(CONF_FAMILY_WINDOWS)
-	return _getcwd(buffer, buffer_size);
+	WCHAR wBuffer[IO_MAX_PATH_LENGTH];
+	if(_wgetcwd(wBuffer, buffer_size) == 0)
+		return 0;
+	WideCharToMultiByte(CP_UTF8, 0, wBuffer, IO_MAX_PATH_LENGTH, buffer, buffer_size, NULL, NULL);
+	return buffer;
 #else
 	return getcwd(buffer, buffer_size);
 #endif

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1738,18 +1738,10 @@ int fs_makedir_recursive(const char *path)
 int fs_is_dir(const char *path)
 {
 #if defined(CONF_FAMILY_WINDOWS)
-	/* TODO: do this smarter */
-	WIN32_FIND_DATAW finddata;
-	HANDLE handle;
-	char buffer[IO_MAX_PATH_LENGTH];
-	WCHAR wBuffer[IO_MAX_PATH_LENGTH];
-	str_format(buffer, sizeof(buffer), "%s/*", path);
-	MultiByteToWideChar(CP_UTF8, 0, buffer, -1, wBuffer, sizeof(wBuffer) / sizeof(WCHAR));
-
-	if((handle = FindFirstFileW(wBuffer, &finddata)) == INVALID_HANDLE_VALUE)
-		return 0;
-	FindClose(handle);
-	return 1;
+	WCHAR wPath[IO_MAX_PATH_LENGTH];
+	MultiByteToWideChar(CP_UTF8, 0, path, -1, wPath, sizeof(wPath) / sizeof(WCHAR));
+	DWORD attributes = GetFileAttributesW(wPath);
+	return attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY) ? 1 : 0;
 #else
 	struct stat sb;
 	if(stat(path, &sb) == -1)

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -302,9 +302,10 @@ void mem_zero(void *block,unsigned size)
 
 IOHANDLE io_open(const char *filename, int flags)
 {
+	dbg_assert(flags == IOFLAG_READ || flags == IOFLAG_WRITE || flags == IOFLAG_APPEND, "flags must be read, write or append");
 	if(flags == IOFLAG_READ)
 	{
-	#if defined(CONF_FAMILY_WINDOWS)
+#if defined(CONF_FAMILY_WINDOWS)
 		// check for filename case sensitive
 		WIN32_FIND_DATA finddata;
 		HANDLE handle;
@@ -322,11 +323,13 @@ IOHANDLE io_open(const char *filename, int flags)
 			return 0x0;
 		}
 		FindClose(handle);
-	#endif
+#endif
 		return (IOHANDLE)fopen(filename, "rb");
 	}
 	if(flags == IOFLAG_WRITE)
 		return (IOHANDLE)fopen(filename, "wb");
+	if(flags == IOFLAG_APPEND)
+		return (IOHANDLE)fopen(filename, "ab");
 	return 0x0;
 }
 

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1760,10 +1760,19 @@ int fs_chdir(const char *path)
 {
 	if(fs_is_dir(path))
 	{
+#if defined(CONF_FAMILY_WINDOWS)
+		WCHAR wBuffer[IO_MAX_PATH_LENGTH];
+		MultiByteToWideChar(CP_UTF8, 0, path, -1, wBuffer, IO_MAX_PATH_LENGTH);
+		if(_wchdir(wBuffer))
+			return 1;
+		else
+			return 0;
+#else
 		if(chdir(path))
 			return 1;
 		else
 			return 0;
+#endif
 	}
 	else
 		return 1;

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1795,9 +1795,17 @@ int fs_parent_dir(char *path)
 
 int fs_remove(const char *filename)
 {
-	if(remove(filename) != 0)
+#if defined(CONF_FAMILY_WINDOWS)
+	WCHAR wFilename[IO_MAX_PATH_LENGTH];
+	MultiByteToWideChar(CP_UTF8, 0, filename, IO_MAX_PATH_LENGTH, wFilename, IO_MAX_PATH_LENGTH);
+	if(DeleteFileW(wFilename) == 0)
 		return 1;
 	return 0;
+#else
+	if(remove(filename))
+		return 1;
+	return 0;
+#endif
 }
 
 int fs_rename(const char *oldname, const char *newname)

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1683,8 +1683,10 @@ int fs_storage_path(const char *appname, char *path, int max)
 int fs_makedir(const char *path)
 {
 #if defined(CONF_FAMILY_WINDOWS)
-	if(_mkdir(path) == 0)
-			return 0;
+	WCHAR wBuffer[IO_MAX_PATH_LENGTH];
+	MultiByteToWideChar(CP_UTF8, 0, path, -1, wBuffer, IO_MAX_PATH_LENGTH);
+	if(_wmkdir(wBuffer) == 0)
+		return 0;
 	if(errno == EEXIST)
 		return 0;
 	return -1;

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1837,8 +1837,12 @@ char *fs_read_str(const char *name)
 int fs_file_time(const char *name, time_t *created, time_t *modified)
 {
 #if defined(CONF_FAMILY_WINDOWS)
-	WIN32_FIND_DATA finddata;
-	HANDLE handle = FindFirstFile(name, &finddata);
+	WIN32_FIND_DATAW finddata;
+	HANDLE handle;
+	WCHAR wBuffer[IO_MAX_PATH_LENGTH];
+
+	MultiByteToWideChar(CP_UTF8, 0, name, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
+	handle = FindFirstFileW(wBuffer, &finddata);
 	if(handle == INVALID_HANDLE_VALUE)
 		return 1;
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1336,12 +1336,10 @@ void fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user);
 
 typedef struct
 {
-	const char* m_pName;
+	const char *m_pName;
 	time_t m_TimeCreated; // seconds since UNIX Epoch
 	time_t m_TimeModified; // seconds since UNIX Epoch
 } CFsFileInfo;
-
-/* Group: Filesystem */
 
 /*
 	Function: fs_listdir_fileinfo
@@ -1353,7 +1351,7 @@ typedef struct
 		type - Type of the directory
 		user - Pointer to give to the callback
 */
-typedef int (*FS_LISTDIR_CALLBACK_FILEINFO)(const CFsFileInfo* info, int is_dir, int dir_type, void *user);
+typedef int (*FS_LISTDIR_CALLBACK_FILEINFO)(const CFsFileInfo *info, int is_dir, int dir_type, void *user);
 void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int type, void *user);
 
 /*

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1407,12 +1407,6 @@ int fs_storage_path(const char *appname, char *path, int max);
 int fs_is_dir(const char *path);
 
 /*
-	Function: fs_getmtime
-		Gets the modification time of a file
-*/
-time_t fs_getmtime(const char *path);
-
-/*
 	Function: fs_chdir
 		Changes current working directory
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -179,7 +179,7 @@ int mem_has_null(const void *block, unsigned size);
 enum {
 	IOFLAG_READ = 1,
 	IOFLAG_WRITE = 2,
-	IOFLAG_RANDOM = 4,
+	IOFLAG_APPEND = 4,
 
 	IOSEEK_START = 0,
 	IOSEEK_CUR = 1,
@@ -196,7 +196,7 @@ typedef struct IOINTERNAL *IOHANDLE;
 
 	Parameters:
 		filename - File to open.
-		flags - A set of flags. IOFLAG_READ, IOFLAG_WRITE, IOFLAG_RANDOM.
+		flags - A set of flags. IOFLAG_READ, IOFLAG_WRITE, IOFLAG_APPEND.
 
 	Returns:
 		Returns a handle to the file on success and 0 on failure.

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1785,6 +1785,32 @@ void secure_random_fill(void *bytes, unsigned length);
 int pid();
 
 /*
+	Function: cmdline_fix
+		Fixes the command line arguments to be encoded in UTF-8 on all
+		systems.
+
+	Parameters:
+		argc - A pointer to the argc parameter that was passed to the main function.
+		argv - A pointer to the argv parameter that was passed to the main function.
+
+	Remarks:
+		- You need to call cmdline_free once you're no longer using the
+		results.
+*/
+void cmdline_fix(int *argc, const char ***argv);
+
+/*
+	Function: cmdline_free
+		Frees memory that was allocated by cmdline_fix.
+
+	Parameters:
+		argc - The argc obtained from cmdline_fix.
+		argv - The argv obtained from cmdline_fix.
+
+*/
+void cmdline_free(int argc, const char **argv);
+
+/*
 	Function: bytes_be_to_uint
 		Packs 4 big endian bytes into an unsigned
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2559,6 +2559,7 @@ extern "C" int TWMain(int argc, const char **argv) // ignore_convention
 int main(int argc, const char **argv) // ignore_convention
 #endif
 {
+	cmdline_fix(&argc, &argv);
 #if defined(CONF_FAMILY_WINDOWS)
 	bool QuickEditMode = false;
 	for(int i = 1; i < argc; i++) // ignore_convention
@@ -2723,5 +2724,6 @@ int main(int argc, const char **argv) // ignore_convention
 	delete pEngineMap;
 	delete pEngineMasterServer;
 
+	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1819,6 +1819,7 @@ void HandleSigInt(int Param)
 
 int main(int argc, const char **argv) // ignore_convention
 {
+	cmdline_fix(&argc, &argv);
 #if defined(CONF_FAMILY_WINDOWS)
 	for(int i = 1; i < argc; i++) // ignore_convention
 	{
@@ -1923,5 +1924,6 @@ int main(int argc, const char **argv) // ignore_convention
 	delete pStorage;
 	delete pConfigManager;
 
+	cmdline_free(argc, argv);
 	return Ret;
 }

--- a/src/mastersrv/mastersrv.cpp
+++ b/src/mastersrv/mastersrv.cpp
@@ -280,14 +280,11 @@ void ReloadBans()
 	m_pConsole->ExecuteFile("master.cfg");
 }
 
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, const char **argv)
 {
-	int64 LastBuild = 0, LastBanReload = 0;
-	ServerType Type = SERVERTYPE_INVALID;
-	NETADDR BindAddr;
-
 	dbg_logger_stdout();
-	
+	cmdline_fix(&argc, &argv);
+
 	mem_copy(m_CountData.m_Header, SERVERBROWSE_COUNT, sizeof(SERVERBROWSE_COUNT));
 
 	int FlagMask = CFGFLAG_MASTER;
@@ -307,9 +304,10 @@ int main(int argc, const char **argv) // ignore_convention
 	pConfigManager->Init(FlagMask);
 	m_pConsole->Init();
 	m_NetBan.Init(m_pConsole, pStorage);
-	if(argc > 1) // ignore_convention
-		m_pConsole->ParseArguments(argc-1, &argv[1]); // ignore_convention
+	if(argc > 1)
+		m_pConsole->ParseArguments(argc-1, &argv[1]);
 
+	NETADDR BindAddr;
 	if(pConfig->m_Bindaddr[0] && net_host_lookup(pConfig->m_Bindaddr, &BindAddr, NETTYPE_ALL) == 0)
 	{
 		// got bindaddr
@@ -345,6 +343,8 @@ int main(int argc, const char **argv) // ignore_convention
 
 	dbg_msg("mastersrv", "started");
 
+	int64 LastBuild = 0, LastBanReload = 0;
+	ServerType Type = SERVERTYPE_INVALID;
 	while(1)
 	{
 		m_NetOp.Update();
@@ -460,5 +460,6 @@ int main(int argc, const char **argv) // ignore_convention
 		thread_sleep(1);
 	}
 
+	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -17,9 +17,12 @@ void CTestInfo::Filename(char *pBuffer, int BufferLength, const char *pSuffix)
 	str_format(pBuffer, BufferLength, "%s%s", m_aFilenamePrefix, pSuffix);
 }
 
-int main(int argc, char **argv)
+int main(int argc, const char **argv)
 {
-	::testing::InitGoogleTest(&argc, argv);
+	cmdline_fix(&argc, &argv);
+	::testing::InitGoogleTest(&argc, const_cast<char **>(argv));
 	net_init();
-	return RUN_ALL_TESTS();
+	int Result = RUN_ALL_TESTS();
+	cmdline_free(argc, argv);
+	return Result;
 }

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -206,7 +206,7 @@ void Run(unsigned short Port, NETADDR Dest)
 	}
 }
 
-int main(int argc, char **argv) // ignore_convention
+int main(int argc, const char **argv)
 {
 	NETADDR Addr = {NETTYPE_IPV4, {127,0,0,1},8303};
 	dbg_logger_stdout();

--- a/src/tools/fake_server.cpp
+++ b/src/tools/fake_server.cpp
@@ -148,8 +148,10 @@ static int Run()
 	}
 }
 
-int main(int argc, char **argv)
+int main(int argc, const char **argv)
 {
+	cmdline_fix(&argc, &argv);
+
 	pNet = new CNetServer;
 
 	while(argc)
@@ -214,6 +216,7 @@ int main(int argc, char **argv)
 	int RunReturn = Run();
 
 	delete pNet;
+	cmdline_free(argc, argv);
 	return RunReturn;
 }
 

--- a/src/tools/map_resave.cpp
+++ b/src/tools/map_resave.cpp
@@ -6,40 +6,40 @@
 
 int main(int argc, const char **argv)
 {
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
-	int Index, ID = 0, Type = 0, Size;
-	void *pPtr;
-	char aFileName[1024];
-	CDataFileReader DataFile;
-	CDataFileWriter df;
+	cmdline_fix(&argc, &argv);
 
+	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
 	if(!pStorage || argc != 3)
 		return -1;
 
-	str_format(aFileName, sizeof(aFileName), "%s", argv[2]);
-
-	if(!DataFile.Open(pStorage, argv[1], IStorage::TYPE_ALL))
+	CDataFileReader Reader;
+	if(!Reader.Open(pStorage, argv[1], IStorage::TYPE_ALL))
 		return -1;
-	if(!df.Open(pStorage, aFileName))
+
+	CDataFileWriter Writer;
+	if(!Writer.Open(pStorage, argv[2]))
 		return -1;
 
 	// add all items
-	for(Index = 0; Index < DataFile.NumItems(); Index++)
+	for(int Index = 0; Index < Reader.NumItems(); Index++)
 	{
-		pPtr = DataFile.GetItem(Index, &Type, &ID);
-		Size = DataFile.GetItemSize(Index);
-		df.AddItem(Type, ID, Size, pPtr);
+		int Type, ID;
+		void *pPtr = Reader.GetItem(Index, &Type, &ID);
+		int Size = Reader.GetItemSize(Index);
+		Writer.AddItem(Type, ID, Size, pPtr);
 	}
 
 	// add all data
-	for(Index = 0; Index < DataFile.NumData(); Index++)
+	for(int Index = 0; Index < Reader.NumData(); Index++)
 	{
-		pPtr = DataFile.GetData(Index);
-		Size = DataFile.GetDataSize(Index);
-		df.AddData(Size, pPtr);
+		void *pPtr = Reader.GetData(Index);
+		int Size = Reader.GetDataSize(Index);
+		Writer.AddData(Size, pPtr);
 	}
 
-	DataFile.Close();
-	df.Finish();
+	Reader.Close();
+	Writer.Finish();
+
+	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/tools/map_version.cpp
+++ b/src/tools/map_version.cpp
@@ -46,8 +46,10 @@ io_write(s_File, aBuf, str_length(aBuf));
 	return 0;
 }
 
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, const char **argv)
 {
+	cmdline_fix(&argc, &argv);
+
 	IKernel *pKernel = IKernel::Create();
 	s_pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
 	s_pEngineMap = CreateEngineMap();
@@ -67,5 +69,6 @@ int main(int argc, const char **argv) // ignore_convention
 		io_close(s_File);
 	}
 
+	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/tools/packetgen.cpp
+++ b/src/tools/packetgen.cpp
@@ -28,7 +28,7 @@ void Run(NETADDR Dest)
 	}
 }
 
-int main(int argc, char **argv)
+int main(int argc, const char **argv)
 {
 	NETADDR Dest = {NETTYPE_IPV4, {127,0,0,1}, 8303};
 	Run(Dest);

--- a/src/versionsrv/versionsrv.cpp
+++ b/src/versionsrv/versionsrv.cpp
@@ -79,11 +79,10 @@ void SendVer(NETADDR *pAddr, TOKEN ResponseToken)
 	g_NetOp.Send(&p, ResponseToken);
 }
 
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, const char **argv)
 {
-	NETADDR BindAddr;
-
 	dbg_logger_stdout();
+	cmdline_fix(&argc, &argv);
 
 	int FlagMask = 0;
 	IKernel *pKernel = IKernel::Create();
@@ -100,6 +99,7 @@ int main(int argc, const char **argv) // ignore_convention
 	pConfigManager->Init(FlagMask);
 	pConsole->Init();
 
+	NETADDR BindAddr;
 	mem_zero(&BindAddr, sizeof(BindAddr));
 	BindAddr.type = NETTYPE_ALL;
 	BindAddr.port = VERSIONSRV_PORT;
@@ -155,5 +155,6 @@ int main(int argc, const char **argv) // ignore_convention
 		thread_sleep(1);
 	}
 
+	cmdline_free(argc, argv);
 	return 0;
 }


### PR DESCRIPTION
It was previously not possible to load a map or really any file with a filename containing unicode, e.g. german umlauts. Console map completion with unicode was also broken. Similarly it was not possible to load, rename or delete a demo with a unicode name. Starting the game and loading the config was also broken with a unicode windows username.

Now all filenames are converted from multibyte to widechar on windows, and the correct functions and structs (with the `W` suffix) are used consistently.

The usage of pnglite is adjusted so the file handle obtained from `io_open` is reused instead of using pnglite's file methods that cannot handle unicode paths correctly.

Fix command line arguments containing unicode on windows, by adding the `cmdline_fix` function to system fix encoding of argv in-place.

Implement `fs_is_dir` smarter by using `GetFileAttributesW` on Windows.

Remove unused `fs_getmtime` that does not work with unicode on Windows in favor of the existing more generalized `fs_file_time`.

Replace unused and not working `IOFLAG_RANDOM` with working `IOFLAG_APPEND`.