### PR TITLE
Fix invalid left shift in CVariableInt::Unpack, add tests for CVariableInt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1728,6 +1728,7 @@ add_custom_target(everything DEPENDS ${TARGETS_OWN})
 if(GTEST_FOUND OR DOWNLOAD_GTEST)
   set_src(TESTS GLOB src/test
     bytes_be.cpp
+    compression.cpp
     datafile.cpp
     fs.cpp
     git_revision.cpp

--- a/src/engine/shared/compression.h
+++ b/src/engine/shared/compression.h
@@ -2,13 +2,21 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef ENGINE_SHARED_COMPRESSION_H
 #define ENGINE_SHARED_COMPRESSION_H
+
 // variable int packing
 class CVariableInt
 {
 public:
+	enum
+	{
+		MAX_BYTES_PACKED = 5, // maximum number of bytes in a packed int
+	};
+
 	static unsigned char *Pack(unsigned char *pDst, int i);
 	static const unsigned char *Unpack(const unsigned char *pSrc, int *pInOut);
+
 	static long Compress(const void *pSrc, int SrcSize, void *pDst, int DstSize);
 	static long Decompress(const void *pSrc, int SrcSize, void *pDst, int DstSize);
 };
+
 #endif

--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -19,7 +19,7 @@ void CPacker::AddInt(int i)
 		return;
 
 	// make sure that we have space enough
-	if(m_pEnd - m_pCurrent < 6)
+	if(m_pEnd - m_pCurrent <= CVariableInt::MAX_BYTES_PACKED)
 	{
 		dbg_break();
 		m_Error = 1;

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -149,7 +149,7 @@ void CSnapshotDelta::UndiffItem(const int *pPast, const int *pDiff, int *pOut, i
 			m_aSnapshotDataRate[m_SnapshotCurrent] += 1;
 		else
 		{
-			unsigned char aBuf[16];
+			unsigned char aBuf[CVariableInt::MAX_BYTES_PACKED];
 			unsigned char *pEnd = CVariableInt::Pack(aBuf, *pDiff);
 			m_aSnapshotDataRate[m_SnapshotCurrent] += (int)(pEnd - (unsigned char*)aBuf) * 8;
 		}

--- a/src/test/compression.cpp
+++ b/src/test/compression.cpp
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+
+#include <engine/shared/compression.h>
+
+static const int DATA[] = {0, 1, -1, 32, 64, 256, -512, 12345, -123456, 1234567, 12345678, 123456789, 2147483647, (-2147483647 - 1)};
+static const int NUM = sizeof(DATA) / sizeof(int);
+static const int SIZES[NUM] = {1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 4, 5, 5};
+
+TEST(CVariableInt, RoundtripPackUnpack)
+{
+	for(int i = 0; i < NUM; i++)
+	{
+		unsigned char aPacked[CVariableInt::MAX_BYTES_PACKED];
+		int Result;
+		EXPECT_EQ(int(CVariableInt::Pack(aPacked, DATA[i]) - aPacked), SIZES[i]);
+		EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result) - aPacked), SIZES[i]);
+		EXPECT_EQ(Result, DATA[i]);
+	}
+}
+
+TEST(CVariableInt, UnpackInvalid)
+{
+	unsigned char aPacked[CVariableInt::MAX_BYTES_PACKED];
+	for(int i = 0; i < CVariableInt::MAX_BYTES_PACKED; i++)
+		aPacked[i] = 0xFF;
+
+	int Result;
+	EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result) - aPacked), int(CVariableInt::MAX_BYTES_PACKED));
+	EXPECT_EQ(Result, (-2147483647 - 1));
+
+	aPacked[0] &= ~0x40; // unset sign bit
+
+	EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result) - aPacked), int(CVariableInt::MAX_BYTES_PACKED));
+	EXPECT_EQ(Result, 2147483647);
+}
+
+TEST(CVariableInt, RoundtripCompressDecompress)
+{
+	unsigned char aCompressed[NUM * CVariableInt::MAX_BYTES_PACKED];
+	int aDecompressed[NUM];
+	long ExpectedCompressedSize = 0;
+	for(int i = 0; i < NUM; i++)
+		ExpectedCompressedSize += SIZES[i];
+
+	long CompressedSize = CVariableInt::Compress(DATA, sizeof(DATA), aCompressed, sizeof(aCompressed));
+	ASSERT_EQ(CompressedSize, ExpectedCompressedSize);
+	long DecompressedSize = CVariableInt::Decompress(aCompressed, ExpectedCompressedSize, aDecompressed, sizeof(aDecompressed));
+	ASSERT_EQ(DecompressedSize, sizeof(DATA));
+	for(int i = 0; i < NUM; i++)
+	{
+		EXPECT_EQ(aDecompressed[i], DATA[i]);
+	}
+}
+
+TEST(CVariableInt, CompressBufferTooSmall)
+{
+	unsigned char aCompressed[NUM]; // too small
+	long CompressedSize = CVariableInt::Compress(DATA, sizeof(DATA), aCompressed, sizeof(aCompressed));
+	ASSERT_EQ(CompressedSize, -1);
+}
+
+TEST(CVariableInt, DecompressBufferTooSmall)
+{
+	unsigned char aCompressed[] = {0x00, 0x01, 0x40, 0x20, 0x80, 0x01, 0x80, 0x04, 0xFF, 0x07, 0xB9, 0xC0, 0x01};
+	int aUncompressed[4]; // too small
+	long CompressedSize = CVariableInt::Decompress(aCompressed, sizeof(aCompressed), aUncompressed, sizeof(aUncompressed));
+	ASSERT_EQ(CompressedSize, -1);
+}


### PR DESCRIPTION
The last iteration in `CVariableInt::Unpack` is changed from

```cpp
*pInOut |= (*pSrc&(0x7F))<<(6+7+7+7);
```
to
```cpp
*pInOut |= (*pSrc & 0x0F) << (6 + 7 + 7 + 7);
```

which means the last iteration will unpack at most 4 more bits instead of 7, hence invalid left shifts by 27 places that could otherwise occur on this line are prevented (see https://github.com/ddnet/ddnet/issues/4280 and https://github.com/ddnet/ddnet/issues/3686). Now at most 31 bits are unpacked, in addition to the sign bit.

Tests are added to ensure correct functionality of all `CVariableInt` functions.

Minor code style improvements as usual.