### PR TITLE
Fix size of labeled scrollbar handle

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -498,7 +498,7 @@ float CUI::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 	pRect->VMargin(5.0f, &Rail);
 
 	CUIRect Handle;
-	Rail.HSplitTop(clamp(33.0f, Rail.w, Rail.h / 8.0f), &Handle, 0);
+	Rail.HSplitTop(clamp(33.0f, Rail.w, Rail.h / 3.0f), &Handle, 0);
 	Handle.y += (Rail.h - Handle.h) * Current;
 
 	// logic
@@ -560,7 +560,7 @@ float CUI::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current)
 	pRect->HMargin(5.0f, &Rail);
 
 	CUIRect Handle;
-	Rail.VSplitLeft(clamp(33.0f, Rail.h, Rail.w / 8.0f), &Handle, 0);
+	Rail.VSplitLeft(clamp(33.0f, Rail.h, Rail.w / 3.0f), &Handle, 0);
 	Handle.x += (Rail.w - Handle.w) * Current;
 
 	// logic


### PR DESCRIPTION
Before:

![scroll_old](https://user-images.githubusercontent.com/23437060/145593435-8e2f3813-a3c4-4ac8-9d7a-7c9b99be0940.png)

Currently (regression from #2993):

![scroll_broken](https://user-images.githubusercontent.com/23437060/145593445-143012af-b1df-4b93-8f43-fea8723c9e35.png)

After:
![scroll_new](https://user-images.githubusercontent.com/23437060/145593414-37811bef-a53e-4369-8de6-6f9f177b7657.png)
