### PR TITLE
Add cancel button to flag picker popup, also confirm popup by activating listbox

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1688,7 +1688,7 @@ void CMenus::RenderMenu(CUIRect Screen)
 			}
 
 			static CButtonContainer s_OkButton;
-			if(DoButton_Menu(&s_OkButton, Localize("Ok"), 0, &OkButton) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+			if(DoButton_Menu(&s_OkButton, Localize("Ok"), 0, &OkButton) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || s_ListBox.WasItemActivated())
 			{
 				(this->*m_aPopupButtons[BUTTON_CONFIRM].m_pfnCallback)();
 				m_Popup = POPUP_NONE;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1677,8 +1677,6 @@ void CMenus::RenderMenu(CUIRect Screen)
 			if(OldSelected != NewSelected)
 				m_PopupCountrySelection = m_pClient->m_pCountryFlags->GetByIndex(NewSelected, true)->m_CountryCode;
 
-			Part.VMargin(120.0f, &Part);
-
 			static CButtonContainer s_ButtonCountry;
 			if(DoButton_Menu(&s_ButtonCountry, Localize("Ok"), 0, &BottomBar) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 			{

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -93,7 +93,7 @@ CMenus::CMenus()
 
 	m_ActiveListBox = ACTLB_NONE;
 
-	m_PopupSelection = -2;
+	m_PopupCountrySelection = -2;
 }
 
 float CMenus::CButtonContainer::GetFade(bool Checked, float Seconds)
@@ -1234,7 +1234,7 @@ void CMenus::PopupConfirm(const char *pTitle, const char *pMessage, const char *
 
 void CMenus::PopupCountry(int Selection, FPopupButtonCallback pfnOkButtonCallback)
 {
-	m_PopupSelection = Selection;
+	m_PopupCountrySelection = Selection;
 	m_aPopupButtons[BUTTON_CONFIRM].m_NextPopup = POPUP_NONE;
 	m_aPopupButtons[BUTTON_CONFIRM].m_pfnCallback = pfnOkButtonCallback;
 	m_Popup = POPUP_COUNTRY;
@@ -1639,7 +1639,7 @@ void CMenus::RenderMenu(CUIRect Screen)
 				const CCountryFlags::CCountryFlag *pEntry = m_pClient->m_pCountryFlags->GetByIndex(i);
 				if(pEntry->m_Blocked)
 					continue;
-				if(pEntry->m_CountryCode == m_PopupSelection)
+				if(pEntry->m_CountryCode == m_PopupCountrySelection)
 					OldSelected = i;
 
 				CListboxItem Item = s_ListBox.DoNextItem(pEntry, OldSelected == i);
@@ -1675,7 +1675,7 @@ void CMenus::RenderMenu(CUIRect Screen)
 
 			const int NewSelected = s_ListBox.DoEnd();
 			if(OldSelected != NewSelected)
-				m_PopupSelection = m_pClient->m_pCountryFlags->GetByIndex(NewSelected, true)->m_CountryCode;
+				m_PopupCountrySelection = m_pClient->m_pCountryFlags->GetByIndex(NewSelected, true)->m_CountryCode;
 
 			Part.VMargin(120.0f, &Part);
 
@@ -1688,7 +1688,7 @@ void CMenus::RenderMenu(CUIRect Screen)
 
 			if(UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 			{
-				m_PopupSelection = -2;
+				m_PopupCountrySelection = -2;
 				m_Popup = POPUP_NONE;
 			}
 		}

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1677,16 +1677,20 @@ void CMenus::RenderMenu(CUIRect Screen)
 			if(OldSelected != NewSelected)
 				m_PopupCountrySelection = m_pClient->m_pCountryFlags->GetByIndex(NewSelected, true)->m_CountryCode;
 
-			static CButtonContainer s_ButtonCountry;
-			if(DoButton_Menu(&s_ButtonCountry, Localize("Ok"), 0, &BottomBar) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+			CUIRect OkButton, CancelButton;
+			BottomBar.VSplitMid(&CancelButton, &OkButton, SpacingW);
+
+			static CButtonContainer s_CancelButton;
+			if(DoButton_Menu(&s_CancelButton, Localize("Cancel"), 0, &CancelButton) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 			{
-				(this->*m_aPopupButtons[BUTTON_CONFIRM].m_pfnCallback)();
+				m_PopupCountrySelection = -2;
 				m_Popup = POPUP_NONE;
 			}
 
-			if(UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+			static CButtonContainer s_OkButton;
+			if(DoButton_Menu(&s_OkButton, Localize("Ok"), 0, &OkButton) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 			{
-				m_PopupCountrySelection = -2;
+				(this->*m_aPopupButtons[BUTTON_CONFIRM].m_pfnCallback)();
 				m_Popup = POPUP_NONE;
 			}
 		}

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -287,7 +287,7 @@ private:
 	bool m_PrevCursorActive;
 	bool m_PopupActive;
 	int m_ActiveListBox;
-	int m_PopupSelection;
+	int m_PopupCountrySelection;
 	bool m_SkinModified;
 	bool m_KeyReaderWasActive;
 	bool m_KeyReaderIsActive;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -747,8 +747,8 @@ void CMenus::PopupConfirmCountryFilter()
 	CServerFilterInfo FilterInfo;
 	pFilter->GetFilter(&FilterInfo);
 
-	if(m_PopupSelection != -2)
-		FilterInfo.m_Country = m_PopupSelection;
+	if(m_PopupCountrySelection != -2)
+		FilterInfo.m_Country = m_PopupCountrySelection;
 
 	pFilter->SetFilter(&FilterInfo);
 }

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2159,8 +2159,8 @@ void CMenus::ResetSettingsSound()
 
 void CMenus::PopupConfirmPlayerCountry()
 {
-	if(m_PopupSelection != -2)
-		Config()->m_PlayerCountry = m_PopupSelection;
+	if(m_PopupCountrySelection != -2)
+		Config()->m_PlayerCountry = m_PopupCountrySelection;
 }
 
 void CMenus::RenderSettings(CUIRect MainView)


### PR DESCRIPTION
- Add "Cancel" button to country (flag) picker popup. It's already possible to cancel with the Escape key, so there should also be a button, which keeps the current selection.
- Delegate the listbox activation (enter / double click on item) to the popup to confirm it. Enter was probably previously working but then broken by recent logic that ensures that every hotkey is only consumed once. Now both enter and double click confirm the popup.
- Refactoring: rename `m_PopupSelection` to `m_PopupCountrySelection` to make it easier to understand its purpose.
- Refactoring: remove dedundant VMargin on CUIRects which were not used anymore.