### PR TITLE
Close thread handle in thread_destroy on windows

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -536,11 +536,8 @@ void thread_wait(void *thread)
 
 void thread_destroy(void *thread)
 {
-#if defined(CONF_FAMILY_UNIX)
-	void *r = 0;
-	pthread_join((pthread_t)thread, &r);
-#else
-	/*#error not implemented*/
+#if defined(CONF_FAMILY_WINDOWS)
+	CloseHandle((HANDLE)thread);
 #endif
 }
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -422,27 +422,35 @@ void thread_wait(void *thread);
 
 /*
 	Function: thread_destroy
-		Destroys a thread.
+		Frees resources associated with a thread handle.
 
 	Parameters:
-		thread - Thread to destroy.
+		thread - Thread handle to destroy.
+
+	Remarks:
+		- The thread must have already terminated normally.
+		- Detached threads must not be destroyed with this function.
 */
 void thread_destroy(void *thread);
 
 /*
-	Function: thread_yeild
-		Yeild the current threads execution slice.
+	Function: thread_yield
+		Yield the current threads execution slice.
 */
 void thread_yield();
 
 /*
 	Function: thread_detach
-		Puts the thread in the detached thread, guaranteeing that
+		Puts the thread in the detached state, guaranteeing that
 		resources of the thread will be freed immediately when the
 		thread terminates.
 
 	Parameters:
 		thread - Thread to detach
+
+	Remarks:
+		- This invalidates the thread handle, hence it must not be
+		used after detaching the thread.
 */
 void thread_detach(void *thread);
 

--- a/src/test/thread.cpp
+++ b/src/test/thread.cpp
@@ -24,6 +24,7 @@ TEST(Thread, Wait)
 	void *pThread = thread_init(SetToOne, &Integer);
 	thread_wait(pThread);
 	EXPECT_EQ(Integer, 1);
+	thread_destroy(pThread);
 }
 
 TEST(Thread, Yield)
@@ -45,4 +46,5 @@ TEST(Thread, Lock)
 	void *pThread = thread_init(LockThread, &Lock);
 	lock_unlock(Lock);
 	thread_wait(pThread);
+	thread_destroy(pThread);
 }


### PR DESCRIPTION
This frees and invalidates the thread handle but does not terminate the thread itself, so `thread_destroy` must only be called after `thread_wait`. This is already the case currently, except in the tests, where I added missing `thread_destroy`s.