### PR TITLE
Consistent corners of browser filter editbox with clear button

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1141,7 +1141,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	UI()->DoLabel(&Label, Localize("Search:"), FontSize, CUI::ALIGN_LEFT);
 	EditBox.VSplitRight(EditBox.h, &EditBox, &Button);
 	static float s_ClearOffset = 0.0f;
-	if(DoEditBox(&Config()->m_BrFilterString, &EditBox, Config()->m_BrFilterString, sizeof(Config()->m_BrFilterString), FontSize, &s_ClearOffset, false, CUIRect::CORNER_ALL))
+	if(DoEditBox(&Config()->m_BrFilterString, &EditBox, Config()->m_BrFilterString, sizeof(Config()->m_BrFilterString), FontSize, &s_ClearOffset, false, CUIRect::CORNER_L))
 	{
 		Client()->ServerBrowserUpdate();
 		ServerBrowserFilterOnUpdate();
@@ -1150,7 +1150,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	// clear button
 	{
 		static CButtonContainer s_ClearButton;
-		if(DoButton_SpriteID(&s_ClearButton, IMAGE_TOOLICONS, SPRITE_TOOL_X_A, false, &Button, CUIRect::CORNER_ALL, 5.0f, true))
+		if(DoButton_SpriteID(&s_ClearButton, IMAGE_TOOLICONS, SPRITE_TOOL_X_A, false, &Button, CUIRect::CORNER_R, 5.0f, true))
 		{
 			Config()->m_BrFilterString[0] = 0;
 			UI()->SetActiveItem(&Config()->m_BrFilterString);


### PR DESCRIPTION
Before:

![grafik](https://user-images.githubusercontent.com/23437060/134985715-cac2f09a-79a1-46a9-aa28-e84b2d01e136.png)

After:

![grafik](https://user-images.githubusercontent.com/23437060/134985669-c825ba42-bc63-435e-aea5-52b30ada8a15.png)

This makes the corners consistent with the editbox in the ingame menu:

![grafik](https://user-images.githubusercontent.com/23437060/134985950-ef6233a7-22f0-4736-afb6-fa75eb7aa16d.png)

