### PR TITLE
Also handle SIGTERM in server, simplify signal handling

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1809,7 +1809,7 @@ void CServer::SnapSetStaticsize(int ItemType, int Size)
 static CServer *CreateServer() { return new CServer(); }
 
 
-void HandleSigInt(int Param)
+void HandleSigIntTerm(int Param)
 {
 	if(InterruptSignaled)
 		_Exit(1); // exit is not async-signal-safe and must not be called from a signal handler
@@ -1847,7 +1847,8 @@ int main(int argc, const char **argv) // ignore_convention
 		return -1;
 	}
 
-	signal(SIGINT, HandleSigInt);
+	signal(SIGINT, HandleSigIntTerm);
+	signal(SIGTERM, HandleSigIntTerm);
 
 	CServer *pServer = CreateServer();
 	IKernel *pKernel = IKernel::Create();

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1811,10 +1811,11 @@ static CServer *CreateServer() { return new CServer(); }
 
 void HandleSigIntTerm(int Param)
 {
-	if(InterruptSignaled)
-		_Exit(1); // exit is not async-signal-safe and must not be called from a signal handler
-	else
-		InterruptSignaled = 1;
+	InterruptSignaled = 1;
+
+	// Exit the next time a signal is received
+	signal(SIGINT, SIG_DFL);
+	signal(SIGTERM, SIG_DFL);
 }
 
 int main(int argc, const char **argv) // ignore_convention


### PR DESCRIPTION
- Handle `SIGTERM` like `SIGINT` in server, shutting down gracefully on first signal and forcefully on second.
- Simplify signal handling by unregistering the signal handler on the first signal.