### PR TITLE
Fix some popup menus immediately being closed

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -725,9 +725,10 @@ void CUI::DoPopupMenu(int X, int Y, int Width, int Height, void *pContext, bool 
 	m_aPopupMenus[m_NumPopupMenus].m_Rect.y = Y;
 	m_aPopupMenus[m_NumPopupMenus].m_Rect.w = Width;
 	m_aPopupMenus[m_NumPopupMenus].m_Rect.h = Height;
+	m_aPopupMenus[m_NumPopupMenus].m_Corners = Corners;
 	m_aPopupMenus[m_NumPopupMenus].m_pContext = pContext;
 	m_aPopupMenus[m_NumPopupMenus].m_pfnFunc = pfnFunc;
-	m_aPopupMenus[m_NumPopupMenus].m_Corners = Corners;
+	m_aPopupMenus[m_NumPopupMenus].m_New = true;
 	m_NumPopupMenus++;
 }
 
@@ -753,7 +754,9 @@ void CUI::RenderPopupMenus()
 
 		if(m_aPopupMenus[i].m_pfnFunc(m_aPopupMenus[i].m_pContext, PopupRect))
 			m_NumPopupMenus = i; // close this popup and all above it
-		if(Active && ((!Inside && s_MousePressed && !MousePressed) || ConsumeHotkey(HOTKEY_ESCAPE)))
+		else if(m_aPopupMenus[i].m_New)
+			m_aPopupMenus[i].m_New = false; // prevent popup from being closed by the click that opens it
+		else if(Active && ((!Inside && s_MousePressed && !MousePressed) || ConsumeHotkey(HOTKEY_ESCAPE)))
 			m_NumPopupMenus--; // close top-most popup by clicking outside and with escape
 	}
 

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -138,6 +138,7 @@ class CUI
 		int m_Corners;
 		void *m_pContext;
 		bool (*m_pfnFunc)(void *pContext, CUIRect View); // returns true to close popup
+		bool m_New;
 	} m_aPopupMenus[MAX_POPUP_MENUS];
 	unsigned m_NumPopupMenus;
 


### PR DESCRIPTION
The editor File popup as well as the New folder and Map details popups were immediately getting closed by the same click that opens them. This is fixed by adding a flag to prevent popups from being closed by clicking and hotkeys on the first frame that they are rendered. This also prevents the popups from being closed by the user at the same time as a popup closes itself, which would previously close a popup below in the stack and potentially result in `m_NumPopupMenus` being `-1`.