### PR TITLE
Move DoEditBox to CUI, use separate CLineInput instances for editboxes

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -21,6 +21,9 @@
 #include "chat.h"
 #include "binds.h"
 
+CChat::CChat() : m_Input(m_aInputBuf, sizeof(m_aInputBuf))
+{
+}
 
 void CChat::OnReset()
 {
@@ -208,7 +211,6 @@ void CChat::ConChatCommand(IConsole::IResult *pResult, void *pUserData)
 void CChat::OnInit()
 {
 	m_CommandManager.Init(Console());
-	m_Input.Init(Input());
 }
 
 void CChat::OnConsoleInit()

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -11,14 +11,15 @@
 
 class CChat : public CComponent
 {
-	CLineInput m_Input;
-
 	enum
 	{
 		MAX_LINES = 250,
 		MAX_CHAT_PAGES = 10,
 		MAX_LINE_LENGTH = 512,
 	};
+
+	char m_aInputBuf[MAX_LINE_LENGTH];
+	CLineInput m_Input;
 
 	struct CLine
 	{
@@ -132,6 +133,7 @@ public:
 	void ClearChatBuffer();
 	const char* GetCommandName(int Mode) const;
 
+	CChat();
 	virtual void OnInit();
 	virtual void OnReset();
 	virtual void OnMapLoad();

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -33,7 +33,7 @@ enum
 	CONSOLE_CLOSING,
 };
 
-CGameConsole::CInstance::CInstance(int Type)
+CGameConsole::CInstance::CInstance(int Type) : m_Input(m_aInputBuf, sizeof(m_aInputBuf))
 {
 	m_pHistoryEntry = 0x0;
 
@@ -63,7 +63,6 @@ CGameConsole::CInstance::CInstance(int Type)
 void CGameConsole::CInstance::Init(CGameConsole *pGameConsole)
 {
 	m_pGameConsole = pGameConsole;
-	m_Input.Init(m_pGameConsole->Input());
 };
 
 void CGameConsole::CInstance::ClearBacklog()

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -21,6 +21,7 @@ class CGameConsole : public CComponent
 		TStaticRingBuffer<char, 64*1024, CRingBufferBase::FLAG_RECYCLE> m_History;
 		char *m_pHistoryEntry;
 
+		char m_aInputBuf[256];
 		CLineInput m_Input;
 		const char *m_pName;
 		int m_Type;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -72,10 +72,6 @@ private:
 	void DoIcon(int ImageId, int SpriteId, const CUIRect *pRect, const vec4 *pColor = 0);
 	bool DoButton_GridHeader(const void *pID, const char *pText, bool Checked, CUI::EAlignment Align, const CUIRect *pRect, int Corners = CUIRect::CORNER_ALL);
 
-	bool DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden = false, int Corners = CUIRect::CORNER_ALL);
-	bool DoEditBoxUTF8(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, unsigned MaxLength, float FontSize, float *pOffset, bool Hidden = false, int Corners = CUIRect::CORNER_ALL);
-	void DoEditBoxOption(void *pID, char *pOption, unsigned OptionSize, const CUIRect *pRect, const char *pStr, float VSplitVal, float *pOffset, bool Hidden = false);
-	void DoEditBoxOptionUTF8(void *pID, char *pOption, unsigned OptionSize, unsigned OptionMaxLength, const CUIRect *pRect, const char *pStr, float VSplitVal, float *pOffset, bool Hidden = false);
 	float DoIndependentDropdownMenu(void *pID, const CUIRect *pRect, const char *pStr, float HeaderHeight, FDropdownCallback pfnCallback, bool *pActive);
 	void DoInfoBox(const CUIRect *pRect, const char *pLable, const char *pValue);
 
@@ -207,8 +203,8 @@ private:
 		float m_FooterHeight;
 		CScrollRegion m_ScrollRegion;
 		vec2 m_ScrollOffset;
+		CLineInput m_FilterInput;
 		char m_aFilterString[64];
-		float m_OffsetFilter;
 		int m_BackgroundCorners;
 
 	protected:
@@ -283,8 +279,6 @@ private:
 	bool m_MenuActive;
 	vec2 m_MousePos;
 	vec2 m_PrevMousePos;
-	bool m_CursorActive;
-	bool m_PrevCursorActive;
 	bool m_PopupActive;
 	int m_ActiveListBox;
 	int m_PopupSelection;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1140,8 +1140,8 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	Label.y += 2.0f;
 	UI()->DoLabel(&Label, Localize("Search:"), FontSize, CUI::ALIGN_LEFT);
 	EditBox.VSplitRight(EditBox.h, &EditBox, &Button);
-	static float s_ClearOffset = 0.0f;
-	if(DoEditBox(&Config()->m_BrFilterString, &EditBox, Config()->m_BrFilterString, sizeof(Config()->m_BrFilterString), FontSize, &s_ClearOffset, false, CUIRect::CORNER_L))
+	static CLineInput s_FilterInput(Config()->m_BrFilterString, sizeof(Config()->m_BrFilterString));
+	if(UI()->DoEditBox(&s_FilterInput, &EditBox, FontSize, false, CUIRect::CORNER_L))
 	{
 		Client()->ServerBrowserUpdate();
 		ServerBrowserFilterOnUpdate();
@@ -1167,16 +1167,16 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 	if(BrowserType == IServerBrowser::TYPE_INTERNET)
 	{
-		static float s_InternetAddressOffset = 0.0f;
-		if(DoEditBox(&Config()->m_UiServerAddress, &EditBox, Config()->m_UiServerAddress, sizeof(Config()->m_UiServerAddress), FontSize, &s_InternetAddressOffset, false, CUIRect::CORNER_ALL))
+		static CLineInput s_AddressInput(Config()->m_UiServerAddress, sizeof(Config()->m_UiServerAddress));
+		if(UI()->DoEditBox(&s_AddressInput, &EditBox, FontSize))
 		{
 			m_AddressSelection |= ADDR_SELECTION_CHANGE | ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND | ADDR_SELECTION_REVEAL;
 		}
 	}
 	else if(BrowserType == IServerBrowser::TYPE_LAN)
 	{
-		static float s_LanAddressOffset = 0.0f;
-		if(DoEditBox(&Config()->m_UiServerAddressLan, &EditBox, Config()->m_UiServerAddressLan, sizeof(Config()->m_UiServerAddressLan), FontSize, &s_LanAddressOffset, false, CUIRect::CORNER_ALL))
+		static CLineInput s_AddressInput(Config()->m_UiServerAddressLan, sizeof(Config()->m_UiServerAddressLan));
+		if(UI()->DoEditBox(&s_AddressInput, &EditBox, FontSize))
 		{
 			m_AddressSelection |= ADDR_SELECTION_CHANGE | ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND | ADDR_SELECTION_REVEAL;
 		}
@@ -1469,16 +1469,16 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 	Button.VSplitLeft(50.0f, &Label, &Button);
 	UI()->DoLabel(&Label, Localize("Name"), FontSize, CUI::ALIGN_LEFT);
 	static char s_aName[MAX_NAME_ARRAY_SIZE] = { 0 };
-	static float s_OffsetName = 0.0f;
-	DoEditBox(&s_aName, &Button, s_aName, sizeof(s_aName), Button.h*ms_FontmodHeight*0.8f, &s_OffsetName);
+	static CLineInput s_NameInput(s_aName, sizeof(s_aName), MAX_NAME_LENGTH);
+	UI()->DoEditBox(&s_NameInput, &Button, Button.h*ms_FontmodHeight*0.8f);
 
 	BottomArea.HSplitTop(HeaderHeight, &Button, &BottomArea);
 	BottomArea.HSplitTop(SpacingH, 0, &BottomArea);
 	Button.VSplitLeft(50.0f, &Label, &Button);
 	UI()->DoLabel(&Label, Localize("Clan"), FontSize, CUI::ALIGN_LEFT);
 	static char s_aClan[MAX_CLAN_ARRAY_SIZE] = { 0 };
-	static float s_OffsetClan = 0.0f;
-	DoEditBox(&s_aClan, &Button, s_aClan, sizeof(s_aClan), Button.h*ms_FontmodHeight*0.8f, &s_OffsetClan);
+	static CLineInput s_ClanInput(s_aClan, sizeof(s_aClan), MAX_CLAN_LENGTH);
+	UI()->DoEditBox(&s_ClanInput, &Button, Button.h*ms_FontmodHeight*0.8f);
 
 	BottomArea.HSplitTop(HeaderHeight, &Button, &BottomArea);
 	Button.Draw(vec4(1.0f, 1.0f, 1.0f, 0.25f));
@@ -1531,8 +1531,8 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 	ServerFilter.HSplitBottom(LineSize, &ServerFilter, &Button);
 	Button.VSplitLeft(60.0f, &Icon, &Button);
 	static char s_aFilterName[32] = { 0 };
-	static float s_FilterOffset = 0.0f;
-	DoEditBox(&s_FilterOffset, &Icon, s_aFilterName, sizeof(s_aFilterName), FontSize, &s_FilterOffset, false, CUIRect::CORNER_L);
+	static CLineInput s_FilterInput(s_aFilterName, sizeof(s_aFilterName));
+	UI()->DoEditBox(&s_FilterInput, &Icon, FontSize, false, CUIRect::CORNER_L);
 	Button.Draw(vec4(1.0f, 1.0f, 1.0f, 0.25f), 5.0f, CUIRect::CORNER_R);
 	Button.VSplitLeft(Button.h, &Icon, &Label);
 	Label.HMargin(2.0f, &Label);
@@ -1698,8 +1698,8 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 		ButtonLine.VSplitRight(ButtonLine.h, &EditBox, &AddIncButton);
 
 		static char s_aGametype[16] = { 0 };
-		static float s_OffsetGametype = 0.0f;
-		DoEditBox(&s_OffsetGametype, &EditBox, s_aGametype, sizeof(s_aGametype), FontSize, &s_OffsetGametype, false, CUIRect::CORNER_L);
+		static CLineInput s_GametypeInput(s_aGametype, sizeof(s_aGametype));
+		UI()->DoEditBox(&s_GametypeInput, &EditBox, FontSize, false, CUIRect::CORNER_L);
 
 		static CButtonContainer s_AddInclusiveGametype;
 		if(DoButton_Menu(&s_AddInclusiveGametype, "+", 0, &AddIncButton, 0, 0) && s_aGametype[0])
@@ -1774,9 +1774,13 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 	UI()->DoLabel(&Button, Localize("Server address:"), FontSize, CUI::ALIGN_LEFT);
 	Button.VSplitRight(60.0f, 0, &Button);
-	static float s_OffsetAddr = 0.0f;
-	if(DoEditBox(&s_OffsetAddr, &Button, FilterInfo.m_aAddress, sizeof(FilterInfo.m_aAddress), FontSize, &s_OffsetAddr))
+	static char s_aAddressFilter[sizeof(FilterInfo.m_aAddress)];
+	static CLineInput s_AddressInput(s_aAddressFilter, sizeof(s_aAddressFilter));
+	if(UI()->DoEditBox(&s_AddressInput, &Button, FontSize))
+	{
+		str_copy(FilterInfo.m_aAddress, s_aAddressFilter, sizeof(FilterInfo.m_aAddress));
 		UpdateFilter = true;
+	}
 
 	// player country
 	{

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -765,8 +765,8 @@ void CMenus::RenderServerControl(CUIRect MainView)
 				Search.VSplitLeft(TextRender()->TextWidth(FontSize, pSearchLabel, -1) + 10.0f, &Label, &Search);
 				Label.y += 2.0f;
 				UI()->DoLabel(&Label, pSearchLabel, FontSize, CUI::ALIGN_LEFT);
-				static float s_SearchOffset = 0.0f;
-				if(DoEditBox(&m_aFilterString, &Search, m_aFilterString, sizeof(m_aFilterString), FontSize, &s_SearchOffset))
+				static CLineInput s_FilterInput(m_aFilterString, sizeof(m_aFilterString));
+				if(UI()->DoEditBox(&s_FilterInput, &Search, FontSize))
 					m_CallvoteSelectedOption = 0;
 			}
 
@@ -789,8 +789,8 @@ void CMenus::RenderServerControl(CUIRect MainView)
 				Reason.VSplitLeft(TextRender()->TextWidth(FontSize, pReasonLabel, -1) + 10.0f, &Label, &Reason);
 				Label.y += 2.0f;
 				UI()->DoLabel(&Label, pReasonLabel, FontSize, CUI::ALIGN_LEFT);
-				static float s_ReasonOffset = 0.0f;
-				DoEditBox(&m_aCallvoteReason, &Reason, m_aCallvoteReason, sizeof(m_aCallvoteReason), FontSize, &s_ReasonOffset, false, CUIRect::CORNER_L);
+				static CLineInput s_ReasonInput(m_aCallvoteReason, sizeof(m_aCallvoteReason));
+				UI()->DoEditBox(&s_ReasonInput, &Reason, FontSize, false, CUIRect::CORNER_L);
 
 				// clear button
 				static CButtonContainer s_ClearButton;
@@ -852,12 +852,12 @@ void CMenus::RenderServerControl(CUIRect MainView)
 						m_pClient->m_pVoting->RconAddVoteOption(s_aVoteDescription, s_aVoteCommand);
 
 				Bottom.VSplitLeft(2*ColumnWidth+Spacing, &Button, &Bottom);
-				static float s_OffsetDesc = 0.0f;
-				DoEditBox(&s_aVoteDescription, &Button, s_aVoteDescription, sizeof(s_aVoteDescription), FontSize, &s_OffsetDesc, false, CUIRect::CORNER_ALL);
+				static CLineInput s_DescriptionInput(s_aVoteDescription, sizeof(s_aVoteDescription));
+				UI()->DoEditBox(&s_DescriptionInput, &Button, FontSize);
 
 				Bottom.VMargin(2*Spacing, &Button);
-				static float s_OffsetCmd = 0.0f;
-				DoEditBox(&s_aVoteCommand, &Button, s_aVoteCommand, sizeof(s_aVoteCommand), FontSize, &s_OffsetCmd, false, CUIRect::CORNER_ALL);
+				static CLineInput s_CommandInput(s_aVoteCommand, sizeof(s_aVoteCommand));
+				UI()->DoEditBox(&s_CommandInput, &Button, FontSize);
 			}
 		}
 	}

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -11,12 +11,11 @@
 
 #include "menus.h"
 
-CMenus::CListBox::CListBox()
+CMenus::CListBox::CListBox() : m_FilterInput(m_aFilterString, sizeof(m_aFilterString))
 {
 	m_ScrollOffset = vec2(0,0);
 	m_ListBoxUpdateScroll = false;
 	m_aFilterString[0] = '\0';
-	m_OffsetFilter = 0.0f;
 }
 
 void CMenus::CListBox::DoBegin(const CUIRect *pRect)
@@ -72,7 +71,7 @@ bool CMenus::CListBox::DoFilter(float FilterHeight, float Spacing)
 	Filter.VSplitLeft(Filter.w/5.0f, &Label, &EditBox);
 	Label.y += Spacing;
 	m_pUI->DoLabel(&Label, Localize("Search:"), FontSize, CUI::ALIGN_CENTER);
-	bool Changed = m_pMenus->DoEditBox(m_aFilterString, &EditBox, m_aFilterString, sizeof(m_aFilterString), FontSize, &m_OffsetFilter);
+	bool Changed = m_pUI->DoEditBox(&m_FilterInput, &EditBox, FontSize);
 
 	View.HSplitTop(Spacing, &Filter, &View);
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1360,13 +1360,13 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 
 		// player name
 		Name.HSplitTop(ButtonHeight, &Button, &Name);
-		static float s_OffsetName = 0.0f;
-		DoEditBoxOptionUTF8(Config()->m_PlayerName, Config()->m_PlayerName, sizeof(Config()->m_PlayerName), MAX_NAME_LENGTH, &Button, Localize("Name"),  100.0f, &s_OffsetName);
+		static CLineInput s_NameInput(Config()->m_PlayerName, sizeof(Config()->m_PlayerName), MAX_NAME_LENGTH);
+		UI()->DoEditBoxOption(&s_NameInput, &Button, Localize("Name"), 100.0f);
 
 		// player clan
 		Clan.HSplitTop(ButtonHeight, &Button, &Clan);
-		static float s_OffsetClan = 0.0f;
-		DoEditBoxOptionUTF8(Config()->m_PlayerClan, Config()->m_PlayerClan, sizeof(Config()->m_PlayerClan), MAX_CLAN_LENGTH, &Button, Localize("Clan"),  100.0f, &s_OffsetClan);
+		static CLineInput s_ClanInput(Config()->m_PlayerClan, sizeof(Config()->m_PlayerClan), MAX_CLAN_LENGTH);
+		UI()->DoEditBoxOption(&s_ClanInput, &Button, Localize("Clan"), 100.0f);
 
 		// country selector
 		Bottom.Draw(vec4(0.0f, 0.0f, 0.0f, 0.25f));

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -32,6 +32,7 @@ void CLineInput::Set(const char *pString)
 {
 	str_copy(m_pStr, pString, m_MaxSize);
 	UpdateStrData();
+	m_CursorPos = m_Len;
 }
 
 void CLineInput::Append(const char *pString)
@@ -65,7 +66,8 @@ void CLineInput::Append(const char *pString)
 void CLineInput::UpdateStrData()
 {
 	m_Len = str_length(m_pStr);
-	m_CursorPos = m_Len;
+	if(m_CursorPos < 0 || m_CursorPos > m_Len)
+		m_CursorPos = m_Len;
 	m_NumChars = 0;
 	int Offset = 0;
 	while(m_pStr[Offset])
@@ -85,10 +87,8 @@ bool CLineInput::MoveWordStop(char c)
 
 bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 {
-	if(m_pStr[0] == 0 && m_Len > 0)
-		UpdateStrData();
-	if(m_CursorPos > m_Len)
-		m_CursorPos = m_Len;
+	// update derived attributes to handle external changes to the buffer
+	UpdateStrData();
 
 	int OldCursorPos = m_CursorPos;
 

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -8,36 +8,43 @@
 // line input helter
 class CLineInput
 {
-	enum
-	{
-		MAX_SIZE=512,
-		MAX_CHARS=MAX_SIZE/4-1,
-	};
-	char m_Str[MAX_SIZE];
+	char *m_pStr;
 	int m_Len;
+	int m_MaxSize;
+	int m_MaxChars;
 	int m_CursorPos;
 	int m_NumChars;
-	IInput *m_pInput;
-public:
+	float m_ScrollOffset;
+	bool m_WasChanged;
+
+	static IInput *s_pInput;
+
+	void UpdateStrData();
 	static bool MoveWordStop(char c);
-	static bool Manipulate(IInput::CEvent e, char *pStr, int StrMaxSize, int StrMaxChars, int *pStrLenPtr, int *pCursorPosPtr, int *pNumCharsPtr, IInput *pInput);
 
-	class CCallback
-	{
-	public:
-		virtual ~CCallback() {}
-		virtual bool Event(IInput::CEvent e) = 0;
-	};
+public:
+	static void Init(IInput *pInput) { s_pInput = pInput; }
 
-	CLineInput();
-	void Init(IInput *pInput);
+	CLineInput() { SetBuffer(0, 0, 0); }
+	CLineInput(char *pStr, int MaxSize) { SetBuffer(pStr, MaxSize, MaxSize); }
+	CLineInput(char *pStr, int MaxSize, int MaxChars) { SetBuffer(pStr, MaxSize, MaxChars); }
+
+	void SetBuffer(char *pStr, int MaxSize) { SetBuffer(pStr, MaxSize, MaxSize); }
+	void SetBuffer(char *pStr, int MaxSize, int MaxChars);
+
 	void Clear();
-	bool ProcessInput(IInput::CEvent e);
+	bool ProcessInput(const IInput::CEvent &Event);
 	void Set(const char *pString);
-	const char *GetString() const { return m_Str; }
+	void Append(const char *pString);
+	const char *GetString() const { return m_pStr; }
+	int GetMaxSize() const { return m_MaxSize; }
+	int GetMaxChars() const { return m_MaxChars; }
 	int GetLength() const { return m_Len; }
 	int GetCursorOffset() const { return m_CursorPos; }
 	void SetCursorOffset(int Offset) { m_CursorPos = Offset > m_Len ? m_Len : Offset < 0 ? 0 : Offset; }
+	float GetScrollOffset() const { return m_ScrollOffset; }
+	void SetScrollOffset(float ScrollOffset) { m_ScrollOffset = ScrollOffset; }
+	bool WasChanged() { bool Changed = m_WasChanged; m_WasChanged = false; return Changed; }
 };
 
 #endif

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -4,6 +4,7 @@
 #define GAME_CLIENT_UI_H
 
 #include <engine/input.h>
+#include "lineinput.h"
 #include "ui_rect.h"
 
 class IScrollbarScale
@@ -54,7 +55,38 @@ public:
 		}
 		return round_to_int(exp(RelativeValue*(log(Max) - log(Min)) + log(Min))) + ResultAdjustment;
 	}
-} LogarithmicScrollbarScale(25);
+} const LogarithmicScrollbarScale(25);
+
+
+class IButtonColorFunction
+{
+public:
+	virtual vec4 GetColor(bool Active, bool Hovered) const = 0;
+};
+static class CDarkButtonColorFunction : public IButtonColorFunction
+{
+public:
+	vec4 GetColor(bool Active, bool Hovered) const
+	{
+		if(Active)
+			return vec4(0.15f, 0.15f, 0.15f, 0.25f);
+		else if(Hovered)
+			return vec4(0.5f, 0.5f, 0.5f, 0.25f);
+		return vec4(0.0f, 0.0f, 0.0f, 0.25f);
+	}
+} const DarkButtonColorFunction;
+static class CLightButtonColorFunction : public IButtonColorFunction
+{
+public:
+	vec4 GetColor(bool Active, bool Hovered) const
+	{
+		if(Active)
+			return vec4(1.0f, 1.0f, 1.0f, 0.4f);
+		else if(Hovered)
+			return vec4(1.0f, 1.0f, 1.0f, 0.6f);
+		return vec4(1.0f, 1.0f, 1.0f, 0.5f);
+	}
+} const LightButtonColorFunction;
 
 
 class CUI
@@ -78,6 +110,7 @@ class CUI
 	unsigned m_LastMouseButtons;
 
 	unsigned m_HotkeysPressed;
+	CLineInput *m_pActiveInput;
 
 	CUIRect m_Screen;
 
@@ -101,7 +134,7 @@ public:
 	static const float ms_FontmodHeight;
 
 	// TODO: Refactor: Fill this in
-	void Init(class CConfig *pConfig, class IGraphics *pGraphics, class IInput *pInput, class ITextRender *pTextRender) { m_pConfig = pConfig; m_pGraphics = pGraphics; m_pInput = pInput; m_pTextRender = pTextRender; CUIRect::Init(pGraphics); }
+	void Init(class CConfig *pConfig, class IGraphics *pGraphics, class IInput *pInput, class ITextRender *pTextRender);
 	class CConfig *Config() const { return m_pConfig; }
 	class IGraphics *Graphics() const { return m_pGraphics; }
 	class IInput *Input() const { return m_pInput; }
@@ -158,7 +191,8 @@ public:
 	bool KeyIsPressed(int Key) const;
 	bool ConsumeHotkey(unsigned Hotkey);
 	void ClearHotkeys() { m_HotkeysPressed = 0; }
-	void OnInput(const IInput::CEvent &e);
+	bool OnInput(const IInput::CEvent &e);
+	bool IsInputActive() const { return m_pActiveInput != 0; }
 
 	const CUIRect *Screen();
 	float PixelSize();
@@ -176,6 +210,10 @@ public:
 	// labels
 	void DoLabel(const CUIRect *pRect, const char *pText, float FontSize, EAlignment Align, float LineWidth = -1.0f, bool MultiLine = true);
 	void DoLabelHighlighted(const CUIRect *pRect, const char *pText, const char *pHighlighted, float FontSize, const vec4 &TextColor, const vec4 &HighlightColor);
+
+	// editboxes
+	bool DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, bool Hidden = false, int Corners = CUIRect::CORNER_ALL, const IButtonColorFunction *pColorFunction = &DarkButtonColorFunction);
+	void DoEditBoxOption(CLineInput *pLineInput, const CUIRect *pRect, const char *pStr, float VSplitVal, bool Hidden = false);
 
 	// scrollbars
 	float DoScrollbarV(const void *pID, const CUIRect *pRect, float Current);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -520,7 +520,7 @@ public:
 	CUI *UI() { return &m_UI; }
 	CRenderTools *RenderTools() { return &m_RenderTools; }
 
-	CEditor() : m_TilesetPicker(16, 16)
+	CEditor() : m_FileDialogFilterInput(m_aFileDialogFilterString, sizeof(m_aFileDialogFilterString)), m_TilesetPicker(16, 16)
 	{
 		m_pInput = 0;
 		m_pClient = 0;
@@ -671,10 +671,10 @@ public:
 	int m_FileDialogFileType;
 	float m_FileDialogScrollValue;
 	int m_FilesSelectedIndex;
+	CLineInput m_FileDialogFilterInput;
 	char m_aFileDialogFilterString[64];
-	char m_FileDialogNewFolderName[64];
-	char m_FileDialogErrString[64];
-	float m_FilesSearchBoxID;
+	char m_aFileDialogNewFolderName[64];
+	char m_aFileDialogErrString[64];
 	IGraphics::CTextureHandle m_FilePreviewImage;
 	bool m_PreviewImageIsLoaded;
 	CImageInfo m_FilePreviewImageInfo;
@@ -775,7 +775,7 @@ public:
 	int DoButton_Menu(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
 	int DoButton_MenuItem(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags=0, const char *pToolTip=0);
 
-	int DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *Offset, bool Hidden=false, int Corners=CUIRect::CORNER_ALL);
+	bool DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize) { return UI()->DoEditBox(pLineInput, pRect, FontSize, false, CUIRect::CORNER_ALL, &LightButtonColorFunction); }
 
 	void RenderBackground(CUIRect View, IGraphics::CTextureHandle Texture, float Size, float Brightness);
 

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -180,11 +180,12 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View)
 	if(!pEditor->GetSelectedGroup()->m_GameGroup)
 	{
 		View.HSplitBottom(5.0f, &View, &Button);
-		View.HSplitBottom(12.0f, &View, &Button);
-		static float s_Name = 0;
+		View.HSplitBottom(16.0f, &View, &Button);
 		pEditor->UI()->DoLabel(&Button, "Name:", 10.0f, CUI::ALIGN_LEFT);
 		Button.VSplitLeft(40.0f, 0, &Button);
-		if(pEditor->DoEditBox(&s_Name, &Button, pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_aName, sizeof(pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_aName), 10.0f, &s_Name))
+		static CLineInput s_NameInput;
+		s_NameInput.SetBuffer(pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_aName, sizeof(pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_aName));
+		if(pEditor->DoEditBox(&s_NameInput, &Button, 10.0f))
 			pEditor->m_Map.m_Modified = true;
 	}
 
@@ -270,11 +271,12 @@ int CEditor::PopupLayer(CEditor *pEditor, CUIRect View)
 	if(!IsGameLayer)
 	{
 		View.HSplitBottom(5.0f, &View, &Button);
-		View.HSplitBottom(12.0f, &View, &Button);
-		static float s_Name = 0;
+		View.HSplitBottom(16.0f, &View, &Button);
 		pEditor->UI()->DoLabel(&Button, "Name:", 10.0f, CUI::ALIGN_LEFT);
 		Button.VSplitLeft(40.0f, 0, &Button);
-		if(pEditor->DoEditBox(&s_Name, &Button, pCurrentLayer->m_aName, sizeof(pCurrentLayer->m_aName), 10.0f, &s_Name))
+		static CLineInput s_NameInput;
+		s_NameInput.SetBuffer(pCurrentLayer->m_aName, sizeof(pCurrentLayer->m_aName));
+		if(pEditor->DoEditBox(&s_NameInput, &Button, 10.0f))
 			pEditor->m_Map.m_Modified = true;
 	}
 
@@ -628,14 +630,14 @@ int CEditor::PopupNewFolder(CEditor *pEditor, CUIRect View)
 	View.HSplitBottom(10.0f, &View, 0);
 	View.HSplitBottom(20.0f, &View, &ButtonBar);
 
-	if(pEditor->m_FileDialogErrString[0] == 0)
+	if(pEditor->m_aFileDialogErrString[0] == 0)
 	{
 		// interaction box
 		View.HSplitBottom(40.0f, &View, 0);
 		View.VMargin(40.0f, &View);
 		View.HSplitBottom(20.0f, &View, &Label);
-		static float s_FolderBox = 0;
-		pEditor->DoEditBox(&s_FolderBox, &Label, pEditor->m_FileDialogNewFolderName, sizeof(pEditor->m_FileDialogNewFolderName), 15.0f, &s_FolderBox);
+		static CLineInput s_FolderInput(pEditor->m_aFileDialogNewFolderName, sizeof(pEditor->m_aFileDialogNewFolderName));
+		pEditor->DoEditBox(&s_FolderInput, &Label, 15.0f);
 		View.HSplitBottom(20.0f, &View, &Label);
 		pEditor->UI()->DoLabel(&Label, "Name:", 10.0f, CUI::ALIGN_LEFT);
 
@@ -646,17 +648,17 @@ int CEditor::PopupNewFolder(CEditor *pEditor, CUIRect View)
 		if(pEditor->DoButton_Editor(&s_CreateButton, "Create", 0, &Label, 0, 0))
 		{
 			// create the folder
-			if(*pEditor->m_FileDialogNewFolderName)
+			if(pEditor->m_aFileDialogNewFolderName[0])
 			{
 				char aBuf[IO_MAX_PATH_LENGTH];
-				str_format(aBuf, sizeof(aBuf), "%s/%s", pEditor->m_pFileDialogPath, pEditor->m_FileDialogNewFolderName);
+				str_format(aBuf, sizeof(aBuf), "%s/%s", pEditor->m_pFileDialogPath, pEditor->m_aFileDialogNewFolderName);
 				if(pEditor->Storage()->CreateFolder(aBuf, IStorage::TYPE_SAVE))
 				{
 					pEditor->FilelistPopulate(IStorage::TYPE_SAVE);
 					return 1;
 				}
 				else
-					str_copy(pEditor->m_FileDialogErrString, "Unable to create the folder", sizeof(pEditor->m_FileDialogErrString));
+					str_copy(pEditor->m_aFileDialogErrString, "Unable to create the folder", sizeof(pEditor->m_aFileDialogErrString));
 			}
 		}
 		ButtonBar.VSplitRight(30.0f, &ButtonBar, 0);
@@ -703,33 +705,37 @@ int CEditor::PopupMapInfo(CEditor *pEditor, CUIRect View)
 	View.HSplitTop(20.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "Author:", 10.0f, CUI::ALIGN_LEFT);
 	Label.VSplitLeft(40.0f, 0, &Button);
-	Button.HSplitTop(12.0f, &Button, 0);
-	static float s_AuthorBox = 0;
-	pEditor->DoEditBox(&s_AuthorBox, &Button, pEditor->m_Map.m_MapInfoTmp.m_aAuthor, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aAuthor), 10.0f, &s_AuthorBox);
+	Button.HSplitTop(16.0f, &Button, 0);
+	static CLineInput s_AuthorInput;
+	s_AuthorInput.SetBuffer(pEditor->m_Map.m_MapInfoTmp.m_aAuthor, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aAuthor));
+	pEditor->DoEditBox(&s_AuthorInput, &Button, 10.0f);
 
 	// version box
 	View.HSplitTop(20.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "Version:", 10.0f, CUI::ALIGN_LEFT);
 	Label.VSplitLeft(40.0f, 0, &Button);
-	Button.HSplitTop(12.0f, &Button, 0);
-	static float s_VersionBox = 0;
-	pEditor->DoEditBox(&s_VersionBox, &Button, pEditor->m_Map.m_MapInfoTmp.m_aVersion, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aVersion), 10.0f, &s_VersionBox);
+	Button.HSplitTop(16.0f, &Button, 0);
+	static CLineInput s_VersionInput;
+	s_VersionInput.SetBuffer(pEditor->m_Map.m_MapInfoTmp.m_aVersion, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aVersion));
+	pEditor->DoEditBox(&s_VersionInput, &Button, 10.0f);
 
 	// credits box
 	View.HSplitTop(20.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "Credits:", 10.0f, CUI::ALIGN_LEFT);
 	Label.VSplitLeft(40.0f, 0, &Button);
-	Button.HSplitTop(12.0f, &Button, 0);
-	static float s_CreditsBox = 0;
-	pEditor->DoEditBox(&s_CreditsBox, &Button, pEditor->m_Map.m_MapInfoTmp.m_aCredits, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aCredits), 10.0f, &s_CreditsBox);
+	Button.HSplitTop(16.0f, &Button, 0);
+	static CLineInput s_CreditsInput;
+	s_CreditsInput.SetBuffer(pEditor->m_Map.m_MapInfoTmp.m_aCredits, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aCredits));
+	pEditor->DoEditBox(&s_CreditsInput, &Button, 10.0f);
 
 	// license box
 	View.HSplitTop(20.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "License:", 10.0f, CUI::ALIGN_LEFT);
 	Label.VSplitLeft(40.0f, 0, &Button);
-	Button.HSplitTop(12.0f, &Button, 0);
-	static float s_LicenseBox = 0;
-	pEditor->DoEditBox(&s_LicenseBox, &Button, pEditor->m_Map.m_MapInfoTmp.m_aLicense, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aLicense), 10.0f, &s_LicenseBox);
+	Button.HSplitTop(16.0f, &Button, 0);
+	static CLineInput s_LicenseInput;
+	s_LicenseInput.SetBuffer(pEditor->m_Map.m_MapInfoTmp.m_aLicense, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aLicense));
+	pEditor->DoEditBox(&s_LicenseInput, &Button, 10.0f);
 
 	// button bar
 	ButtonBar.VSplitLeft(30.0f, 0, &ButtonBar);


### PR DESCRIPTION
Consolidate editboxes of menus and editor in `CUI` to get rid of duplicated code and the usage of `CLineInput::Manipulate`.

Add a `IButtonColorFunction` interface to allow editboxes in editor to look the same as before. 

Most `CLineInput` instances are initialized with their buffers once using the constructor, but some have dynamic buffer locations which must be set using `SetBuffer`.