### PR TITLE
Fix arrow key scrolling when serverbrowser is refreshing

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -865,7 +865,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	}
 
 	// update selection based on address if it changed
-	if(ServerBrowser()->IsRefreshing() || ServerBrowser()->WasUpdated(true))
+	if(ServerBrowser()->WasUpdated(true))
 		m_AddressSelection |= ADDR_SELECTION_CHANGE;
 
 	const int BrowserType = ServerBrowser()->GetType();


### PR DESCRIPTION
Fixes scrolling with arrow keys not working at all when the serverbrowser is refreshing. See #3014. Now it works but it's a bit flickery if you try to scroll while it's refreshing. Better than not working at all though.

@Dune-jr @fokkonaut Please test if this works (better than before).