### PR TITLE
Fix build: Use https:// instead of git:// for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "datasrc/languages"]
 	path = datasrc/languages
-	url = git://github.com/teeworlds/teeworlds-translation.git
+	url = https://github.com/teeworlds/teeworlds-translation.git
 	branch = master
 [submodule "datasrc/maps"]
 	path = datasrc/maps
-	url = git://github.com/teeworlds/teeworlds-maps.git
+	url = https://github.com/teeworlds/teeworlds-maps.git
 	branch = master


### PR DESCRIPTION
Fix the build:

>  Error: fatal: remote error: 
>  The unauthenticated git protocol on port 9418 is no longer supported.
>  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
