### PR TITLE
Move special hotkey handling to CUI

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -79,13 +79,6 @@ CMenus::CMenus()
 
 	m_PopupActive = false;
 
-	m_EscapePressed = false;
-	m_EnterPressed = false;
-	m_TabPressed = false;
-	m_DeletePressed = false;
-	m_UpArrowPressed = false;
-	m_DownArrowPressed = false;
-
 	m_aDemoLoadingFile[0] = 0;
 	m_DemoLoadingPopupRendered = false;
 
@@ -1025,7 +1018,7 @@ void CMenus::RenderBackButton(CUIRect MainView)
 	MainView.HSplitTop(25.0f, &MainView, 0);
 	Button = MainView;
 	static CButtonContainer s_MenuButton;
-	if(DoButton_Menu(&s_MenuButton, Localize("Back"), 0, &Button) || m_EscapePressed)
+	if(DoButton_Menu(&s_MenuButton, Localize("Back"), 0, &Button) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 	{
 		SetMenuPage(m_MenuPageOld);
 		m_MenuPageOld = PAGE_START;
@@ -1490,11 +1483,11 @@ void CMenus::RenderMenu(CUIRect Screen)
 			BottomBar.VSplitMid(&No, &Yes, SpacingW);
 
 			static CButtonContainer s_ButtonAbort;
-			if(DoButton_Menu(&s_ButtonAbort, Localize("No"), 0, &No) || m_EscapePressed)
+			if(DoButton_Menu(&s_ButtonAbort, Localize("No"), 0, &No) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 				m_Popup = POPUP_NONE;
 
 			static CButtonContainer s_ButtonTryAgain;
-			if(DoButton_Menu(&s_ButtonTryAgain, Localize("Yes"), 0, &Yes) || m_EnterPressed)
+			if(DoButton_Menu(&s_ButtonTryAgain, Localize("Yes"), 0, &Yes) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 				Client()->Quit();
 		}
 		else if(m_Popup == POPUP_PASSWORD)
@@ -1528,14 +1521,14 @@ void CMenus::RenderMenu(CUIRect Screen)
 			BottomBar.VSplitMid(&Abort, &TryAgain, SpacingW);
 
 			static CButtonContainer s_ButtonAbort;
-			if(DoButton_Menu(&s_ButtonAbort, Localize("Abort"), 0, &Abort) || m_EscapePressed)
+			if(DoButton_Menu(&s_ButtonAbort, Localize("Abort"), 0, &Abort) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 			{
 				m_Popup = POPUP_NONE;
 				m_aPasswordPopupServerAddress[0] = '\0';
 			}
 
 			static CButtonContainer s_ButtonTryAgain;
-			if(DoButton_Menu(&s_ButtonTryAgain, Localize("Try again"), 0, &TryAgain) || m_EnterPressed)
+			if(DoButton_Menu(&s_ButtonTryAgain, Localize("Try again"), 0, &TryAgain) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 			{
 				Client()->Connect(ServerInfo.m_aHostname);
 				m_aPasswordPopupServerAddress[0] = '\0';
@@ -1544,7 +1537,7 @@ void CMenus::RenderMenu(CUIRect Screen)
 		else if(m_Popup == POPUP_CONNECTING)
 		{
 			static CButtonContainer s_ButtonConnect;
-			if(DoButton_Menu(&s_ButtonConnect, Localize("Abort"), 0, &BottomBar) || m_EscapePressed || m_EnterPressed)
+			if(DoButton_Menu(&s_ButtonConnect, Localize("Abort"), 0, &BottomBar) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 			{
 				Client()->Disconnect();
 				m_Popup = POPUP_NONE;
@@ -1631,7 +1624,7 @@ void CMenus::RenderMenu(CUIRect Screen)
 			RenderLanguageSelection(Box, false);
 
 			static CButtonContainer s_ButtonLanguage;
-			if(DoButton_Menu(&s_ButtonLanguage, Localize("Ok"), 0, &BottomBar) || m_EscapePressed || m_EnterPressed)
+			if(DoButton_Menu(&s_ButtonLanguage, Localize("Ok"), 0, &BottomBar) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 				m_Popup = POPUP_FIRST_LAUNCH;
 		}
 		else if(m_Popup == POPUP_COUNTRY)
@@ -1687,13 +1680,13 @@ void CMenus::RenderMenu(CUIRect Screen)
 			Part.VMargin(120.0f, &Part);
 
 			static CButtonContainer s_ButtonCountry;
-			if(DoButton_Menu(&s_ButtonCountry, Localize("Ok"), 0, &BottomBar) || m_EnterPressed)
+			if(DoButton_Menu(&s_ButtonCountry, Localize("Ok"), 0, &BottomBar) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 			{
 				(this->*m_aPopupButtons[BUTTON_CONFIRM].m_pfnCallback)();
 				m_Popup = POPUP_NONE;
 			}
 
-			if(m_EscapePressed)
+			if(UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 			{
 				m_PopupSelection = -2;
 				m_Popup = POPUP_NONE;
@@ -1717,11 +1710,11 @@ void CMenus::RenderMenu(CUIRect Screen)
 			BottomBar.VSplitMid(&No, &Yes, SpacingW);
 
 			static CButtonContainer s_ButtonNo;
-			if(DoButton_Menu(&s_ButtonNo, Localize("No"), 0, &No) || m_EscapePressed)
+			if(DoButton_Menu(&s_ButtonNo, Localize("No"), 0, &No) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 				m_Popup = POPUP_NONE;
 
 			static CButtonContainer s_ButtonYes;
-			if(DoButton_Menu(&s_ButtonYes, Localize("Yes"), !m_aCurrentDemoFile[0], &Yes) || m_EnterPressed)
+			if(DoButton_Menu(&s_ButtonYes, Localize("Yes"), !m_aCurrentDemoFile[0], &Yes) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 			{
 				if(m_aCurrentDemoFile[0])
 				{
@@ -1766,11 +1759,11 @@ void CMenus::RenderMenu(CUIRect Screen)
 			BottomBar.VSplitMid(&No, &Yes, SpacingW);
 
 			static CButtonContainer s_ButtonAbort;
-			if(DoButton_Menu(&s_ButtonAbort, Localize("No"), 0, &No) || m_EscapePressed)
+			if(DoButton_Menu(&s_ButtonAbort, Localize("No"), 0, &No) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 				m_Popup = POPUP_NONE;
 
 			static CButtonContainer s_ButtonTryAgain;
-			if(DoButton_Menu(&s_ButtonTryAgain, Localize("Yes"), !m_aSaveSkinName[0], &Yes) || m_EnterPressed)
+			if(DoButton_Menu(&s_ButtonTryAgain, Localize("Yes"), !m_aSaveSkinName[0], &Yes) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 			{
 				if(m_aSaveSkinName[0] && m_aSaveSkinName[0] != 'x' && m_aSaveSkinName[1] != '_')
 				{
@@ -1795,7 +1788,7 @@ void CMenus::RenderMenu(CUIRect Screen)
 
 			// button
 			static CButtonContainer s_EnterButton;
-			if(DoButton_Menu(&s_EnterButton, Localize("Enter"), 0, &BottomBar) || m_EnterPressed)
+			if(DoButton_Menu(&s_EnterButton, Localize("Enter"), 0, &BottomBar) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 			{
 				if(Config()->m_PlayerName[0])
 					m_Popup = POPUP_NONE;
@@ -1813,7 +1806,7 @@ void CMenus::RenderMenu(CUIRect Screen)
 			if(m_Popup == POPUP_MESSAGE)
 			{
 				static CButtonContainer s_ButtonConfirm;
-				if(DoButton_Menu(&s_ButtonConfirm, m_aPopupButtons[BUTTON_CONFIRM].m_aLabel, 0, &BottomBar) || m_EscapePressed || m_EnterPressed)
+				if(DoButton_Menu(&s_ButtonConfirm, m_aPopupButtons[BUTTON_CONFIRM].m_aLabel, 0, &BottomBar) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 				{
 					m_Popup = m_aPopupButtons[BUTTON_CONFIRM].m_NextPopup;
 					(this->*m_aPopupButtons[BUTTON_CONFIRM].m_pfnCallback)();
@@ -1825,14 +1818,14 @@ void CMenus::RenderMenu(CUIRect Screen)
 				BottomBar.VSplitMid(&CancelButton, &ConfirmButton, SpacingW);
 
 				static CButtonContainer s_ButtonCancel;
-				if(DoButton_Menu(&s_ButtonCancel, m_aPopupButtons[BUTTON_CANCEL].m_aLabel, 0, &CancelButton) || m_EscapePressed)
+				if(DoButton_Menu(&s_ButtonCancel, m_aPopupButtons[BUTTON_CANCEL].m_aLabel, 0, &CancelButton) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 				{
 					m_Popup = m_aPopupButtons[BUTTON_CANCEL].m_NextPopup;
 					(this->*m_aPopupButtons[BUTTON_CANCEL].m_pfnCallback)();
 				}
 
 				static CButtonContainer s_ButtonConfirm;
-				if(DoButton_Menu(&s_ButtonConfirm, m_aPopupButtons[BUTTON_CONFIRM].m_aLabel, 0, &ConfirmButton) || m_EnterPressed)
+				if(DoButton_Menu(&s_ButtonConfirm, m_aPopupButtons[BUTTON_CONFIRM].m_aLabel, 0, &ConfirmButton) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 				{
 					m_Popup = m_aPopupButtons[BUTTON_CONFIRM].m_NextPopup;
 					(this->*m_aPopupButtons[BUTTON_CONFIRM].m_pfnCallback)();
@@ -1900,36 +1893,17 @@ bool CMenus::OnInput(IInput::CEvent e)
 {
 	m_LastInput = time_get();
 
-	// special handle esc and enter for popup purposes
-	if(e.m_Flags&IInput::FLAG_PRESS)
-	{
-		if(e.m_Key == KEY_ESCAPE)
-		{
-			m_EscapePressed = true;
-			SetActive(!IsActive());
-			return true;
-		}
-	}
+	UI()->OnInput(e);
 
-	if(IsActive())
+	// special handle esc and enter for popup purposes
+	if(e.m_Flags&IInput::FLAG_PRESS && e.m_Key == KEY_ESCAPE)
 	{
-		if(e.m_Flags&IInput::FLAG_PRESS)
-		{
-			// special for popups
-			if(e.m_Key == KEY_RETURN || e.m_Key == KEY_KP_ENTER)
-				m_EnterPressed = true;
-			else if(e.m_Key == KEY_TAB && !Input()->KeyIsPressed(KEY_LALT) && !Input()->KeyIsPressed(KEY_RALT))
-				m_TabPressed = true;
-			else if(e.m_Key == KEY_DELETE)
-				m_DeletePressed = true;
-			else if(e.m_Key == KEY_UP)
-				m_UpArrowPressed = true;
-			else if(e.m_Key == KEY_DOWN)
-				m_DownArrowPressed = true;
-		}
+		SetActive(!IsActive());
 		return true;
 	}
-	return false;
+
+	// TODO: check for active lineinput instead
+	return IsActive();
 }
 
 void CMenus::OnConsoleInit()
@@ -2045,12 +2019,7 @@ void CMenus::OnRender()
 		}
 	}
 
-	m_EscapePressed = false;
-	m_EnterPressed = false;
-	m_TabPressed = false;
-	m_DeletePressed = false;
-	m_UpArrowPressed = false;
-	m_DownArrowPressed = false;
+	UI()->ClearHotkeys();
 }
 
 bool CMenus::CheckHotKey(int Key) const

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -384,14 +384,6 @@ private:
 	bool m_RefreshSkinSelector;
 	const CSkins::CSkin *m_pSelectedSkin;
 
-	//
-	bool m_EscapePressed;
-	bool m_EnterPressed;
-	bool m_TabPressed;
-	bool m_DeletePressed;
-	bool m_UpArrowPressed;
-	bool m_DownArrowPressed;
-
 	// for map download popup
 	int64 m_DownloadLastCheckTime;
 	int m_DownloadLastCheckSize;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -925,7 +925,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		int NewFilter = SelectedFilter;
 		int ToBeSelectedServer = -1;
 
-		if(m_DownArrowPressed)
+		if(UI()->ConsumeHotkey(CUI::HOTKEY_DOWN))
 		{
 			if(!CtrlPressed)
 			{
@@ -939,7 +939,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 				NewFilter = SelectedFilter + 1;
 			}
 		}
-		else if(m_UpArrowPressed)
+		else if(UI()->ConsumeHotkey(CUI::HOTKEY_UP))
 		{
 			if(!CtrlPressed)
 			{
@@ -1240,7 +1240,7 @@ void CMenus::RenderServerbrowserSidebar(CUIRect View)
 	View.Draw(vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f));
 
 	// handle Tab key
-	if(m_TabPressed)
+	if(UI()->ConsumeHotkey(CUI::HOTKEY_TAB))
 	{
 		if(Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT))
 		{
@@ -2099,10 +2099,9 @@ void CMenus::RenderServerbrowserBottomBox(CUIRect MainView)
 	MainView.VSplitLeft(Spacing, 0, &MainView); // little space
 	MainView.VSplitLeft(ButtonWidth, &Button, &MainView);
 	static CButtonContainer s_JoinButton;
-	if(DoButton_Menu(&s_JoinButton, Localize("Connect"), 0, &Button) || m_EnterPressed)
+	if(DoButton_Menu(&s_JoinButton, Localize("Connect"), 0, &Button) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 	{
 		Client()->Connect(GetServerBrowserAddress());
-		m_EnterPressed = false;
 	}
 }
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -634,7 +634,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	{
 		BottomView.VSplitLeft(ButtonWidth, &Button, &BottomView);
 		static CButtonContainer s_DeleteButton;
-		if(DoButton_Menu(&s_DeleteButton, Localize("Delete"), 0, &Button) || m_DeletePressed)
+		if(DoButton_Menu(&s_DeleteButton, Localize("Delete"), 0, &Button) || UI()->ConsumeHotkey(CUI::HOTKEY_DELETE))
 		{
 			if(m_DemolistSelectedIndex >= 0)
 			{

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -126,9 +126,9 @@ void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, i
 	// handle input
 	if(!pActive || *pActive)
 	{
-		if(m_pMenus->m_DownArrowPressed)
+		if(m_pUI->ConsumeHotkey(CUI::HOTKEY_DOWN))
 			m_ListBoxNewSelOffset += 1;
-		if(m_pMenus->m_UpArrowPressed)
+		if(m_pUI->ConsumeHotkey(CUI::HOTKEY_UP))
 			m_ListBoxNewSelOffset -= 1;
 	}
 
@@ -195,7 +195,7 @@ CMenus::CListboxItem CMenus::CListBox::DoNextItem(const void *pId, bool Selected
 		{
 			m_ListBoxDoneEvents = 1;
 
-			if(m_pMenus->m_EnterPressed || (s_ItemClicked && m_pInput->MouseDoubleClick()))
+			if(m_pUI->ConsumeHotkey(CUI::HOTKEY_ENTER) || (s_ItemClicked && m_pInput->MouseDoubleClick()))
 			{
 				m_ListBoxItemActivated = true;
 				m_pUI->SetActiveItem(0);

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -88,7 +88,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	TopMenu.HSplitBottom(5.0f, &TopMenu, 0); // little space
 	TopMenu.HSplitBottom(40.0f, &TopMenu, &Button);
 	static CButtonContainer s_PlayButton;
-	if(DoButton_Menu(&s_PlayButton, Localize("Play"), 0, &Button, Config()->m_ClShowStartMenuImages ? "play_game" : 0, CUIRect::CORNER_ALL, Rounding, 0.5f) || m_EnterPressed || CheckHotKey(KEY_P))
+	if(DoButton_Menu(&s_PlayButton, Localize("Play"), 0, &Button, Config()->m_ClShowStartMenuImages ? "play_game" : 0, CUIRect::CORNER_ALL, Rounding, 0.5f) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || CheckHotKey(KEY_P))
 		NewPage = Config()->m_UiBrowserPage;
 	
 	BottomMenu.HSplitTop(90.0f, 0, &BottomMenu);
@@ -96,7 +96,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 
 	BottomMenu.HSplitTop(40.0f, &Button, &TopMenu);
 	static CButtonContainer s_QuitButton;
-	if(DoButton_Menu(&s_QuitButton, Localize("Quit"), 0, &Button, 0, CUIRect::CORNER_ALL, Rounding, 0.5f) || m_EscapePressed || CheckHotKey(KEY_Q))
+	if(DoButton_Menu(&s_QuitButton, Localize("Quit"), 0, &Button, 0, CUIRect::CORNER_ALL, Rounding, 0.5f) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE) || CheckHotKey(KEY_Q))
 		m_Popup = POPUP_QUIT;
 
 	// render version

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -37,6 +37,8 @@ CUI::CUI()
 	m_LastMouseButtons = 0;
 	m_Enabled = true;
 
+	m_HotkeysPressed = 0;
+
 	m_Screen.x = 0;
 	m_Screen.y = 0;
 
@@ -73,6 +75,32 @@ bool CUI::KeyPress(int Key) const
 bool CUI::KeyIsPressed(int Key) const
 {
 	return Enabled() && Input()->KeyIsPressed(Key);
+}
+
+bool CUI::ConsumeHotkey(unsigned Hotkey)
+{
+	bool Pressed = m_HotkeysPressed&Hotkey;
+	m_HotkeysPressed &= ~Hotkey;
+	return Pressed;
+}
+
+void CUI::OnInput(const IInput::CEvent &e)
+{
+	if(e.m_Flags&IInput::FLAG_PRESS)
+	{
+		if(e.m_Key == KEY_RETURN || e.m_Key == KEY_KP_ENTER)
+			m_HotkeysPressed |= HOTKEY_ENTER;
+		else if(e.m_Key == KEY_ESCAPE)
+			m_HotkeysPressed |= HOTKEY_ESCAPE;
+		else if(e.m_Key == KEY_TAB && !Input()->KeyIsPressed(KEY_LALT) && !Input()->KeyIsPressed(KEY_RALT))
+			m_HotkeysPressed |= HOTKEY_TAB;
+		else if(e.m_Key == KEY_DELETE)
+			m_HotkeysPressed |= HOTKEY_DELETE;
+		else if(e.m_Key == KEY_UP)
+			m_HotkeysPressed |= HOTKEY_UP;
+		else if(e.m_Key == KEY_DOWN)
+			m_HotkeysPressed |= HOTKEY_DOWN;
+	}
 }
 
 void CUI::ConvertCursorMove(float *pX, float *pY, int CursorType) const

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -3,8 +3,8 @@
 #ifndef GAME_CLIENT_UI_H
 #define GAME_CLIENT_UI_H
 
+#include <engine/input.h>
 #include "ui_rect.h"
-
 
 class IScrollbarScale
 {
@@ -77,6 +77,8 @@ class CUI
 	unsigned m_MouseButtons;
 	unsigned m_LastMouseButtons;
 
+	unsigned m_HotkeysPressed;
+
 	CUIRect m_Screen;
 
 	CUIRect m_aClips[MAX_CLIP_NESTING_DEPTH];
@@ -114,6 +116,16 @@ public:
 		ALIGN_RIGHT,
 	};
 
+	enum
+	{
+		HOTKEY_ENTER = 1,
+		HOTKEY_ESCAPE = 2,
+		HOTKEY_UP = 4,
+		HOTKEY_DOWN = 8,
+		HOTKEY_DELETE = 16,
+		HOTKEY_TAB = 32,
+	};
+
 	void SetEnabled(bool Enabled) { m_Enabled = Enabled; }
 	bool Enabled() const { return m_Enabled; }
 	void Update(float MouseX, float MouseY, float MouseWorldX, float MouseWorldY);
@@ -144,6 +156,9 @@ public:
 
 	bool KeyPress(int Key) const;
 	bool KeyIsPressed(int Key) const;
+	bool ConsumeHotkey(unsigned Hotkey);
+	void ClearHotkeys() { m_HotkeysPressed = 0; }
+	void OnInput(const IInput::CEvent &e);
 
 	const CUIRect *Screen();
 	float PixelSize();


### PR DESCRIPTION
This moves handling of special hotkeys from `CMenus` to `CUI` to remove yet another dependency of the UI elements on the menus.

The `ConsumeHotkey` method will purge the flag for that particular hotkey, so this change will also prevent any potential cases of a hotkey being handled twice.