### PR TITLE
Fix skin name being cleared after saving

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1979,7 +1979,6 @@ void CMenus::RenderMenu(CUIRect Screen)
 				{
 					m_Popup = POPUP_NONE;
 					m_pClient->m_pSkins->SaveSkinfile(m_aSaveSkinName);
-					m_aSaveSkinName[0] = 0;
 					m_RefreshSkinSelector = true;
 				}
 			}


### PR DESCRIPTION
`m_aSaveSkinName` should not be cleared, as it is only set once when the selection changes and the name would otherwise be unset when saving the same skin without changing selection. 