### PR TITLE
Remove unused ToolBar argument which is sometimes uninitialized, prevent use of uninitialized variable ToolBox

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2561,10 +2561,6 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 void CEditor::RenderLayers(CUIRect ToolBox, CUIRect View)
 {
 	CUIRect LayersBox = ToolBox;
-
-	if(!m_GuiActive)
-		return;
-
 	CUIRect Slot, Button;
 	char aBuf[64];
 
@@ -4232,11 +4228,12 @@ void CEditor::Render()
 		}
 	}
 
-	if(m_Mode == MODE_LAYERS)
+	if(m_Mode == MODE_LAYERS && m_GuiActive)
 		RenderLayers(ToolBox, View);
 	else if(m_Mode == MODE_IMAGES)
 	{
-		RenderImagesList(ToolBox);
+		if(m_GuiActive)
+			RenderImagesList(ToolBox);
 		RenderSelectedImage(View);
 	}
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1792,7 +1792,7 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 	Graphics()->QuadsDraw(&QuadItem, 1);
 }
 
-void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
+void CEditor::DoMapEditor(CUIRect View)
 {
 	// render all good stuff
 	if(!m_ShowTilePicker)
@@ -1801,7 +1801,6 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 		{
 			if(m_Map.m_lGroups[g]->m_Visible)
 				m_Map.m_lGroups[g]->Render();
-			//UI()->ClipEnable(&view);
 		}
 
 		// render the game above everything else
@@ -2385,7 +2384,6 @@ void CEditor::DoMapEditor(CUIRect View, CUIRect ToolBar)
 	}
 
 	UI()->MapScreen();
-	//UI()->ClipDisable();
 }
 
 
@@ -2560,7 +2558,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 	return Change;
 }
 
-void CEditor::RenderLayers(CUIRect ToolBox, CUIRect ToolBar, CUIRect View)
+void CEditor::RenderLayers(CUIRect ToolBox, CUIRect View)
 {
 	CUIRect LayersBox = ToolBox;
 
@@ -2856,7 +2854,7 @@ void CEditor::SortImages()
 }
 
 
-void CEditor::RenderImagesList(CUIRect ToolBox, CUIRect ToolBar)
+void CEditor::RenderImagesList(CUIRect ToolBox)
 {
 	static float s_ScrollValue = 0.0f;
 	const float RowHeight = 14.0f;
@@ -4156,7 +4154,6 @@ void CEditor::Render()
 
 	if(m_GuiActive)
 	{
-
 		View.HSplitTop(16.0f, &MenuBar, &View);
 		View.HSplitTop(53.0f, &ToolBar, &View);
 		View.VSplitLeft(100.0f, &ToolBox, &View);
@@ -4175,7 +4172,7 @@ void CEditor::Render()
 
 	//	a little hack for now
 	if(m_Mode == MODE_LAYERS)
-		DoMapEditor(View, ToolBar);
+		DoMapEditor(View);
 
 	// do zooming
 	if(Input()->KeyPress(KEY_KP_MINUS))
@@ -4235,12 +4232,11 @@ void CEditor::Render()
 		}
 	}
 
-
 	if(m_Mode == MODE_LAYERS)
-		RenderLayers(ToolBox, ToolBar, View);
+		RenderLayers(ToolBox, View);
 	else if(m_Mode == MODE_IMAGES)
 	{
-		RenderImagesList(ToolBox, ToolBar);
+		RenderImagesList(ToolBox);
 		RenderSelectedImage(View);
 	}
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -821,7 +821,7 @@ public:
 	void DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int pIndex);
 	void DoQuadPoint(CQuad *pQuad, int QuadIndex, int v);
 
-	void DoMapEditor(CUIRect View, CUIRect Toolbar);
+	void DoMapEditor(CUIRect View);
 	void DoToolbar(CUIRect Toolbar);
 	void DoQuad(CQuad *pQuad, int Index);
 	float UiDoScrollbarV(const void *pID, const CUIRect *pRect, float Current);
@@ -830,9 +830,9 @@ public:
 	static void ReplaceImage(const char *pFilename, int StorageType, void *pUser);
 	static void AddImage(const char *pFilename, int StorageType, void *pUser);
 
-	void RenderImagesList(CUIRect Toolbox, CUIRect Toolbar);
+	void RenderImagesList(CUIRect Toolbox);
 	void RenderSelectedImage(CUIRect View);
-	void RenderLayers(CUIRect Toolbox, CUIRect Toolbar, CUIRect View);
+	void RenderLayers(CUIRect Toolbox, CUIRect View);
 	void RenderModebar(CUIRect View);
 	void RenderStatusbar(CUIRect View);
 	void RenderEnvelopeEditor(CUIRect View);


### PR DESCRIPTION
Remove unused `ToolBar` argument from some methods in editor. Because the value being passed as this argument was sometimes uninitialized, this presumably causes the client to crash when compiling with some compilers.

Some checks are moved/added to ensure that the uninitialized `ToolBox` variable is not passed as an argument.