### PR TITLE
Improve text contrast of selected console completion option

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -330,7 +330,7 @@ void CGameConsole::PossibleCommandsRenderCallback(int Index, const char *pStr, v
 
 	if(pInfo->m_EnumCount == pInfo->m_WantedCompletion)
 	{
-		pInfo->m_pSelf->TextRender()->TextColor(0.05f, 0.05f, 0.05f,1);
+		pInfo->m_pSelf->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 		const float BeginX = pInfo->m_pCursor->AdvancePosition().x - pInfo->m_Offset;
 		pInfo->m_pSelf->TextRender()->TextDeferred(pInfo->m_pCursor, pStr, -1);
 		CTextBoundingBox Box = pInfo->m_pCursor->BoundingBox();


### PR DESCRIPTION
Before:

![screenshot_2022-02-04_18-12-34](https://user-images.githubusercontent.com/23437060/152572812-f0efbc9f-e747-45e5-8e7d-7c43af9cc24d.png)

After:

![screenshot_2022-02-04_18-13-37](https://user-images.githubusercontent.com/23437060/152572822-68eb0d86-2c53-4736-9139-deef79d488e4.png)

From #2930.
