### PR TITLE
Ensure zero-termination inside of fs_getcwd, assert correct buffer sizes in system functions

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1419,8 +1419,15 @@ int fs_chdir(const char *path);
 	Function: fs_getcwd
 		Gets the current working directory.
 
+	Parameters:
+		buffer - Pointer to a buffer that will hold the result.
+		buffer_size - The size of the buffer in bytes.
+
 	Returns:
 		Returns a pointer to the buffer on success, 0 on failure.
+		On success, the buffer contains the result as a zero-terminated string.
+		On failure, the buffer contains an empty zero-terminated string.
+
 */
 char *fs_getcwd(char *buffer, int buffer_size);
 

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -46,8 +46,7 @@ public:
 		FindDataDir();
 
 		// get currentdir
-		if(!fs_getcwd(m_aCurrentDir, sizeof(m_aCurrentDir)))
-			m_aCurrentDir[0] = 0;
+		fs_getcwd(m_aCurrentDir, sizeof(m_aCurrentDir));
 
 		// load paths from storage.cfg
 		LoadPaths();


### PR DESCRIPTION
- Zero-terminate the buffer inside of `fs_getcwd` on failure for more convenience when using the function (see change in `CStorage`).
- Assert that buffer sizes are positive numbers before doing manual zero-termination like this:
```cpp
buffer[buffer_size-1] = 0;	/* assure null termination */
```

Code looks messier than I wanted, because `ISO C90 forbids mixed declarations and code`.