### PR TITLE
Make CTile a struct like all other mapitems

### DIFF
--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -7,7 +7,7 @@
 
 class CCollision
 {
-	class CTile *m_pTiles;
+	struct CTile *m_pTiles;
 	int m_Width;
 	int m_Height;
 	class CLayers *m_pLayers;

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -82,9 +82,8 @@ struct CQuad
 	int m_ColorEnvOffset;
 };
 
-class CTile
+struct CTile
 {
-public:
 	unsigned char m_Index;
 	unsigned char m_Flags;
 	unsigned char m_Skip;


### PR DESCRIPTION
This makes `CTile` a struct for consistency, as all other mapitems and the like are also structs. 

Preparation for #2931.