### PR TITLE
Fix various memory leaks in the client

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1986,7 +1986,7 @@ void CClient::Run()
 	}
 
 	// init font rendering
-	Kernel()->RequestInterface<IEngineTextRender>()->Init();
+	m_pTextRender->Init();
 
 	// init the input
 	Input()->Init();

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2712,6 +2712,7 @@ int main(int argc, const char **argv) // ignore_convention
 		dbg_console_cleanup();
 #endif
 	// free components
+	pClient->~CClient();
 	mem_free(pClient);
 	delete pKernel;
 	delete pEngine;

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -39,7 +39,11 @@ inline int GetNewToken()
 	return random_int();
 }
 
-//
+CServerBrowser::CServerlist::~CServerlist()
+{
+	mem_free(m_ppServerlist);
+}
+
 void CServerBrowser::CServerlist::Clear()
 {
 	m_ServerlistHeap.Reset();

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -87,6 +87,7 @@ private:
 		CServerEntry *m_aServerlistIp[256]; // ip hash list
 		CServerEntry **m_ppServerlist;
 
+		~CServerlist();
 		void Clear();
 	} m_aServerlist[NUM_TYPES];
 

--- a/src/engine/client/serverbrowser_filter.cpp
+++ b/src/engine/client/serverbrowser_filter.cpp
@@ -79,6 +79,8 @@ CServerBrowserFilter::CServerFilter& CServerBrowserFilter::CServerFilter::operat
 		m_NumSortedServers = Other.m_NumSortedServers;
 		m_SortedServersCapacity = Other.m_SortedServersCapacity;
 
+		if(m_pSortedServerlist)
+			mem_free(m_pSortedServerlist);
 		m_pSortedServerlist = (int *)mem_alloc(m_SortedServersCapacity * sizeof(int));
 		for(int i = 0; i < m_SortedServersCapacity; ++i)
 			m_pSortedServerlist[i] = Other.m_pSortedServerlist[i];

--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -281,13 +281,10 @@ CGlyphMap::CGlyphMap(IGraphics *pGraphics, FT_Library FtLibrary)
 
 CGlyphMap::~CGlyphMap()
 {
+	FT_Stroker_Done(m_FtStroker);
+
 	for(int i = 0; i < m_Glyphs.size(); ++i)
 		delete m_Glyphs[i].m_pGlyph;
-
-	for(int i = 0; i < m_NumFtFaces; ++i)
-		FT_Done_Face(m_aFtFaces[i]);
-
-	FT_Stroker_Done(m_FtStroker);
 }
 
 int CGlyphMap::GetCharGlyph(int Chr, FT_Face *pFace)
@@ -725,13 +722,6 @@ CTextRender::CTextRender()
 	mem_zero(m_apFontData, sizeof(m_apFontData));
 }
 
-CTextRender::~CTextRender()
-{
-	for(int i = 0; i < MAX_FACES; ++i)
-		if(m_apFontData[i])
-			mem_free(m_apFontData[i]);
-}
-
 void CTextRender::Init()
 {
 	m_pGraphics = Kernel()->RequestInterface<IGraphics>();
@@ -748,8 +738,15 @@ void CTextRender::Update()
 void CTextRender::Shutdown()
 {
 	delete m_pGlyphMap;
+
+	FT_Done_FreeType(m_FTLibrary);
+
 	if(m_paVariants)
 		mem_free(m_paVariants);
+
+	for(int i = 0; i < MAX_FACES; ++i)
+		if(m_apFontData[i])
+			mem_free(m_apFontData[i]);
 }
 
 void CTextRender::LoadFonts(IStorage *pStorage, IConsole *pConsole)

--- a/src/engine/client/textrender.h
+++ b/src/engine/client/textrender.h
@@ -187,7 +187,6 @@ class CTextRender : public IEngineTextRender
 
 public:
 	CTextRender();
-	~CTextRender();
 
 	void Init();
 	void Update();

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -319,9 +319,7 @@ int CSnapshotDelta::UnpackDelta(const CSnapshot *pFrom, CSnapshot *pTo, const vo
 	// unpack deleted stuff
 	pDeleted = pData;
 	if(pDelta->m_NumDeletedItems < 0)
-	{
 		return -1;
-	}
 	pData += pDelta->m_NumDeletedItems;
 	if(pData > pEnd)
 		return -1;
@@ -406,6 +404,11 @@ int CSnapshotDelta::UnpackDelta(const CSnapshot *pFrom, CSnapshot *pTo, const vo
 
 // CSnapshotStorage
 
+CSnapshotStorage::~CSnapshotStorage()
+{
+	PurgeAll();
+}
+
 void CSnapshotStorage::Init()
 {
 	m_pFirst = 0;
@@ -415,11 +418,10 @@ void CSnapshotStorage::Init()
 void CSnapshotStorage::PurgeAll()
 {
 	CHolder *pHolder = m_pFirst;
-	CHolder *pNext;
 
 	while(pHolder)
 	{
-		pNext = pHolder->m_pNext;
+		CHolder *pNext = pHolder->m_pNext;
 		mem_free(pHolder);
 		pHolder = pNext;
 	}
@@ -432,11 +434,10 @@ void CSnapshotStorage::PurgeAll()
 void CSnapshotStorage::PurgeUntil(int Tick)
 {
 	CHolder *pHolder = m_pFirst;
-	CHolder *pNext;
 
 	while(pHolder)
 	{
-		pNext = pHolder->m_pNext;
+		CHolder *pNext = pHolder->m_pNext;
 		if(pHolder->m_Tick >= Tick)
 			return; // no more to remove
 		mem_free(pHolder);
@@ -583,8 +584,7 @@ CSnapshotItem *CSnapshotBuilder::GetItem(int Index)
 
 int *CSnapshotBuilder::GetItemData(int Key)
 {
-	int i;
-	for(i = 0; i < m_NumItems; i++)
+	for(int i = 0; i < m_NumItems; i++)
 	{
 		if(GetItem(i)->Key() == Key)
 			return GetItem(i)->Data();

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -116,6 +116,7 @@ public:
 	CHolder *m_pFirst;
 	CHolder *m_pLast;
 
+	~CSnapshotStorage();
 	void Init();
 	void PurgeAll();
 	void PurgeUntil(int Tick);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -2165,6 +2165,7 @@ int CMenus::GameIconScan(const char *pName, int IsDir, int DirType, void *pUser)
 	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
 
 	GameIcon.m_IconTexture = pSelf->Graphics()->LoadTextureRaw(CGameIcon::GAMEICON_SIZE, CGameIcon::GAMEICON_SIZE, Info.m_Format, Info.m_pData, Info.m_Format, IGraphics::TEXLOAD_LINEARMIPMAPS);
+	mem_free(Info.m_pData);
 	pSelf->m_lGameIcons.add(GameIcon);
 	if(!str_comp_nocase(aGameIconName, "mod"))
 		pSelf->m_GameIconDefault = GameIcon.m_IconTexture;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -655,6 +655,7 @@ int CMenus::ThemeIconScan(const char *pName, int IsDir, int DirType, void *pUser
 			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
 
 			r.front().m_IconTexture = pSelf->Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
+			mem_free(Info.m_pData);
 			return 0;
 		}
 	}

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -313,6 +313,7 @@ void CSkins::OnInit()
 			str_format(aBuf, sizeof(aBuf), "loaded xmas hat '%s'", pFileName);
 			Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
 			m_XmasHatTexture = Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
+			mem_free(Info.m_pData);
 		}
 	}
 	m_pClient->m_pMenus->RenderLoading(1);
@@ -333,6 +334,7 @@ void CSkins::OnInit()
 			str_format(aBuf, sizeof(aBuf), "loaded bot '%s'", pFileName);
 			Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
 			m_BotTexture = Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
+			mem_free(Info.m_pData);
 		}
 	}
 	m_pClient->m_pMenus->RenderLoading(1);


### PR DESCRIPTION
- Free icon image buffers (xmas and bot skin decoration, game icons, theme icons)
- Fix leak of FreeType library by adding `FT_Done_FreeType(m_FTLibrary)`. This also frees the faces automatically, so `FT_Done_Face(m_aFtFaces[i])` is no longer necessary, but `FT_Stroker_Done(m_FtStroker)` is still necessary. I combined `~CTextRender` into the `Shutdown` method as there is no reason to split this over two methods.
- Fix leak of `CSnapshotStorage` data.
- Fix leak of everything owned by `CClient` by calling destructor explicitly.
- Fix leaks of server list and filter data.

Leaks found and confirmed fixed by using AddressSanitizer.