### PR TITLE
Minor refactoring: Use IsGameLayer instead of unused LAYERTYPE_GAME

### DIFF
--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -238,7 +238,7 @@ bool CEditor::PopupLayer(void *pContext, CUIRect View)
 
 	if(Prop == PROP_ORDER)
 		pEditor->m_SelectedLayer = pCurrentGroup->SwapLayers(pEditor->m_SelectedLayer, NewVal);
-	else if(Prop == PROP_GROUP && pCurrentLayer->m_Type != LAYERTYPE_GAME)
+	else if(Prop == PROP_GROUP && !IsGameLayer)
 	{
 		if(NewVal >= 0 && NewVal < pEditor->m_Map.m_lGroups.size())
 		{


### PR DESCRIPTION
`LAYERTYPE_GAME` was always unused, as game layers are instead tile layers with the game flag. This fixes the check for consistency, but it wasn't really required anyway, as the UI controls for the group are hidden and it's therefore already impossible to change the group of the game layer.