### PR TITLE
Fix OOB access in linereader, improve code style

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -508,14 +508,13 @@ bool CConsole::ExecuteFile(const char *pFilename)
 	char aBuf[256];
 	if(File)
 	{
-		char *pLine;
-		CLineReader lr;
-
 		str_format(aBuf, sizeof(aBuf), "executing '%s'", pFilename);
 		Print(IConsole::OUTPUT_LEVEL_STANDARD, "console", aBuf);
-		lr.Init(File);
 
-		while((pLine = lr.Get()))
+		CLineReader LineReader;
+		LineReader.Init(File);
+		const char *pLine;
+		while((pLine = LineReader.Get()))
 			ExecuteLine(pLine);
 
 		io_close(File);

--- a/src/engine/shared/linereader.cpp
+++ b/src/engine/shared/linereader.cpp
@@ -2,27 +2,26 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "linereader.h"
 
-void CLineReader::Init(IOHANDLE io)
+void CLineReader::Init(IOHANDLE IoHandle)
 {
 	m_BufferMaxSize = sizeof(m_aBuffer) - 1;
 	m_BufferSize = 0;
 	m_BufferPos = 0;
-	m_IO = io;
+	m_IO = IoHandle;
 }
 
-char *CLineReader::Get()
+const char *CLineReader::Get()
 {
 	unsigned LineStart = m_BufferPos;
 	bool CRLFBreak = false;
 
-	while(1)
+	while(true)
 	{
 		if(m_BufferPos >= m_BufferSize)
 		{
 			// fetch more
 
 			// move the remaining part to the front
-			unsigned Read;
 			unsigned Left = m_BufferSize - LineStart;
 
 			if(LineStart > m_BufferSize)
@@ -32,7 +31,7 @@ char *CLineReader::Get()
 			m_BufferPos = Left;
 
 			// fill the buffer
-			Read = io_read(m_IO, &m_aBuffer[m_BufferPos], m_BufferMaxSize-m_BufferPos);
+			unsigned Read = io_read(m_IO, &m_aBuffer[m_BufferPos], m_BufferMaxSize - m_BufferPos);
 			m_BufferSize = Left + Read;
 			LineStart = 0;
 
@@ -56,14 +55,14 @@ char *CLineReader::Get()
 				// line found
 				if(m_aBuffer[m_BufferPos] == '\r')
 				{
-					if(m_BufferPos+1 >= m_BufferSize)
+					if(m_BufferPos + 1 >= m_BufferSize)
 					{
 						// read more to get the connected '\n'
 						CRLFBreak = true;
 						++m_BufferPos;
 						continue;
 					}
-					else if(m_aBuffer[m_BufferPos+1] == '\n')
+					else if(m_aBuffer[m_BufferPos + 1] == '\n')
 						m_aBuffer[m_BufferPos++] = 0;
 				}
 				m_aBuffer[m_BufferPos++] = 0;

--- a/src/engine/shared/linereader.cpp
+++ b/src/engine/shared/linereader.cpp
@@ -4,7 +4,7 @@
 
 void CLineReader::Init(IOHANDLE io)
 {
-	m_BufferMaxSize = sizeof(m_aBuffer);
+	m_BufferMaxSize = sizeof(m_aBuffer) - 1;
 	m_BufferSize = 0;
 	m_BufferPos = 0;
 	m_IO = io;

--- a/src/engine/shared/linereader.h
+++ b/src/engine/shared/linereader.h
@@ -7,7 +7,7 @@
 // buffered stream for reading lines, should perhaps be something smaller
 class CLineReader
 {
-	char m_aBuffer[4*1024];
+	char m_aBuffer[4 * 1024 + 1]; // 1 additional byte for null termination
 	unsigned m_BufferPos;
 	unsigned m_BufferSize;
 	unsigned m_BufferMaxSize;

--- a/src/engine/shared/linereader.h
+++ b/src/engine/shared/linereader.h
@@ -12,8 +12,9 @@ class CLineReader
 	unsigned m_BufferSize;
 	unsigned m_BufferMaxSize;
 	IOHANDLE m_IO;
+
 public:
 	void Init(IOHANDLE IoHandle);
-	char *Get();
+	const char *Get();
 };
 #endif

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -105,10 +105,9 @@ public:
 			}
 		}
 
-		char *pLine;
 		CLineReader LineReader;
 		LineReader.Init(File);
-
+		const char *pLine;
 		while((pLine = LineReader.Get()))
 		{
 			const char *pLineWithoutPrefix = str_startswith(pLine, "add_path ");


### PR DESCRIPTION
Reserve one additional byte to ensure null termination in linereader and prevent OOB access when reading a very long line.