### PR TITLE
Implement tooltips that fade in on hovering

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1799,6 +1799,7 @@ void CMenus::OnRender()
 
 		if(IsActive())
 		{
+			UI()->RenderTooltip();
 			RenderTools()->RenderCursor(MouseX, MouseY, 24.0f);
 
 			// render debug information

--- a/src/game/client/components/menus_callback.cpp
+++ b/src/game/client/components/menus_callback.cpp
@@ -204,6 +204,7 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 				str_format(aBuf, sizeof(aBuf), "Joystick %d: %s", Input()->GetActiveJoystick()->GetIndex(), Input()->GetActiveJoystick()->GetName());
 				if(DoButton_Menu(&s_ButtonJoystickId, aBuf, 0, &Button))
 					m_pClient->Input()->SelectNextJoystick();
+				UI()->DoTooltip(&s_ButtonJoystickId, &Button, Localize("Click to cycle through all available joysticks."));
 			}
 
 			{

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -121,7 +121,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		str_format(aBuffer, sizeof(aBuffer), "%d:%02d / %d:%02d",
 			CurrentTick/SERVER_TICK_SPEED/60, (CurrentTick/SERVER_TICK_SPEED)%60,
 			TotalTicks/SERVER_TICK_SPEED/60, (TotalTicks/SERVER_TICK_SPEED)%60);
-		UI()->DoLabel(&SeekBar, aBuffer, SeekBar.h*0.70f, TEXTALIGN_CENTER);
+		UI()->DoLabel(&SeekBar, aBuffer, SeekBar.h*0.70f, TEXTALIGN_MC);
 
 		// do the logic
 		if(UI()->CheckActiveItem(&s_PrevAmount))
@@ -151,6 +151,13 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 				s_PausedBeforeSeeking = pInfo->m_Paused;
 				if(!pInfo->m_Paused)
 					DemoPlayer()->Pause();
+			}
+			else
+			{
+				int HoveredTick = (int)(clamp((UI()->MouseX()-SeekBar.x-Rounding)/(float)(SeekBar.w-2*Rounding), 0.0f, 1.0f)*TotalTicks);
+				str_format(aBuffer, sizeof(aBuffer), "%d:%02d",
+					HoveredTick/SERVER_TICK_SPEED/60, (HoveredTick/SERVER_TICK_SPEED)%60);
+				UI()->DoTooltip(&s_PrevAmount, &SeekBar, aBuffer);
 			}
 		}
 

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -131,6 +131,10 @@ class CUI
 	unsigned m_NumClips;
 	void UpdateClipping();
 
+	const void *m_pActiveTooltip;
+	CUIRect m_TooltipAnchor;
+	char m_aTooltipText[256];
+
 	class
 	{
 	public:
@@ -146,6 +150,8 @@ class CUI
 	class IGraphics *m_pGraphics;
 	class IInput *m_pInput;
 	class ITextRender *m_pTextRender;
+
+	void ApplyCursorAlign(class CTextCursor *pCursor, const CUIRect *pRect, int Align);
 
 public:
 	static const vec4 ms_DefaultTextColor;
@@ -237,6 +243,10 @@ public:
 	float DoScrollbarH(const void *pID, const CUIRect *pRect, float Current);
 	void DoScrollbarOption(const void *pID, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, const IScrollbarScale *pScale = &LinearScrollbarScale, bool Infinite = false);
 	void DoScrollbarOptionLabeled(const void *pID, int *pOption, const CUIRect *pRect, const char *pStr, const char *apLabels[], int NumLabels, const IScrollbarScale *pScale = &LinearScrollbarScale);
+
+	// tooltips
+	void DoTooltip(const void *pID, const CUIRect *pRect, const char *pText);
+	void RenderTooltip();
 
 	// popup menu
 	void DoPopupMenu(int X, int Y, int Width, int Height, void *pContext, bool (*pfnFunc)(void *pContext, CUIRect View), int Corners = CUIRect::CORNER_ALL);


### PR DESCRIPTION
Add tooltips for the server browser icons and buttons, the demo seekbar
and the joystick selection button.

![grafik](https://user-images.githubusercontent.com/23437060/145594001-5a2b471b-f725-4413-94bc-83aaf1ad8267.png)

![grafik](https://user-images.githubusercontent.com/23437060/145594030-2812d7d6-e011-4bbe-a0ce-83c3ce518856.png)

![grafik](https://user-images.githubusercontent.com/23437060/145594123-fd6d3be2-12fb-405f-aff5-6f33884833de.png)

![grafik](https://user-images.githubusercontent.com/23437060/145594159-c73f23a6-0c07-417d-9725-deafb6f1a905.png)

Closes #1834.