### PR TITLE
Fix OOB access in CHud::RenderSpectatorHud

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -775,16 +775,16 @@ void CHud::RenderHealthAndAmmo(const CNetObj_Character *pCharacter)
 
 void CHud::RenderSpectatorHud()
 {
+	const int SpecID = m_pClient->m_Snap.m_SpecInfo.m_SpectatorID;
+	const int SpecMode = m_pClient->m_Snap.m_SpecInfo.m_SpecMode;
+
 	// draw the box
 	const float Width = m_Width * 0.25f - 2.0f;
 	CUIRect Rect = {m_Width-Width, m_Height-15.0f, Width, 15.0f};
 	Rect.Draw(vec4(0.0f, 0.0f, 0.0f, 0.4f), 5.0f, CUIRect::CORNER_TL);
 
 	// draw the text
-	char aName[64];
-	const int SpecID = m_pClient->m_Snap.m_SpecInfo.m_SpectatorID;
-	const int SpecMode = m_pClient->m_Snap.m_SpecInfo.m_SpecMode;
-	str_format(aName, sizeof(aName), "%s", Config()->m_ClShowsocial ? m_pClient->m_aClients[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID].m_aName : "");
+	const char *pName = Config()->m_ClShowsocial && SpecID != -1 ? m_pClient->m_aClients[SpecID].m_aName : "";
 	char aBuf[128];
 
 	static CTextCursor s_SpectateLabelCursor(8.0f);
@@ -802,7 +802,7 @@ void CHud::RenderSpectatorHud()
 		str_format(aBuf, sizeof(aBuf), "%s", Localize("Free-View"));
 		break;
 	case SPEC_PLAYER:
-		str_format(aBuf, sizeof(aBuf), "%s", aName);
+		str_format(aBuf, sizeof(aBuf), "%s", pName);
 		break;
 	case SPEC_FLAGRED:
 	case SPEC_FLAGBLUE:
@@ -810,7 +810,7 @@ void CHud::RenderSpectatorHud()
 		str_format(aFlag, sizeof(aFlag), SpecMode == SPEC_FLAGRED ? Localize("Red Flag") : Localize("Blue Flag"));
 
 		if(SpecID != -1)
-			str_format(aBuf, sizeof(aBuf), "%s (%s)", aFlag, aName);
+			str_format(aBuf, sizeof(aBuf), "%s (%s)", aFlag, pName);
 		else
 			str_format(aBuf, sizeof(aBuf), "%s", aFlag);
 		break;


### PR DESCRIPTION
`SpecID` can be `-1`, resulting in 

```
src/game/client/components/hud.cpp:787:132: runtime error: index -1 out of bounds for type 'CClientData [64]'
    #0 0x561ffa4cdc3f in CHud::RenderSpectatorHud() src/game/client/components/hud.cpp:787
    #1 0x561ffa4daf12 in CHud::OnRender() src/game/client/components/hud.cpp:1007
    #2 0x561ffa1b9fd6 in CGameClient::OnRender() src/game/client/gameclient.cpp:611
    #3 0x561ffa08d4eb in CClient::Render() src/engine/client/client.cpp:798
    #4 0x561ffa0cdac6 in CClient::Run() src/engine/client/client.cpp:2135
    #5 0x561ffa0e70c2 in main src/engine/client/client.cpp:2712
    #6 0x7fddba2da0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #7 0x561ff9f640bd in _start (/teeworlds/build/x86_64/debug/teeworlds+0x11dc0bd)
```