### PR TITLE
Fix memory leaks in CServer::Run when returning early

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1317,6 +1317,7 @@ int CServer::Run()
 	if(!LoadMap(Config()->m_SvMap))
 	{
 		dbg_msg("server", "failed to load map. mapname='%s'", Config()->m_SvMap);
+		Free();
 		return -1;
 	}
 	m_MapChunksPerRequest = Config()->m_SvMapDownloadSpeed;
@@ -1340,6 +1341,7 @@ int CServer::Run()
 		Config()->m_SvMaxClients, Config()->m_SvMaxClientsPerIP, NewClientCallback, DelClientCallback, this))
 	{
 		dbg_msg("server", "couldn't open socket. port %d might already be in use", Config()->m_SvPort);
+		Free();
 		return -1;
 	}
 
@@ -1472,19 +1474,29 @@ int CServer::Run()
 	m_Econ.Shutdown();
 
 	GameServer()->OnShutdown();
-	m_pMap->Unload();
+	Free();
+
+	return 0;
+}
+
+void CServer::Free()
+{
+	if(m_pMap)
+	{
+		m_pMap->Unload();
+	}
 
 	if(m_pCurrentMapData)
 	{
 		mem_free(m_pCurrentMapData);
 		m_pCurrentMapData = 0;
 	}
+
 	if(m_pMapListHeap)
 	{
 		delete m_pMapListHeap;
 		m_pMapListHeap = 0;
 	}
-	return 0;
 }
 
 int CServer::MapListEntryCallback(const char *pFilename, int IsDir, int DirType, void *pUser)

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -259,6 +259,7 @@ public:
 	void InitRegister(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, CConfig *pConfig, IConsole *pConsole);
 	void InitInterfaces(CConfig *pConfig, IConsole *pConsole, IGameServer *pGameServer, IEngineMap *pMap, IStorage *pStorage);
 	int Run();
+	void Free();
 
 	static int MapListEntryCallback(const char *pFilename, int IsDir, int DirType, void *pUser);
 


### PR DESCRIPTION
Fixes the following memory leaks that occur when initial map loading or socket opening fails:

```
[2021-12-28 12:00:36][server]: starting...
[2021-12-28 12:00:36][mapchecker]: invalid standard map
[2021-12-28 12:00:36][server]: failed to load map. mapname='dm1'

=================================================================
==61193==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f6c17188947 in operator new(unsigned long) (/lib/x86_64-linux-gnu/libasan.so.5+0x10f947)
    #1 0x5622a35edc25 in CServer::Run() src/engine/server/server.cpp:1310
    #2 0x5622a35f3a58 in main src/engine/server/server.cpp:1914
    #3 0x7f6c16b7d0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)

Indirect leak of 65568 byte(s) in 1 object(s) allocated from:
    #0 0x7f6c17186bc8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dbc8)
    #1 0x5622a36b3859 in mem_alloc src/base/system.c:289
    #2 0x5622a368c14b in CHeap::NewChunk() src/engine/shared/memheap.cpp:11
    #3 0x5622a368c407 in CHeap::CHeap() src/engine/shared/memheap.cpp:43
    #4 0x5622a35edc30 in CServer::Run() src/engine/server/server.cpp:1310
    #5 0x5622a35f3a58 in main src/engine/server/server.cpp:1914
    #6 0x7f6c16b7d0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)

SUMMARY: AddressSanitizer: 65576 byte(s) leaked in 2 allocation(s).
```
