### PR TITLE
Fix integer overflow due to latency being uninitialized

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -672,6 +672,7 @@ int CServer::NewClientCallback(int ClientID, void *pUser)
 	pThis->m_aClients[ClientID].m_pMapListEntryToSend = 0;
 	pThis->m_aClients[ClientID].m_NoRconNote = false;
 	pThis->m_aClients[ClientID].m_Quitting = false;
+	pThis->m_aClients[ClientID].m_Latency = 0;
 	pThis->m_aClients[ClientID].Reset();
 
 	return 0;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -33,6 +33,7 @@ CPlayer::CPlayer(CGameContext *pGameServer, int ClientID, bool Dummy, bool AsSpe
 	m_RespawnDisabled = GameServer()->m_pController->GetStartRespawnState();
 	m_DeadSpecMode = false;
 	m_Spawning = false;
+	mem_zero(&m_Latency, sizeof(m_Latency));
 }
 
 CPlayer::~CPlayer()


### PR DESCRIPTION
Fixes `src/game/server/player.cpp:57:22: runtime error: signed integer overflow: -1094795586 + -1094795586 cannot be represented in type 'int'` due to latency member not being initialized.