### PR TITLE
Fix UTF-8 chat input, improve chat input scrolling, refactoring

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -21,8 +21,10 @@
 #include "chat.h"
 #include "binds.h"
 
-CChat::CChat() : m_Input(m_aInputBuf, sizeof(m_aInputBuf))
+CChat::CChat()
 {
+	m_aInputBuf[0] = '\0';
+	m_Input.SetBuffer(m_aInputBuf, sizeof(m_aInputBuf));
 }
 
 void CChat::OnReset()

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -51,9 +51,6 @@ class CChat : public CComponent
 	int m_LastWhisperFrom;
 	bool m_Show;
 	int m_BacklogPage;
-	bool m_InputUpdate;
-	int m_ChatStringOffset;
-	int m_OldChatStringLength;
 	int m_CompletionChosen;
 	int m_CompletionFav;
 	char m_aCompletionBuffer[256];

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -33,7 +33,7 @@ enum
 	CONSOLE_CLOSING,
 };
 
-CGameConsole::CInstance::CInstance(int Type) : m_Input(m_aInputBuf, sizeof(m_aInputBuf))
+CGameConsole::CInstance::CInstance(int Type)
 {
 	m_pHistoryEntry = 0x0;
 
@@ -58,6 +58,8 @@ CGameConsole::CInstance::CInstance(int Type) : m_Input(m_aInputBuf, sizeof(m_aIn
 	m_CompletionRenderOffset = 0.0f;
 
 	m_IsCommand = false;
+	m_aInputBuf[0] = '\0';
+	m_Input.SetBuffer(m_aInputBuf, sizeof(m_aInputBuf));
 }
 
 void CGameConsole::CInstance::Init(CGameConsole *pGameConsole)

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -499,21 +499,9 @@ void CGameConsole::OnRender()
 		s_Cursor.Reset();
 		s_Cursor.m_MaxWidth = Screen.w - 10.0f - x;
 		TextRender()->TextDeferred(&s_Cursor, aInputString, -1);
-		int Lines = s_Cursor.LineCount();
-		
-		y -= (Lines - 1) * FontSize;
+		y -= (s_Cursor.LineCount() - 1) * FontSize;
 		s_Cursor.MoveTo(x, y);
-
-		static CTextCursor s_MarkerCursor;
-		s_MarkerCursor.Reset();
-		s_MarkerCursor.m_FontSize = FontSize;
-		TextRender()->TextDeferred(&s_MarkerCursor, "|", -1);
-		s_MarkerCursor.m_Align = TEXTALIGN_CENTER;
-		vec2 MarkerPosition = TextRender()->CaretPosition(&s_Cursor, pConsole->m_Input.GetCursorOffset());
-		s_MarkerCursor.MoveTo(MarkerPosition);
-
-		TextRender()->DrawTextOutlined(&s_Cursor);
-		TextRender()->DrawTextOutlined(&s_MarkerCursor);
+		pConsole->m_Input.Render(&s_Cursor, true);
 
 		// render possible commands
 		if(m_ConsoleType == CONSOLETYPE_LOCAL || Client()->RconAuthed())

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -202,8 +202,8 @@ private:
 		float m_FooterHeight;
 		CScrollRegion m_ScrollRegion;
 		vec2 m_ScrollOffset;
-		CLineInput m_FilterInput;
 		char m_aFilterString[64];
+		CLineInput m_FilterInput;
 		int m_BackgroundCorners;
 
 	protected:

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -11,11 +11,12 @@
 
 #include "menus.h"
 
-CMenus::CListBox::CListBox() : m_FilterInput(m_aFilterString, sizeof(m_aFilterString))
+CMenus::CListBox::CListBox()
 {
 	m_ScrollOffset = vec2(0,0);
 	m_ListBoxUpdateScroll = false;
 	m_aFilterString[0] = '\0';
+	m_FilterInput.SetBuffer(m_aFilterString, sizeof(m_aFilterString));
 }
 
 void CMenus::CListBox::DoBegin(const CUIRect *pRect)

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -5,25 +5,29 @@
 
 #include <engine/input.h>
 
-// line input helter
+// line input helper
 class CLineInput
 {
 	char *m_pStr;
-	int m_Len;
 	int m_MaxSize;
 	int m_MaxChars;
-	int m_CursorPos;
+	int m_Len;
 	int m_NumChars;
+
+	int m_CursorPos;
+
 	float m_ScrollOffset;
+
 	bool m_WasChanged;
 
-	static IInput *s_pInput;
+	static class IInput *s_pInput;
+	static class ITextRender *s_pTextRender;
 
 	void UpdateStrData();
 	static bool MoveWordStop(char c);
 
 public:
-	static void Init(IInput *pInput) { s_pInput = pInput; }
+	static void Init(class IInput *pInput, class ITextRender *pTextRender) { s_pInput = pInput; s_pTextRender = pTextRender; }
 
 	CLineInput() { SetBuffer(0, 0, 0); }
 	CLineInput(char *pStr, int MaxSize) { SetBuffer(pStr, MaxSize, MaxSize); }
@@ -33,18 +37,26 @@ public:
 	void SetBuffer(char *pStr, int MaxSize, int MaxChars);
 
 	void Clear();
-	bool ProcessInput(const IInput::CEvent &Event);
 	void Set(const char *pString);
 	void Append(const char *pString);
+
 	const char *GetString() const { return m_pStr; }
 	int GetMaxSize() const { return m_MaxSize; }
 	int GetMaxChars() const { return m_MaxChars; }
 	int GetLength() const { return m_Len; }
+	int GetNumChars() const { return m_NumChars; }
+
 	int GetCursorOffset() const { return m_CursorPos; }
 	void SetCursorOffset(int Offset) { m_CursorPos = Offset > m_Len ? m_Len : Offset < 0 ? 0 : Offset; }
+
+	// used either for vertical or horizontal scrolling
 	float GetScrollOffset() const { return m_ScrollOffset; }
 	void SetScrollOffset(float ScrollOffset) { m_ScrollOffset = ScrollOffset; }
+
+	bool ProcessInput(const IInput::CEvent &Event);
 	bool WasChanged() { bool Changed = m_WasChanged; m_WasChanged = false; return Changed; }
+
+	void Render(class CTextCursor *pCursor, bool Active);
 };
 
 #endif

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -29,9 +29,9 @@ class CLineInput
 public:
 	static void Init(class IInput *pInput, class ITextRender *pTextRender) { s_pInput = pInput; s_pTextRender = pTextRender; }
 
-	CLineInput() { SetBuffer(0, 0, 0); }
-	CLineInput(char *pStr, int MaxSize) { SetBuffer(pStr, MaxSize, MaxSize); }
-	CLineInput(char *pStr, int MaxSize, int MaxChars) { SetBuffer(pStr, MaxSize, MaxChars); }
+	CLineInput() : m_pStr(0) { SetBuffer(0, 0, 0); }
+	CLineInput(char *pStr, int MaxSize) : m_pStr(0)  { SetBuffer(pStr, MaxSize, MaxSize); }
+	CLineInput(char *pStr, int MaxSize, int MaxChars) : m_pStr(0)  { SetBuffer(pStr, MaxSize, MaxChars); }
 
 	void SetBuffer(char *pStr, int MaxSize) { SetBuffer(pStr, MaxSize, MaxSize); }
 	void SetBuffer(char *pStr, int MaxSize, int MaxChars);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -520,7 +520,7 @@ public:
 	CUI *UI() { return &m_UI; }
 	CRenderTools *RenderTools() { return &m_RenderTools; }
 
-	CEditor() : m_FileDialogFilterInput(m_aFileDialogFilterString, sizeof(m_aFileDialogFilterString)), m_TilesetPicker(16, 16)
+	CEditor() : m_TilesetPicker(16, 16)
 	{
 		m_pInput = 0;
 		m_pClient = 0;
@@ -545,6 +545,8 @@ public:
 		m_PopupEventWasActivated = false;
 
 		m_FileDialogStorageType = 0;
+		m_aFileDialogFilterString[0] = '\0';
+		m_FileDialogFilterInput.SetBuffer(m_aFileDialogFilterString, sizeof(m_aFileDialogFilterString));
 		m_pFileDialogTitle = 0;
 		m_pFileDialogButtonText = 0;
 		m_pFileDialogUser = 0;
@@ -671,8 +673,8 @@ public:
 	int m_FileDialogFileType;
 	float m_FileDialogScrollValue;
 	int m_FilesSelectedIndex;
-	CLineInput m_FileDialogFilterInput;
 	char m_aFileDialogFilterString[64];
+	CLineInput m_FileDialogFilterInput;
 	char m_aFileDialogNewFolderName[64];
 	char m_aFileDialogErrString[64];
 	IGraphics::CTextureHandle m_FilePreviewImage;


### PR DESCRIPTION
Implement chat input scrolling with clipping instead of string offset, fixing handling of unicode.

Consolidate caret rendering in CLineInput. 
Change cursor to actual caret symbol instead of pipe.

Closes #2809. Closes #2662.

Also fixes undefined behavior when setting the initial lineinput buffer:

- Initialize `m_pStr` to zero in constructor initializer list before calling `SetBuffer`.
- Do not initialize `CLineInput` in the constructor initializer list, to ensure that the buffer is zero-terminated before calling `SetBuffer` explicitly.