### PR TITLE
Fix default filter initialization, fix potential OOB access to filter array

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -630,17 +630,17 @@ private:
 	static CColumn ms_aBrowserCols[NUM_BROWSER_COLS];
 	static CColumn ms_aDemoCols[NUM_DEMO_COLS];
 
-	CBrowserFilter* GetSelectedBrowserFilter()
+	CBrowserFilter *GetSelectedBrowserFilter()
 	{
 		const int Tab = ServerBrowser()->GetType();
-		if(m_aSelectedFilters[Tab] == -1)
+		if(m_aSelectedFilters[Tab] < 0 || m_aSelectedFilters[Tab] >= m_lFilters.size())
 			return 0;
 		return &m_lFilters[m_aSelectedFilters[Tab]];
 	}
 
-	const CServerInfo* GetSelectedServerInfo()
+	const CServerInfo *GetSelectedServerInfo()
 	{
-		CBrowserFilter* pSelectedFilter = GetSelectedBrowserFilter();
+		CBrowserFilter *pSelectedFilter = GetSelectedBrowserFilter();
 		if(!pSelectedFilter)
 			return 0;
 		const int Tab = ServerBrowser()->GetType();

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -408,7 +408,12 @@ void CMenus::InitDefaultFilters()
 		m_lFilters.add(CBrowserFilter(CBrowserFilter::FILTER_ALL, Localize("All"), ServerBrowser()));
 	// expand the all filter tab by default
 	if(UseDefaultFilters)
-		m_lFilters[m_lFilters.size()-1].Switch();
+	{
+		const int AllFilterIndex = m_lFilters.size()-1;
+		for(unsigned i = 0; i < IServerBrowser::NUM_TYPES; ++i)
+			m_aSelectedFilters[i] = AllFilterIndex; // default to "all" if not set
+		m_lFilters[AllFilterIndex].Switch();
+	}
 }
 
 // 1 = browser entry click, 2 = server info click


### PR DESCRIPTION
- Make sure `GetSelectedBrowserFilter` does not access out of bounds.
- Initialize `m_aSelectedFilters` when loading default filters (i.e. when no filters exist yet).

Closes #2967.