### PR TITLE
Hotfix CVE-2021-43518

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -175,7 +175,7 @@ void CMapLayers::LoadEnvPoints(const CLayers *pLayers, array<CEnvPoint>& lEnvPoi
 				p.m_Time = pEnvPoint_v1->m_Time;
 				p.m_Curvetype = pEnvPoint_v1->m_Curvetype;
 
-				for(int c = 0; c < pItem->m_Channels; c++)
+				for(int c = 0; c < minimum(pItem->m_Channels, 4); c++)
 				{
 					p.m_aValues[c] = pEnvPoint_v1->m_aValues[c];
 					p.m_aInTangentdx[c] = 0;

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -479,7 +479,8 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 			for(int e = 0; e < Num; e++)
 			{
 				CMapItemEnvelope *pItem = (CMapItemEnvelope *)DataFile.GetItem(Start+e, 0, 0);
-				CEnvelope *pEnv = new CEnvelope(pItem->m_Channels);
+				const int Channels = minimum(pItem->m_Channels, 4);
+				CEnvelope *pEnv = new CEnvelope(Channels);
 				pEnv->m_lPoints.set_size(pItem->m_NumPoints);
 				for(int n = 0; n < pItem->m_NumPoints; n++)
 				{
@@ -496,7 +497,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						pEnv->m_lPoints[n].m_Time = pEnvPoint_v1->m_Time;
 						pEnv->m_lPoints[n].m_Curvetype = pEnvPoint_v1->m_Curvetype;
 
-						for(int c = 0; c < pItem->m_Channels; c++)
+						for(int c = 0; c < Channels; c++)
 						{
 							pEnv->m_lPoints[n].m_aValues[c] = pEnvPoint_v1->m_aValues[c];
 						}


### PR DESCRIPTION
Hotfix for CVE-2021-43518. Closes #2981.

Adding all the datafile validation (#2931) ended up being a rather large patch and it still needs some work. This hotfix just addresses the exploitable stack buffer overflow write.

Fixing the other issues individually would be pointless, as there are at least 50-100 more distinct maps that can crash the client or cause ASAN/UBSAN errors.