### PR TITLE
Add max_count parameter to str_utf8_stats

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2705,20 +2705,17 @@ void str_utf8_copy_num(char *dst, const char *src, int dst_size, int num)
 	str_copy(dst, src, cursor < dst_size ? cursor+1 : dst_size);
 }
 
-void str_utf8_stats(const char *str, int max_size, int *size, int *count)
+void str_utf8_stats(const char *str, int max_size, int max_count, int *size, int *count)
 {
 	*size = 0;
 	*count = 0;
-	while(str[*size] && *size < max_size)
+	while(*size < max_size && *count < max_count)
 	{
 		int new_size = str_utf8_forward(str, *size);
-		if(new_size != *size)
-		{
-			if(new_size >= max_size)
-				break;
-			*size = new_size;
-			++(*count);
-		}
+		if(new_size == *size || new_size >= max_size || *count >= max_count)
+			break;
+		*size = new_size;
+		++(*count);
 	}
 }
 

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2712,7 +2712,7 @@ void str_utf8_stats(const char *str, int max_size, int max_count, int *size, int
 	while(*size < max_size && *count < max_count)
 	{
 		int new_size = str_utf8_forward(str, *size);
-		if(new_size == *size || new_size >= max_size || *count >= max_count)
+		if(new_size == *size || new_size >= max_size)
 			break;
 		*size = new_size;
 		++(*count);

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1748,19 +1748,20 @@ void str_utf8_copy_num(char *dst, const char *src, int dst_size, int num);
 
 /*
 	Function: str_utf8_stats
-		Determines the byte size and utf8 character count of a string.
+		Determines the byte size and utf8 character count of a utf8 string.
 
 	Parameters:
 		str - Pointer to the string.
 		max_size - Maximum number of bytes to count.
+		max_count - Maximum number of utf8 characters to count.
 		size - Pointer to store size (number of non-zero bytes) of the string.
 		count - Pointer to store count of utf8 characters of the string.
 
 	Remarks:
-		- Assumes nothing about the encoding of the string.
-		  It's the users responsibility to make sure the bounds are aligned.
+		- The string is treated as zero-terminated utf8 string.
+		- It's the user's responsibility to make sure the bounds are aligned.
 */
-void str_utf8_stats(const char *str, int max_size, int *size, int *count);
+void str_utf8_stats(const char *str, int max_size, int max_count, int *size, int *count);
 
 /*
 	Function: secure_random_init

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -129,31 +129,35 @@ TEST(Str, Utf8Stats)
 {
 	int Size, Count;
 
-	str_utf8_stats("abc", 4, &Size, &Count);
+	str_utf8_stats("abc", 4, 3, &Size, &Count);
 	EXPECT_EQ(Size, 3);
 	EXPECT_EQ(Count, 3);
 
-	str_utf8_stats("abc", 2, &Size, &Count);
+	str_utf8_stats("abc", 2, 3, &Size, &Count);
 	EXPECT_EQ(Size, 1);
 	EXPECT_EQ(Count, 1);
 
-	str_utf8_stats("", 1, &Size, &Count);
+	str_utf8_stats("", 1, 0, &Size, &Count);
 	EXPECT_EQ(Size, 0);
 	EXPECT_EQ(Count, 0);
 
-	str_utf8_stats("abcde", 6, &Size, &Count);
+	str_utf8_stats("abcde", 6, 5, &Size, &Count);
 	EXPECT_EQ(Size, 5);
 	EXPECT_EQ(Count, 5);
 
-	str_utf8_stats("любовь", 13, &Size, &Count);
+	str_utf8_stats("любовь", 13, 6, &Size, &Count);
 	EXPECT_EQ(Size, 12);
 	EXPECT_EQ(Count, 6);
 
-	str_utf8_stats("abc愛", 7, &Size, &Count);
+	str_utf8_stats("abc愛", 7, 4, &Size, &Count);
 	EXPECT_EQ(Size, 6);
 	EXPECT_EQ(Count, 4);
 
-	str_utf8_stats("abc愛", 6, &Size, &Count);
+	str_utf8_stats("abc愛", 6, 4, &Size, &Count);
 	EXPECT_EQ(Size, 3);
+	EXPECT_EQ(Count, 3);
+
+	str_utf8_stats("любовь", 13, 3, &Size, &Count);
+	EXPECT_EQ(Size, 6);
 	EXPECT_EQ(Count, 3);
 }


### PR DESCRIPTION
This will be used by the new text editing support to fix UTF8 inputs not being limited to the maximum number of characters (e.g. the name/clan input when adding a friend accepts ASCII-only names longer than otherwise supported, temporarily breaking the friend menu).