### PR TITLE
CCamera no longer snaps back to the main-menu position of settings after leaving game

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -138,10 +138,10 @@ void CCamera::OnRender()
 
 void CCamera::ChangePosition(int PositionNumber)
 {
-	if (m_pClient->Client()->State() == IClient::STATE_ONLINE)
+	if(m_pClient->Client()->State() == IClient::STATE_ONLINE)
 		return; //Do not change Main Menu Camera Positions while we are changing settings in-game
 
-	if (PositionNumber < 0 || PositionNumber > NUM_POS - 1)
+	if(PositionNumber < 0 || PositionNumber > NUM_POS-1)
 		return;
 
 	m_AnimationStartPos = m_Center;

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -138,8 +138,12 @@ void CCamera::OnRender()
 
 void CCamera::ChangePosition(int PositionNumber)
 {
-	if(PositionNumber < 0 || PositionNumber > NUM_POS-1)
+	if (m_pClient->Client()->State() == IClient::STATE_ONLINE)
+		return; //Do not change Main Menu Camera Positions while we are changing settings in-game
+
+	if (PositionNumber < 0 || PositionNumber > NUM_POS - 1)
 		return;
+
 	m_AnimationStartPos = m_Center;
 	m_RotationCenter = m_Positions[PositionNumber];
 	m_CurrentPosition = PositionNumber;


### PR DESCRIPTION
Currently after you enter a game and change between setting menus ingame, the positions for main menu camera are changed, which causes the camera to rapidly snap back to the (newly)set position after exiting the game instead of going to the position declared for the server browser.

And while snapping back to the main menu position after leaving the game may seem kind of interesting, the fact that you get to see the Out of Bounds area of the background map while "snapping back" makes me believe this is an oversight rather than intended behaviour.