### PR TITLE
Fix undefined behavior in byte packing functions, add tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1727,6 +1727,7 @@ add_custom_target(everything DEPENDS ${TARGETS_OWN})
 
 if(GTEST_FOUND OR DOWNLOAD_GTEST)
   set_src(TESTS GLOB src/test
+    bytes_be.cpp
     datafile.cpp
     fs.cpp
     git_revision.cpp

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2900,18 +2900,47 @@ void cmdline_free(int argc, const char **argv)
 #endif
 }
 
+int bytes_be_to_int(const unsigned char *bytes)
+{
+	int Result;
+	unsigned char *pResult = (unsigned char *)&Result;
+	for(unsigned i = 0; i < sizeof(int); i++)
+	{
+#if defined(CONF_ARCH_ENDIAN_BIG)
+		pResult[i] = bytes[i];
+#else
+		pResult[i] = bytes[sizeof(int) - i - 1];
+#endif
+	}
+	return Result;
+}
+
+void int_to_bytes_be(unsigned char *bytes, int value)
+{
+	const unsigned char *pValue = (const unsigned char *)&value;
+	for(unsigned i = 0; i < sizeof(int); i++)
+	{
+#if defined(CONF_ARCH_ENDIAN_BIG)
+		bytes[i] = pValue[i];
+#else
+		bytes[sizeof(int) - i - 1] = pValue[i];
+#endif
+	}
+}
+
 unsigned bytes_be_to_uint(const unsigned char *bytes)
 {
-	return (bytes[0]<<24) | (bytes[1]<<16) | (bytes[2]<<8) | bytes[3];
+	return ((bytes[0] & 0xffu) << 24u) | ((bytes[1] & 0xffu) << 16u) | ((bytes[2] & 0xffu) << 8u) | (bytes[3] & 0xffu);
 }
 
 void uint_to_bytes_be(unsigned char *bytes, unsigned value)
 {
-	bytes[0] = (value>>24)&0xff;
-	bytes[1] = (value>>16)&0xff;
-	bytes[2] = (value>>8)&0xff;
-	bytes[3] = value&0xff;
+	bytes[0] = (value >> 24u) & 0xffu;
+	bytes[1] = (value >> 16u) & 0xffu;
+	bytes[2] = (value >> 8u) & 0xffu;
+	bytes[3] = value & 0xffu;
 }
+
 
 #if defined(__cplusplus)
 }

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1812,6 +1812,29 @@ void cmdline_fix(int *argc, const char ***argv);
 void cmdline_free(int argc, const char **argv);
 
 /*
+	Function: bytes_be_to_int
+		Packs 4 big endian bytes into an int
+
+	Returns:
+		The packed int
+
+	Remarks:
+		- Assumes the passed array is 4 bytes
+		- Assumes int is 4 bytes
+*/
+int bytes_be_to_int(const unsigned char *bytes);
+
+/*
+	Function: int_to_bytes_be
+		Packs an int into 4 big endian bytes
+
+	Remarks:
+		- Assumes the passed array is 4 bytes
+		- Assumes int is 4 bytes
+*/
+void int_to_bytes_be(unsigned char *bytes, int value);
+
+/*
 	Function: bytes_be_to_uint
 		Packs 4 big endian bytes into an unsigned
 
@@ -1833,6 +1856,7 @@ unsigned bytes_be_to_uint(const unsigned char *bytes);
 		- Assumes unsigned is 4 bytes
 */
 void uint_to_bytes_be(unsigned char *bytes, unsigned value);
+
 
 #ifdef __cplusplus
 }

--- a/src/engine/external/pnglite/pnglite.c
+++ b/src/engine/external/pnglite/pnglite.c
@@ -65,7 +65,7 @@ static int file_read_ul(png_t* png, unsigned *out)
 	if(file_read(png, buf, 1, 4) != 4)
 		return PNG_FILE_ERROR;
 
-	*out = (buf[0]<<24) | (buf[1]<<16) | (buf[2]<<8) | buf[3];
+	*out = ((buf[0] & 0xffu)<<24u) | ((buf[1] & 0xffu)<<16u) | ((buf[2] & 0xffu)<<8u) | (buf[3] & 0xffu);
 
 	return PNG_NO_ERROR;
 }
@@ -74,10 +74,10 @@ static int file_write_ul(png_t* png, unsigned in)
 {
 	unsigned char buf[4];
 
-	buf[0] = (in>>24) & 0xff;
-	buf[1] = (in>>16) & 0xff;
-	buf[2] = (in>>8) & 0xff;
-	buf[3] = (in) & 0xff;
+	buf[0] = (in>>24u) & 0xffu;
+	buf[1] = (in>>16u) & 0xffu;
+	buf[2] = (in>>8u) & 0xffu;
+	buf[3] = (in) & 0xffu;
 
 	if(file_write(png, buf, 1, 4) != 4)
 		return PNG_FILE_ERROR;
@@ -93,17 +93,17 @@ static unsigned get_ul(unsigned char* buf)
 
 	memcpy(foo, buf, 4);
 
-	result = (foo[0]<<24) | (foo[1]<<16) | (foo[2]<<8) | foo[3];
+	result = ((foo[0] & 0xffu)<<24u) | ((foo[1] & 0xffu)<<16u) | ((foo[2] & 0xffu)<<8u) | (foo[3] & 0xffu);
 
 	return result;
 }
 
 static unsigned set_ul(unsigned char* buf, unsigned in)
 {
-	buf[0] = (in>>24) & 0xff;
-	buf[1] = (in>>16) & 0xff;
-	buf[2] = (in>>8) & 0xff;
-	buf[3] = (in) & 0xff;
+	buf[0] = (in>>24u) & 0xffu;
+	buf[1] = (in>>16u) & 0xffu;
+	buf[2] = (in>>8u) & 0xffu;
+	buf[3] = (in) & 0xffu;
 
 	return PNG_NO_ERROR;
 }

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -162,7 +162,7 @@ void CDemoRecorder::WriteTickMarker(int Tick, int Keyframe)
 	{
 		unsigned char aChunk[5];
 		aChunk[0] = CHUNKTYPEFLAG_TICKMARKER;
-		uint_to_bytes_be(aChunk+1, Tick);
+		int_to_bytes_be(aChunk+1, Tick);
 
 		if(Keyframe)
 			aChunk[0] |= CHUNKTICKFLAG_KEYFRAME;
@@ -282,18 +282,18 @@ int CDemoRecorder::Stop()
 	// add the demo length to the header
 	io_seek(m_File, gs_LengthOffset, IOSEEK_START);
 	unsigned char aLength[4];
-	uint_to_bytes_be(aLength, Length());
+	int_to_bytes_be(aLength, Length());
 	io_write(m_File, aLength, sizeof(aLength));
 
 	// add the timeline markers to the header
 	io_seek(m_File, gs_NumMarkersOffset, IOSEEK_START);
 	unsigned char aNumMarkers[4];
-	uint_to_bytes_be(aNumMarkers, m_NumTimelineMarkers);
+	int_to_bytes_be(aNumMarkers, m_NumTimelineMarkers);
 	io_write(m_File, aNumMarkers, sizeof(aNumMarkers));
 	for(int i = 0; i < m_NumTimelineMarkers; i++)
 	{
 		unsigned char aMarker[4];
-		uint_to_bytes_be(aMarker, m_aTimelineMarkers[i]);
+		int_to_bytes_be(aMarker, m_aTimelineMarkers[i]);
 		io_write(m_File, aMarker, sizeof(aMarker));
 	}
 
@@ -383,7 +383,7 @@ int CDemoPlayer::ReadChunkHeader(int *pType, int *pSize, int *pTick)
 			unsigned char aTickData[4];
 			if(io_read(m_File, aTickData, sizeof(aTickData)) != sizeof(aTickData))
 				return -1;
-			*pTick = bytes_be_to_uint(aTickData);
+			*pTick = bytes_be_to_int(aTickData);
 		}
 		else
 		{
@@ -705,11 +705,9 @@ const char *CDemoPlayer::Load(const char *pFilename, int StorageType, const char
 	}
 
 	// get timeline markers
-	m_Info.m_Info.m_NumTimelineMarkers = minimum(bytes_be_to_uint(m_Info.m_Header.m_aNumTimelineMarkers), unsigned(MAX_TIMELINE_MARKERS));
+	m_Info.m_Info.m_NumTimelineMarkers = minimum(bytes_be_to_int(m_Info.m_Header.m_aNumTimelineMarkers), int(MAX_TIMELINE_MARKERS));
 	for(int i = 0; i < m_Info.m_Info.m_NumTimelineMarkers; i++)
-	{
-		m_Info.m_Info.m_aTimelineMarkers[i] = bytes_be_to_uint(m_Info.m_Header.m_aTimelineMarkers[i]);
-	}
+		m_Info.m_Info.m_aTimelineMarkers[i] = bytes_be_to_int(m_Info.m_Header.m_aTimelineMarkers[i]);
 
 	// scan the file for interesting points
 	ScanFile();

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -416,12 +416,12 @@ private:
 		{
 			if(!m_Valid || !m_InfosLoaded)
 				return -1;
-			return bytes_be_to_uint(m_Info.m_aNumTimelineMarkers);
+			return bytes_be_to_int(m_Info.m_aNumTimelineMarkers);
 		}
 
 		int Length() const
 		{
-			return bytes_be_to_uint(m_Info.m_aLength);
+			return bytes_be_to_int(m_Info.m_aLength);
 		}
 
 		bool operator<(const CDemoItem &Other) const

--- a/src/test/bytes_be.cpp
+++ b/src/test/bytes_be.cpp
@@ -1,0 +1,31 @@
+#include "test.h"
+
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+
+static const int INT_DATA[] = {0, 1, -1, 32, 64, 256, -512, 12345, -123456, 1234567, 12345678, 123456789, 2147483647, (-2147483647 - 1)};
+static const int INT_NUM = sizeof(INT_DATA) / sizeof(int);
+
+static const unsigned UINT_DATA[] = {0u, 1u, 2u, 32u, 64u, 256u, 512u, 12345u, 123456u, 1234567u, 12345678u, 123456789u, 2147483647u, 2147483648u, 4294967295u};
+static const int UINT_NUM = sizeof(INT_DATA) / sizeof(unsigned);
+
+TEST(BytePacking, RoundtripInt)
+{
+	for(int i = 0; i < INT_NUM; i++)
+	{
+		unsigned char aPacked[4];
+		int_to_bytes_be(aPacked, INT_DATA[i]);
+		EXPECT_EQ(bytes_be_to_int(aPacked), INT_DATA[i]);
+	}
+}
+
+TEST(BytePacking, RoundtripUnsigned)
+{
+	for(int i = 0; i < UINT_NUM; i++)
+	{
+		unsigned char aPacked[4];
+		uint_to_bytes_be(aPacked, UINT_DATA[i]);
+		EXPECT_EQ(bytes_be_to_uint(aPacked), UINT_DATA[i]);
+	}
+}


### PR DESCRIPTION
- Fix undefined behavior in `uint_to_bytes_be` and `bytes_be_to_uint` due to intermittent usage of `int`.
   - Fix the same issue in pnglite.
- Add separate  `int_to_bytes_be` and `bytes_be_to_int` to fix conversions between signed and unsigned and fix undefined/implementation-specific behavior due to right shift of negative number, by instead copying the bytes without using any bit arithmetic.
- Add tests for all four byte packing functions.