### PR TITLE
Fix CDemoItem::m_Valid and m_InfosLoaded being uninitialized

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -412,6 +412,8 @@ private:
 		bool m_Valid;
 		CDemoHeader m_Info;
 
+		CDemoItem() : m_InfosLoaded(false), m_Valid(false) {}
+
 		int GetMarkerCount() const
 		{
 			if(!m_Valid || !m_InfosLoaded)

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -385,12 +385,10 @@ int CMenus::DemolistFetchCallback(const CFsFileInfo* pFileInfo, int IsDir, int S
 	if(IsDir)
 	{
 		str_format(Item.m_aName, sizeof(Item.m_aName), "%s/", pName);
-		Item.m_Valid = false;
 	}
 	else
 	{
 		str_truncate(Item.m_aName, sizeof(Item.m_aName), pName, str_length(pName) - 5);
-		Item.m_InfosLoaded = false;
 		Item.m_Date = pFileInfo->m_TimeModified;
 	}
 	Item.m_IsDir = IsDir != 0;


### PR DESCRIPTION
Fix use of uninitialized memory, which causes:

```
src/game/client/components/menus.h:417:8: runtime error: load of value 240, which is not a valid value for type 'bool'
    #0 0x558e9f2e1fcb in CMenus::CDemoItem::GetMarkerCount() const src/game/client/components/menus.h:417
    #1 0x558e9f2d4919 in CMenus::RenderDemoList(CUIRect) src/game/client/components/menus_demo.cpp:552
    #2 0x558e9f1a29f9 in CMenus::RenderMenu(CUIRect) src/game/client/components/menus.cpp:1158
    #3 0x558e9f1c6851 in CMenus::OnRender() src/game/client/components/menus.cpp:1798
    #4 0x558e9f00cfd6 in CGameClient::OnRender() src/game/client/gameclient.cpp:611
    #5 0x558e9eee04eb in CClient::Render() src/engine/client/client.cpp:798
    #6 0x558e9ef20ac6 in CClient::Run() src/engine/client/client.cpp:2135
    #7 0x558e9ef3a0c2 in main src/engine/client/client.cpp:2712
    #8 0x7fde25c5a0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #9 0x558e9edb70bd in _start (/teeworlds/build/x86_64/debug/teeworlds+0x11dc0bd)

src/game/client/components/menus_demo.cpp:739:99: runtime error: load of value 240, which is not a valid value for type 'bool'
    #0 0x558e9f2ddc0f in CMenus::RenderDemoDetails(CUIRect) src/game/client/components/menus_demo.cpp:739
    #1 0x558e9f17c750 in CMenus::DoIndependentDropdownMenu(void*, CUIRect const*, char const*, float, float (CMenus::*)(CUIRect), bool*) src/game/client/components/menus.cpp:360
    #2 0x558e9f2d76bb in CMenus::RenderDemoList(CUIRect) src/game/client/components/menus_demo.cpp:621
    #3 0x558e9f1a29f9 in CMenus::RenderMenu(CUIRect) src/game/client/components/menus.cpp:1158
    #4 0x558e9f1c6851 in CMenus::OnRender() src/game/client/components/menus.cpp:1798
    #5 0x558e9f00cfd6 in CGameClient::OnRender() src/game/client/gameclient.cpp:611
    #6 0x558e9eee04eb in CClient::Render() src/engine/client/client.cpp:798
    #7 0x558e9ef20ac6 in CClient::Run() src/engine/client/client.cpp:2135
    #8 0x558e9ef3a0c2 in main src/engine/client/client.cpp:2712
    #9 0x7fde25c5a0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #10 0x558e9edb70bd in _start (/teeworlds/build/x86_64/debug/teeworlds+0x11dc0bd)
```