### PR TITLE
Add sv_maplist to configure maplist sending, add IMapChecker interface, refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1302,6 +1302,7 @@ set_src(ENGINE_INTERFACE GLOB src/engine
   kernel.h
   keys.h
   map.h
+  mapchecker.h
   masterserver.h
   message.h
   server.h

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -62,6 +62,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	IEngineTextRender *m_pTextRender;
 	IGameClient *m_pGameClient;
 	IEngineMap *m_pMap;
+	IMapChecker *m_pMapChecker;
 	IConfigManager *m_pConfigManager;
 	CConfig *m_pConfig;
 	IConsole *m_pConsole;
@@ -81,7 +82,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	class CServerBrowser m_ServerBrowser;
 	class CFriends m_Friends;
 	class CBlacklist m_Blacklist;
-	class CMapChecker m_MapChecker;
 
 	char m_aServerAddressStr[256];
 	char m_aServerPassword[128];

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -10,6 +10,7 @@
 #include <engine/shared/network.h>
 #include <engine/shared/packer.h>
 #include <engine/shared/jsonwriter.h>
+#include <engine/shared/mapchecker.h>
 
 #include <engine/config.h>
 #include <engine/console.h>
@@ -85,6 +86,7 @@ void CServerBrowser::Init(class CNetClient *pNetClient, const char *pNetVersion)
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 	m_pMasterServer = Kernel()->RequestInterface<IMasterServer>();
+	m_pMapChecker = Kernel()->RequestInterface<IMapChecker>();
 	m_pNetClient = pNetClient;
 
 	m_ServerBrowserFavorites.Init(pNetClient, m_pConsole, Kernel()->RequestInterface<IEngine>(), pConfigManager);
@@ -589,13 +591,7 @@ void CServerBrowser::SetInfo(int ServerlistType, CServerEntry *pEntry, const CSe
 		str_comp(pEntry->m_Info.m_aGameType, "LTS") == 0 ||	str_comp(pEntry->m_Info.m_aGameType, "LMS") == 0)
 		pEntry->m_Info.m_Flags |= FLAG_PURE;
 
-	if(str_comp(pEntry->m_Info.m_aMap, "dm1") == 0 || str_comp(pEntry->m_Info.m_aMap, "dm2") == 0 || str_comp(pEntry->m_Info.m_aMap, "dm3") == 0 ||
-		str_comp(pEntry->m_Info.m_aMap, "dm6") == 0 || str_comp(pEntry->m_Info.m_aMap, "dm7") == 0 || str_comp(pEntry->m_Info.m_aMap, "dm8") == 0 ||
-		str_comp(pEntry->m_Info.m_aMap, "dm9") == 0 ||
-		str_comp(pEntry->m_Info.m_aMap, "ctf1") == 0 || str_comp(pEntry->m_Info.m_aMap, "ctf2") == 0 || str_comp(pEntry->m_Info.m_aMap, "ctf3") == 0 ||
-		str_comp(pEntry->m_Info.m_aMap, "ctf4") == 0 || str_comp(pEntry->m_Info.m_aMap, "ctf5") == 0 || str_comp(pEntry->m_Info.m_aMap, "ctf6") == 0 ||
-		str_comp(pEntry->m_Info.m_aMap, "ctf7") == 0 || str_comp(pEntry->m_Info.m_aMap, "ctf8") == 0 ||
-		str_comp(pEntry->m_Info.m_aMap, "lms1") == 0)
+	if(m_pMapChecker->IsStandardMap(pEntry->m_Info.m_aMap))
 		pEntry->m_Info.m_Flags |= FLAG_PUREMAP;
 	pEntry->m_Info.m_Favorite = Fav;
 	pEntry->m_Info.m_NetAddr = pEntry->m_Addr;

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -64,7 +64,8 @@ private:
 	class IConsole *m_pConsole;
 	class IStorage *m_pStorage;
 	class IMasterServer *m_pMasterServer;
-		
+	class IMapChecker *m_pMapChecker;
+
 	class CServerBrowserFavorites m_ServerBrowserFavorites;
 	class CServerBrowserFilter m_ServerBrowserFilter;
 

--- a/src/engine/mapchecker.h
+++ b/src/engine/mapchecker.h
@@ -1,0 +1,23 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef ENGINE_MAPCHECKER_H
+#define ENGINE_MAPCHECKER_H
+
+#include "kernel.h"
+
+class IMapChecker : public IInterface
+{
+	MACRO_INTERFACE("mapchecker", 0)
+public:
+	virtual void AddMaplist(struct CMapVersion *pMaplist, int Num) = 0;
+	virtual bool IsMapValid(const char *pMapName, const SHA256_DIGEST *pMapSha256, unsigned MapCrc, unsigned MapSize) = 0;
+	virtual bool ReadAndValidateMap(const char *pFilename, int StorageType) = 0;
+
+	virtual int NumStandardMaps() = 0;
+	virtual const char *GetStandardMapName(int Index) = 0;
+	virtual bool IsStandardMap(const char *pMapName) = 0;
+};
+
+extern IMapChecker *CreateMapChecker();
+
+#endif

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1245,7 +1245,7 @@ int CServer::LoadMap(const char *pMapName)
 	str_format(aBuf, sizeof(aBuf), "maps/%s.map", pMapName);
 
 	// check for valid standard map
-	if(!m_MapChecker.ReadAndValidateMap(Storage(), aBuf, IStorage::TYPE_ALL))
+	if(!m_pMapChecker->ReadAndValidateMap(aBuf, IStorage::TYPE_ALL))
 	{
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "mapchecker", "invalid standard map");
 		return 0;
@@ -1292,13 +1292,14 @@ void CServer::InitRegister(CNetServer *pNetServer, IEngineMasterServer *pMasterS
 	m_Register.Init(pNetServer, pMasterServer, pConfig, pConsole);
 }
 
-void CServer::InitInterfaces(CConfig *pConfig, IConsole *pConsole, IGameServer *pGameServer, IEngineMap *pMap, IStorage *pStorage)
+void CServer::InitInterfaces(IKernel *pKernel)
 {
-	m_pConfig = pConfig;
-	m_pConsole = pConsole;
-	m_pGameServer = pGameServer;
-	m_pMap = pMap;
-	m_pStorage = pStorage;
+	m_pConfig = pKernel->RequestInterface<IConfigManager>()->Values();
+	m_pConsole = pKernel->RequestInterface<IConsole>();
+	m_pGameServer = pKernel->RequestInterface<IGameServer>();
+	m_pMap = pKernel->RequestInterface<IEngineMap>();
+	m_pMapChecker = pKernel->RequestInterface<IMapChecker>();
+	m_pStorage = pKernel->RequestInterface<IStorage>();
 }
 
 int CServer::Run()
@@ -1306,12 +1307,7 @@ int CServer::Run()
 	//
 	m_PrintCBIndex = Console()->RegisterPrintCallback(Config()->m_ConsoleOutputLevel, SendRconLineAuthed, this);
 
-	// list maps
-	m_pMapListHeap = new CHeap();
-	CSubdirCallbackUserdata Userdata;
-	Userdata.m_pServer = this;
-	str_copy(Userdata.m_aName, "", sizeof(Userdata.m_aName));
-	m_pStorage->ListDirectory(IStorage::TYPE_ALL, "maps/", MapListEntryCallback, &Userdata);
+	InitMapList();
 
 	// load map
 	if(!LoadMap(Config()->m_SvMap))
@@ -1487,6 +1483,13 @@ int CServer::Run()
 	return 0;
 }
 
+struct CSubdirCallbackUserdata
+{
+	CServer *m_pServer;
+	char m_aName[IConsole::TEMPMAP_NAME_LENGTH];
+	bool m_StandardOnly;
+};
+
 int CServer::MapListEntryCallback(const char *pFilename, int IsDir, int DirType, void *pUser)
 {
 	CSubdirCallbackUserdata *pUserdata = (CSubdirCallbackUserdata *)pUser;
@@ -1504,19 +1507,22 @@ int CServer::MapListEntryCallback(const char *pFilename, int IsDir, int DirType,
 	if(IsDir)
 	{
 		CSubdirCallbackUserdata Userdata;
+		Userdata.m_StandardOnly = pUserdata->m_StandardOnly;
 		Userdata.m_pServer = pThis;
 		str_copy(Userdata.m_aName, aFilename, sizeof(Userdata.m_aName));
-		char FindPath[IO_MAX_PATH_LENGTH];
-		str_format(FindPath, sizeof(FindPath), "maps/%s/", aFilename);
-		pThis->m_pStorage->ListDirectory(IStorage::TYPE_ALL, FindPath, MapListEntryCallback, &Userdata);
+		char aFindPath[IO_MAX_PATH_LENGTH];
+		str_format(aFindPath, sizeof(aFindPath), "maps/%s/", aFilename);
+		pThis->m_pStorage->ListDirectory(IStorage::TYPE_ALL, aFindPath, MapListEntryCallback, &Userdata);
 		return 0;
 	}
 
 	const char *pSuffix = str_endswith(aFilename, ".map");
 	if(!pSuffix) // not ending with .map
-	{
-			return 0;
-	}
+		return 0;
+	aFilename[pSuffix - aFilename] = 0; // remove suffix
+
+	if(pUserdata->m_StandardOnly && !pThis->m_pMapChecker->IsStandardMap(aFilename))
+		return 0;
 
 	CMapListEntry *pEntry = (CMapListEntry *)pThis->m_pMapListHeap->Allocate(sizeof(CMapListEntry));
 	pThis->m_NumMapEntries++;
@@ -1528,9 +1534,27 @@ int CServer::MapListEntryCallback(const char *pFilename, int IsDir, int DirType,
 	if(!pThis->m_pFirstMapEntry)
 		pThis->m_pFirstMapEntry = pEntry;
 
-	str_truncate(pEntry->m_aName, sizeof(pEntry->m_aName), aFilename, pSuffix-aFilename);
+	str_copy(pEntry->m_aName, aFilename, sizeof(pEntry->m_aName));
 
 	return 0;
+}
+
+void CServer::InitMapList()
+{
+	m_pMapListHeap = new CHeap();
+
+	CSubdirCallbackUserdata Userdata;
+	if(str_comp(Config()->m_SvMaplist, "standard") == 0)
+		Userdata.m_StandardOnly = true;
+	else if(str_comp(Config()->m_SvMaplist, "all") == 0)
+		Userdata.m_StandardOnly = false;
+	else /* "none" or any other value */
+		return;
+
+	Userdata.m_pServer = this;
+	str_copy(Userdata.m_aName, "", sizeof(Userdata.m_aName));
+	m_pStorage->ListDirectory(IStorage::TYPE_ALL, "maps/", MapListEntryCallback, &Userdata);
+	dbg_msg("server", "%d maps added to maplist", m_NumMapEntries);
 }
 
 void CServer::ConKick(IConsole::IResult *pResult, void *pUser)
@@ -1856,6 +1880,7 @@ int main(int argc, const char **argv) // ignore_convention
 	int FlagMask = CFGFLAG_SERVER|CFGFLAG_ECON;
 	IEngine *pEngine = CreateEngine("Teeworlds_Server");
 	IEngineMap *pEngineMap = CreateEngineMap();
+	IMapChecker *pMapChecker = CreateMapChecker();
 	IGameServer *pGameServer = CreateGameServer();
 	IConsole *pConsole = CreateConsole(CFGFLAG_SERVER|CFGFLAG_ECON);
 	IEngineMasterServer *pEngineMasterServer = CreateEngineMasterServer();
@@ -1871,6 +1896,7 @@ int main(int argc, const char **argv) // ignore_convention
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pEngine);
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(static_cast<IEngineMap*>(pEngineMap)); // register as both
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(static_cast<IMap*>(pEngineMap));
+		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pMapChecker);
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pGameServer);
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pConsole);
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pStorage);
@@ -1888,7 +1914,7 @@ int main(int argc, const char **argv) // ignore_convention
 	pEngineMasterServer->Init();
 	pEngineMasterServer->Load();
 
-	pServer->InitInterfaces(pConfigManager->Values(), pConsole, pGameServer, pEngineMap, pStorage);
+	pServer->InitInterfaces(pKernel);
 	if(!UseDefaultConfig)
 	{
 		// register all console commands

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -150,6 +150,7 @@ public:
 	CServerBan m_ServerBan;
 
 	IEngineMap *m_pMap;
+	IMapChecker *m_pMapChecker;
 
 	int64 m_GameStartTime;
 	bool m_RunServer;
@@ -179,12 +180,6 @@ public:
 		char m_aName[IConsole::TEMPMAP_NAME_LENGTH];
 	};
 
-	struct CSubdirCallbackUserdata
-	{
-		CServer *m_pServer;
-		char m_aName[IConsole::TEMPMAP_NAME_LENGTH];
-	};
-
 	CHeap *m_pMapListHeap;
 	CMapListEntry *m_pLastMapEntry;
 	CMapListEntry *m_pFirstMapEntry;
@@ -195,7 +190,6 @@ public:
 
 	CDemoRecorder m_DemoRecorder;
 	CRegister m_Register;
-	CMapChecker m_MapChecker;
 
 	CServer();
 
@@ -257,10 +251,11 @@ public:
 	int LoadMap(const char *pMapName);
 
 	void InitRegister(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, CConfig *pConfig, IConsole *pConsole);
-	void InitInterfaces(CConfig *pConfig, IConsole *pConsole, IGameServer *pGameServer, IEngineMap *pMap, IStorage *pStorage);
+	void InitInterfaces(IKernel *pKernel);
 	int Run();
 
 	static int MapListEntryCallback(const char *pFilename, int IsDir, int DirType, void *pUser);
+	void InitMapList();
 
 	static void ConKick(IConsole::IResult *pResult, void *pUser);
 	static void ConStatus(IConsole::IResult *pResult, void *pUser);

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -97,6 +97,7 @@ MACRO_CONFIG_INT(SvRconMaxTries, sv_rcon_max_tries, 3, 0, 100, CFGFLAG_SAVE|CFGF
 MACRO_CONFIG_INT(SvRconBantime, sv_rcon_bantime, 5, 0, 1440, CFGFLAG_SAVE|CFGFLAG_SERVER, "The time a client gets banned if remote console authentication fails. 0 makes it just use kick")
 MACRO_CONFIG_INT(SvAutoDemoRecord, sv_auto_demo_record, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_SERVER, "Automatically record demos")
 MACRO_CONFIG_INT(SvAutoDemoMax, sv_auto_demo_max, 10, 0, 1000, CFGFLAG_SAVE|CFGFLAG_SERVER, "Maximum number of automatically recorded demos (0 = no limit)")
+MACRO_CONFIG_STR(SvMaplist, sv_maplist, 32, "all", CFGFLAG_SAVE|CFGFLAG_SERVER, "Maplist for authed clients (none, standard, all)")
 
 MACRO_CONFIG_STR(EcBindaddr, ec_bindaddr, 128, "localhost", CFGFLAG_SAVE|CFGFLAG_ECON, "Address to bind the external console to. Anything but 'localhost' is dangerous")
 MACRO_CONFIG_INT(EcPort, ec_port, 0, 0, 0, CFGFLAG_SAVE|CFGFLAG_ECON, "Port to use for the external console")

--- a/src/engine/shared/mapchecker.cpp
+++ b/src/engine/shared/mapchecker.cpp
@@ -20,18 +20,18 @@ void CMapChecker::Init()
 {
 	m_Whitelist.Reset();
 	m_pFirst = 0;
-	m_RemoveDefaultList = false;
+	m_ClearListBeforeAdding = false;
 }
 
 void CMapChecker::SetDefaults()
 {
 	AddMaplist(s_aMapVersionList, s_NumMapVersionItems);
-	m_RemoveDefaultList = true;
+	m_ClearListBeforeAdding = true;
 }
 
 void CMapChecker::AddMaplist(CMapVersion *pMaplist, int Num)
 {
-	if(m_RemoveDefaultList)
+	if(m_ClearListBeforeAdding)
 		Init();
 
 	for(int i = 0; i < Num; ++i)
@@ -41,8 +41,8 @@ void CMapChecker::AddMaplist(CMapVersion *pMaplist, int Num)
 		m_pFirst = pEntry;
 
 		str_copy(pEntry->m_aMapName, pMaplist[i].m_aName, sizeof(pEntry->m_aMapName));
-		pEntry->m_MapCrc = (pMaplist[i].m_aCrc[0]<<24) | (pMaplist[i].m_aCrc[1]<<16) | (pMaplist[i].m_aCrc[2]<<8) | pMaplist[i].m_aCrc[3];
-		pEntry->m_MapSize = (pMaplist[i].m_aSize[0]<<24) | (pMaplist[i].m_aSize[1]<<16) | (pMaplist[i].m_aSize[2]<<8) | pMaplist[i].m_aSize[3];
+		pEntry->m_MapCrc = bytes_be_to_uint(pMaplist[i].m_aCrc);
+		pEntry->m_MapSize = bytes_be_to_uint(pMaplist[i].m_aSize);
 		mem_copy(&pEntry->m_MapSha256, &pMaplist[i].m_aSha256, sizeof(pEntry->m_MapSha256));
 	}
 }
@@ -59,12 +59,13 @@ bool CMapChecker::IsMapValid(const char *pMapName, const SHA256_DIGEST *pMapSha2
 				return true;
 		}
 	}
-
 	return !StandardMap;
 }
 
-bool CMapChecker::ReadAndValidateMap(IStorage *pStorage, const char *pFilename, int StorageType)
+bool CMapChecker::ReadAndValidateMap(const char *pFilename, int StorageType)
 {
+	IStorage *pStorage = Kernel()->RequestInterface<IStorage>();
+
 	// extract map name
 	char aMapName[MAX_MAP_LENGTH];
 	char aMapNameExt[MAX_MAP_LENGTH+4];
@@ -102,3 +103,30 @@ bool CMapChecker::ReadAndValidateMap(IStorage *pStorage, const char *pFilename, 
 
 	return !StandardMap;
 }
+
+int CMapChecker::NumStandardMaps()
+{
+	int Count = 0;
+	for(CWhitelistEntry *pCurrent = m_pFirst; pCurrent; pCurrent = pCurrent->m_pNext)
+		Count++;
+	return Count;
+}
+
+const char *CMapChecker::GetStandardMapName(int Index)
+{
+	int i = 0;
+	for(CWhitelistEntry *pCurrent = m_pFirst; pCurrent; pCurrent = pCurrent->m_pNext, i++)
+		if(i == Index)
+			return pCurrent->m_aMapName;
+	return 0x0;
+}
+
+bool CMapChecker::IsStandardMap(const char *pMapName)
+{
+	for(CWhitelistEntry *pCurrent = m_pFirst; pCurrent; pCurrent = pCurrent->m_pNext)
+		if(str_comp(pCurrent->m_aMapName, pMapName) == 0)
+			return true;
+	return false;
+}
+
+IMapChecker *CreateMapChecker() { return new CMapChecker; }

--- a/src/engine/shared/mapchecker.h
+++ b/src/engine/shared/mapchecker.h
@@ -5,13 +5,15 @@
 
 #include <base/hash.h>
 
+#include <engine/mapchecker.h>
+
 #include "memheap.h"
 
-class CMapChecker
+class CMapChecker : public IMapChecker
 {
 	enum
 	{
-		MAX_MAP_LENGTH=8,
+		MAX_MAP_LENGTH = 8,
 	};
 
 	struct CWhitelistEntry
@@ -26,7 +28,7 @@ class CMapChecker
 	class CHeap m_Whitelist;
 	CWhitelistEntry *m_pFirst;
 
-	bool m_RemoveDefaultList;
+	bool m_ClearListBeforeAdding; // whether to clear the existing list before adding a new map list
 
 	void Init();
 	void SetDefaults();
@@ -35,7 +37,11 @@ public:
 	CMapChecker();
 	void AddMaplist(struct CMapVersion *pMaplist, int Num);
 	bool IsMapValid(const char *pMapName, const SHA256_DIGEST *pMapSha256, unsigned MapCrc, unsigned MapSize);
-	bool ReadAndValidateMap(class IStorage *pStorage, const char *pFilename, int StorageType);
+	bool ReadAndValidateMap(const char *pFilename, int StorageType);
+
+	int NumStandardMaps();
+	const char *GetStandardMapName(int Index);
+	bool IsStandardMap(const char *pMapName);
 };
 
 #endif

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -11,6 +11,7 @@
 #include <engine/graphics.h>
 #include <engine/input.h>
 #include <engine/keys.h>
+#include <engine/mapchecker.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
 
@@ -4267,7 +4268,6 @@ void CEditor::Init()
 #endif
 }
 
-static const char *s_aMaps[] = {"ctf1", "ctf2", "ctf3", "ctf4", "ctf5", "ctf6", "ctf7", "ctf8", "dm1", "dm2", "dm3", "dm6", "dm7", "dm8", "dm9", "lms1"};
 static const char *s_aImageName[] = { "grass_doodads", "winter_main" };
 
 static int s_GrassDoodadsIndicesOld[] = { 42, 43, 44, 58, 59, 60, 74, 75, 76, 132, 133, 148, 149, 163, 164, 165, 169, 170, 185, 186 };
@@ -4278,13 +4278,15 @@ static int s_WinterMainIndicesNew[] = { 218, 219, 220, 221, 222, 223, 234, 235, 
 void CEditor::ConMapMagic(IConsole::IResult *pResult, void *pUserData)
 {
 	CEditor *pSelf = static_cast<CEditor *>(pUserData);
+	IMapChecker *pMapChecker = pSelf->Kernel()->RequestInterface<IMapChecker>();
 	int Flag = pResult->GetInteger(0);
 
-	for(unsigned m = 0; m < sizeof(s_aMaps) / sizeof(s_aMaps[0]); ++m)
+	for(int m = 0; m < pMapChecker->NumStandardMaps(); ++m)
 	{
-		char aBuf[64] = { 0 };
-		str_format(aBuf, sizeof(aBuf), "maps/%s.map", s_aMaps[m]);
-		dbg_msg("map magic", "processing map '%s'", s_aMaps[m]);
+		const char *pMapName = pMapChecker->GetStandardMapName(m);
+		char aBuf[64];
+		str_format(aBuf, sizeof(aBuf), "maps/%s.map", pMapName);
+		dbg_msg("map magic", "processing map '%s'", pMapName);
 		CallbackOpenMap(aBuf, IStorage::TYPE_ALL, pSelf);
 		bool Edited = false;
 
@@ -4304,8 +4306,8 @@ void CEditor::ConMapMagic(IConsole::IResult *pResult, void *pUserData)
 
 		if(Edited)
 		{
-			str_format(aBuf, sizeof(aBuf), "maps/%s_mapmagic.map", s_aMaps[m]);
-			dbg_msg("map magic", "saving map '%s_mapmagic'", s_aMaps[m]);
+			str_format(aBuf, sizeof(aBuf), "maps/%s_mapmagic.map", pMapName);
+			dbg_msg("map magic", "saving map '%s_mapmagic'", pMapName);
 			CallbackSaveMap(aBuf, IStorage::TYPE_SAVE, pSelf);
 		}
 	}


### PR DESCRIPTION
Add `sv_maplist` to configure which maps the server sends to authenticated clients. Possible values:
 - `none` (or any invalid value) - send no maps
 - `standard` - only send standard maps (defined by the map checker)
 - `all` (default) - send all maps

Server must be restarted for the setting to take effect, as the maplist is only loaded once.

The config variable is a string because it's more readable and can potentially be extended in the future to specify custom lists like `sv_maplist mylist.json`.

Refactor map checker: Add IMapChecker interface. Remove static definition of the standard maps in editor and browser and add the functionality to the map checker.

Fixes another part of #1972.