### PR TITLE
Fix OOB access and undefined behavior in CSnapshot

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1464,7 +1464,9 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 					SnapSize = m_SnapshotDelta.UnpackDelta(pDeltaShot, pTmpBuffer3, pDeltaData, DeltaSize);
 					if(SnapSize < 0)
 					{
-						m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "client", "delta unpack failed!");
+						char aBuf[64];
+						str_format(aBuf, sizeof(aBuf), "delta unpack failed! (%d)", SnapSize);
+						m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "client", aBuf);
 						return;
 					}
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1407,7 +1407,6 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 					static CSnapshot Emptysnap;
 					CSnapshot *pDeltaShot = &Emptysnap;
 					int PurgeTick;
-					void *pDeltaData;
 					int DeltaSize;
 					unsigned char aTmpBuffer2[CSnapshot::MAX_SIZE];
 					unsigned char aTmpBuffer3[CSnapshot::MAX_SIZE];
@@ -1446,7 +1445,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 					}
 
 					// decompress snapshot
-					pDeltaData = m_SnapshotDelta.EmptyDelta();
+					const void *pDeltaData = m_SnapshotDelta.EmptyDelta();
 					DeltaSize = sizeof(int)*3;
 
 					if(CompleteSize)

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -599,7 +599,7 @@ void CServer::DoSnapshot()
 			// create delta
 			DeltaSize = m_SnapshotDelta.CreateDelta(pDeltashot, pData, aDeltaData);
 
-			if(DeltaSize)
+			if(DeltaSize > 0)
 			{
 				// compress it
 				int SnapshotSize;
@@ -644,6 +644,13 @@ void CServer::DoSnapshot()
 				Msg.AddInt(m_CurrentGameTick);
 				Msg.AddInt(m_CurrentGameTick-DeltaTick);
 				SendMsg(&Msg, MSGFLAG_FLUSH, i);
+
+				if(DeltaSize < 0)
+				{
+					char aBuf[64];
+					str_format(aBuf, sizeof(aBuf), "delta pack failed! (%d)", DeltaSize);
+					m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "server", aBuf);
+				}
 			}
 		}
 	}

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -177,7 +177,7 @@ void CSnapshotDelta::SetStaticsize(int ItemType, int Size)
 	m_aItemSizes[ItemType] = Size;
 }
 
-CSnapshotDelta::CData *CSnapshotDelta::EmptyDelta()
+const CSnapshotDelta::CData *CSnapshotDelta::EmptyDelta() const
 {
 	return &m_Empty;
 }

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -38,7 +38,7 @@ void CSnapshot::InvalidateItem(int Index)
 	((CSnapshotItem *)(DataStart() + Offsets()[Index]))->Invalidate();
 }
 
-int CSnapshot::Serialize(char *pDstData)
+int CSnapshot::Serialize(char *pDstData) const
 {
 	int *pData = (int*)pDstData;
 	pData[0] = m_DataSize;
@@ -494,7 +494,7 @@ void CSnapshotStorage::Add(int Tick, int64 Tagtime, int DataSize, const void *pD
 	m_pLast = pHolder;
 }
 
-int CSnapshotStorage::Get(int Tick, int64 *pTagtime, CSnapshot **ppData, CSnapshot **ppAltData)
+int CSnapshotStorage::Get(int Tick, int64 *pTagtime, CSnapshot **ppData, CSnapshot **ppAltData) const
 {
 	CHolder *pHolder = m_pFirst;
 
@@ -578,12 +578,12 @@ bool CSnapshotBuilder::UnserializeSnap(const char *pSrcData, int SrcSize)
 	return true;
 }
 
-CSnapshotItem *CSnapshotBuilder::GetItem(int Index)
+CSnapshotItem *CSnapshotBuilder::GetItem(int Index) const
 {
 	return (CSnapshotItem *)&(m_aData[m_aOffsets[Index]]);
 }
 
-int *CSnapshotBuilder::GetItemData(int Key)
+int *CSnapshotBuilder::GetItemData(int Key) const
 {
 	int i;
 	for(i = 0; i < m_NumItems; i++)

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -460,7 +460,7 @@ void CSnapshotStorage::PurgeUntil(int Tick)
 	m_pLast = 0;
 }
 
-void CSnapshotStorage::Add(int Tick, int64 Tagtime, int DataSize, void *pData, int CreateAlt)
+void CSnapshotStorage::Add(int Tick, int64 Tagtime, int DataSize, const void *pData, bool CreateAlt)
 {
 	// allocate memory for holder + snapshot_data
 	int TotalSize = sizeof(CHolder)+DataSize;

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -358,9 +358,13 @@ int CSnapshotDelta::UnpackDelta(const CSnapshot *pFrom, CSnapshot *pTo, const vo
 			return -1;
 
 		Type = *pData++;
-		if(Type < 0)
-			return -1;
+		if(Type < 0 || Type > CSnapshot::MAX_TYPE)
+			return -3;
+
 		ID = *pData++;
+		if(ID < 0 || ID > CSnapshot::MAX_ID)
+			return -3;
+
 		if(Type < MAX_NETOBJSIZES && m_aItemSizes[Type])
 			ItemSize = m_aItemSizes[Type];
 		else

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -37,6 +37,8 @@ class CSnapshot
 public:
 	enum
 	{
+		MAX_TYPE = 0x7fff,
+		MAX_ID = 0xffff,
 		MAX_PARTS	= 64,
 		MAX_SIZE	= MAX_PARTS*1024
 	};
@@ -75,8 +77,8 @@ private:
 		MAX_NETOBJSIZES=64
 	};
 	short m_aItemSizes[MAX_NETOBJSIZES];
-	int m_aSnapshotDataRate[0xffff];
-	int m_aSnapshotDataUpdates[0xffff];
+	int m_aSnapshotDataRate[CSnapshot::MAX_TYPE + 1];
+	int m_aSnapshotDataUpdates[CSnapshot::MAX_TYPE + 1];
 	int m_SnapshotCurrent;
 	CData m_Empty;
 

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -89,7 +89,7 @@ public:
 	int GetDataRate(int Index) const { return m_aSnapshotDataRate[Index]; }
 	int GetDataUpdates(int Index) const { return m_aSnapshotDataUpdates[Index]; }
 	void SetStaticsize(int ItemType, int Size);
-	CData *EmptyDelta();
+	const CData *EmptyDelta() const;
 	int CreateDelta(const class CSnapshot *pFrom, class CSnapshot *pTo, void *pData);
 	int UnpackDelta(const class CSnapshot *pFrom, class CSnapshot *pTo, const void *pData, int DataSize);
 };

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -87,8 +87,8 @@ public:
 	int GetDataUpdates(int Index) const { return m_aSnapshotDataUpdates[Index]; }
 	void SetStaticsize(int ItemType, int Size);
 	const CData *EmptyDelta() const;
-	int CreateDelta(const class CSnapshot *pFrom, class CSnapshot *pTo, void *pData);
-	int UnpackDelta(const class CSnapshot *pFrom, class CSnapshot *pTo, const void *pData, int DataSize);
+	int CreateDelta(const class CSnapshot *pFrom, class CSnapshot *pTo, void *pDstData);
+	int UnpackDelta(const class CSnapshot *pFrom, class CSnapshot *pTo, const void *pSrcData, int DataSize);
 };
 
 

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -79,10 +79,7 @@ private:
 	short m_aItemSizes[MAX_NETOBJSIZES];
 	int m_aSnapshotDataRate[CSnapshot::MAX_TYPE + 1];
 	int m_aSnapshotDataUpdates[CSnapshot::MAX_TYPE + 1];
-	int m_SnapshotCurrent;
 	CData m_Empty;
-
-	void UndiffItem(const int *pPast, const int *pDiff, int *pOut, int Size);
 
 public:
 	CSnapshotDelta();

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -121,7 +121,7 @@ public:
 	void Init();
 	void PurgeAll();
 	void PurgeUntil(int Tick);
-	void Add(int Tick, int64 Tagtime, int DataSize, void *pData, int CreateAlt);
+	void Add(int Tick, int64 Tagtime, int DataSize, const void *pData, bool CreateAlt);
 	int Get(int Tick, int64 *pTagtime, CSnapshot **ppData, CSnapshot **ppAltData);
 };
 

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -50,7 +50,7 @@ public:
 	int GetItemIndex(int Key) const;
 	void InvalidateItem(int Index);
 
-	int Serialize(char *pDstData);
+	int Serialize(char *pDstData) const;
 
 	int Crc() const;
 	void DebugDump() const;
@@ -119,7 +119,7 @@ public:
 	void PurgeAll();
 	void PurgeUntil(int Tick);
 	void Add(int Tick, int64 Tagtime, int DataSize, const void *pData, bool CreateAlt);
-	int Get(int Tick, int64 *pTagtime, CSnapshot **ppData, CSnapshot **ppAltData);
+	int Get(int Tick, int64 *pTagtime, CSnapshot **ppData, CSnapshot **ppAltData) const;
 };
 
 class CSnapshotBuilder
@@ -142,8 +142,8 @@ public:
 
 	void *NewItem(int Type, int ID, int Size);
 
-	CSnapshotItem *GetItem(int Index);
-	int *GetItemData(int Key);
+	CSnapshotItem *GetItem(int Index) const;
+	int *GetItemData(int Key) const;
 
 	int Finish(void *pSnapdata);
 };


### PR DESCRIPTION
The `Type` unpacked from the snapshot delta is not validated and later stored in `m_SnapshotCurrent`. This index is used to read and write `m_aSnapshotDataRate` and `m_aSnapshotDataUpdates`. Out of bound indices (e.g. `INT_MAX` or random large integers) can easily crash the client. Arbitrary code execution is technically possible, though it would be hard to exploit, as the write accesses will only increment the selected memory location.

This is fixed be ensuring that the `Type` is in the correct range. The `ID` also checked for mental wellbeing. Constants are introduced for the maximum value that both values can take. The maximum Type is changed from `0xffff` to `0x7fff`, as any types larger than that would lead to undefined behavior due to the sign bit of the `int m_TypeAndID` being used. A negative `m_TypeAndID` is already treated as an invalid snap item, hence normal Types should only be in range `0 - 0x7fff` to begin with.

Additionally, there was an off-by-one error on the array sizes of `m_aSnapshotDataRate` and `m_aSnapshotDataUpdates`. The arrays need to be one element larger each, as the allowed range includes the maximum value, which would otherwise be out of bounds.

Refactoring:

- Output the return value of `UnpackDelta` and `CreateDelta` in case of errors (when the value is negative). Though this does not happen for `CreateDelta` currently, it likely will, when validation is added for this method.
- Mark the empty delta as `const`, as it should never change.
- Remove `m_SnapshotCurrent` and make `UndiffItem` static: The member variable `m_SnapshotCurrent` was only used to pass a value directly to `UndiffItem` to index a specific array element. The middleman is removed by directly passing a pointer to the relevant memory location to the now static `UndiffItem`.
- Minor refactoring (see commits).