### PR TITLE
Skip the UTF-8 BOM when reading text files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1731,6 +1731,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     fs.cpp
     git_revision.cpp
     hash.cpp
+    io.cpp
     jsonwriter.cpp
     sorted_array.cpp
     storage.cpp

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -309,12 +309,12 @@ void mem_zero(void *block,unsigned size)
 	memset(block, 0, size);
 }
 
-IOHANDLE io_open(const char *filename, int flags)
+IOHANDLE io_open_impl(const char *filename, int flags)
 {
-	dbg_assert(flags == IOFLAG_READ || flags == IOFLAG_WRITE || flags == IOFLAG_APPEND, "flags must be read, write or append");
+	dbg_assert(flags == (IOFLAG_READ | IOFLAG_SKIP_BOM) || flags == IOFLAG_READ || flags == IOFLAG_WRITE || flags == IOFLAG_APPEND, "flags must be read, read+skipbom, write or append");
 #if defined(CONF_FAMILY_WINDOWS)
 	WCHAR wBuffer[IO_MAX_PATH_LENGTH];
-	if(flags == IOFLAG_READ)
+	if((flags & IOFLAG_READ) != 0)
 	{
 		// check for filename case sensitive
 		WIN32_FIND_DATAW finddata;
@@ -349,7 +349,7 @@ IOHANDLE io_open(const char *filename, int flags)
 	}
 	return 0x0;
 #else
-	if(flags == IOFLAG_READ)
+	if((flags & IOFLAG_READ) != 0)
 		return (IOHANDLE)fopen(filename, "rb");
 	if(flags == IOFLAG_WRITE)
 		return (IOHANDLE)fopen(filename, "wb");
@@ -357,6 +357,21 @@ IOHANDLE io_open(const char *filename, int flags)
 		return (IOHANDLE)fopen(filename, "ab");
 	return 0x0;
 #endif
+}
+
+IOHANDLE io_open(const char *filename, int flags)
+{
+	IOHANDLE result = io_open_impl(filename, flags);
+	unsigned char buf[3];
+	if((flags & IOFLAG_SKIP_BOM) == 0 || !result)
+	{
+		return result;
+	}
+	if(io_read(result, buf, sizeof(buf)) != 3 || buf[0] != 0xef || buf[1] != 0xbb || buf[2] != 0xbf)
+	{
+		io_seek(result, 0, IOSEEK_START);
+	}
+	return result;
 }
 
 unsigned io_read(IOHANDLE io, void *buffer, unsigned size)

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1868,7 +1868,7 @@ int fs_read(const char *name, void **result, unsigned *result_len)
 
 char *fs_read_str(const char *name)
 {
-	IOHANDLE file = io_open(name, IOFLAG_READ);
+	IOHANDLE file = io_open(name, IOFLAG_READ | IOFLAG_SKIP_BOM);
 	char *result;
 	if(!file)
 	{

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -180,6 +180,7 @@ enum {
 	IOFLAG_READ = 1,
 	IOFLAG_WRITE = 2,
 	IOFLAG_APPEND = 4,
+	IOFLAG_SKIP_BOM = 8,
 
 	IOSEEK_START = 0,
 	IOSEEK_CUR = 1,
@@ -196,7 +197,7 @@ typedef struct IOINTERNAL *IOHANDLE;
 
 	Parameters:
 		filename - File to open.
-		flags - A set of flags. IOFLAG_READ, IOFLAG_WRITE, IOFLAG_APPEND.
+		flags - A set of flags. IOFLAG_READ, IOFLAG_WRITE, IOFLAG_APPEND, IOFLAG_SKIP_BOM.
 
 	Returns:
 		Returns a handle to the file on success and 0 on failure.

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -503,7 +503,7 @@ bool CConsole::ExecuteFile(const char *pFilename)
 	m_pFirstExec = &ThisFile;
 
 	// exec the file
-	IOHANDLE File = m_pStorage->OpenFile(pFilename, IOFLAG_READ, IStorage::TYPE_ALL);
+	IOHANDLE File = m_pStorage->OpenFile(pFilename, IOFLAG_READ | IOFLAG_SKIP_BOM, IStorage::TYPE_ALL);
 
 	char aBuf[256];
 	if(File)

--- a/src/engine/shared/masterserver.cpp
+++ b/src/engine/shared/masterserver.cpp
@@ -133,7 +133,7 @@ public:
 			return -1;
 
 		// try to open file
-		IOHANDLE File = m_pStorage->OpenFile("masters.cfg", IOFLAG_READ, IStorage::TYPE_SAVE);
+		IOHANDLE File = m_pStorage->OpenFile("masters.cfg", IOFLAG_READ | IOFLAG_SKIP_BOM, IStorage::TYPE_SAVE);
 		if(!File)
 			return -1;
 

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -90,14 +90,14 @@ public:
 	void LoadPaths()
 	{
 		// check current directory
-		IOHANDLE File = io_open("storage.cfg", IOFLAG_READ);
+		IOHANDLE File = io_open("storage.cfg", IOFLAG_READ | IOFLAG_SKIP_BOM);
 		if(!File)
 		{
 			// check usable path in argv[0]
 			char aBuffer[IO_MAX_PATH_LENGTH];
 			str_copy(aBuffer, m_aAppDir, sizeof(aBuffer));
 			str_append(aBuffer, "/storage.cfg", sizeof(aBuffer));
-			File = io_open(aBuffer, IOFLAG_READ);
+			File = io_open(aBuffer, IOFLAG_READ | IOFLAG_SKIP_BOM);
 			if(!File)
 			{
 				dbg_msg("storage", "couldn't open storage.cfg");
@@ -409,7 +409,7 @@ public:
 
 	char *ReadFileStr(const char *pFilename, int Type)
 	{
-		IOHANDLE File = OpenFile(pFilename, IOFLAG_READ, Type);
+		IOHANDLE File = OpenFile(pFilename, IOFLAG_READ | IOFLAG_SKIP_BOM, Type);
 		if(!File)
 		{
 			return 0;

--- a/src/test/io.cpp
+++ b/src/test/io.cpp
@@ -1,0 +1,63 @@
+#include "test.h"
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+
+void TestFileRead(const char *pWritten, bool SkipBom, const char *pRead)
+{
+	CTestInfo Info;
+	char aBuf[512] = {0};
+	IOHANDLE File = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(File);
+	EXPECT_EQ(io_write(File, pWritten, str_length(pWritten)), str_length(pWritten));
+	EXPECT_FALSE(io_close(File));
+	File = io_open(Info.m_aFilename, IOFLAG_READ | (SkipBom ? IOFLAG_SKIP_BOM : 0));
+	ASSERT_TRUE(File);
+	EXPECT_EQ(io_read(File, aBuf, sizeof(aBuf)), str_length(pRead));
+	EXPECT_TRUE(mem_comp(aBuf, pRead, str_length(pRead)) == 0);
+	EXPECT_FALSE(io_close(File));
+
+	fs_remove(Info.m_aFilename);
+}
+
+TEST(Io, Read1)
+{
+	TestFileRead("", false, "");
+}
+TEST(Io, Read2)
+{
+	TestFileRead("abc", false, "abc");
+}
+TEST(Io, Read3)
+{
+	TestFileRead("\xef\xbb\xbf", false, "\xef\xbb\xbf");
+}
+TEST(Io, Read4)
+{
+	TestFileRead("\xef\xbb\xbfxyz", false, "\xef\xbb\xbfxyz");
+}
+
+TEST(Io, ReadBom1)
+{
+	TestFileRead("", true, "");
+}
+TEST(Io, ReadBom2)
+{
+	TestFileRead("abc", true, "abc");
+}
+TEST(Io, ReadBom3)
+{
+	TestFileRead("\xef\xbb\xbf", true, "");
+}
+TEST(Io, ReadBom4)
+{
+	TestFileRead("\xef\xbb\xbfxyz", true, "xyz");
+}
+TEST(Io, ReadBom5)
+{
+	TestFileRead("\xef\xbb\xbf\xef\xbb\xbf", true, "\xef\xbb\xbf");
+}
+TEST(Io, ReadBom6)
+{
+	TestFileRead("\xef\xbb\xbfxyz\xef\xbb\xbf", true, "xyz\xef\xbb\xbf");
+}


### PR DESCRIPTION
Fixes handling of text files encoded with UTF-8 BOM. This changes `io_open` so the UTF-8 BOM signature is transparently skipped if the flag `IOFLAG_SKIP_BOM` is set.

It is not necessary to skip the BOM when reading `json` files, as the json parser already does this on its own.