### PR TITLE
Minor refactoring of map_version tool

### DIFF
--- a/src/tools/map_version.cpp
+++ b/src/tools/map_version.cpp
@@ -1,7 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <base/math.h>
 #include <base/system.h>
+#include <base/math.h>
 
 #include <engine/kernel.h>
 #include <engine/map.h>
@@ -34,14 +34,16 @@ int MaplistCallback(const char *pName, int IsDir, int DirType, void *pUser)
 	char aMapName[8];
 	str_copy(aMapName, pName, minimum((int)sizeof(aMapName),l-3));
 
-	str_format(aBuf, sizeof(aBuf), "\t{\"%s\", {0x%02x, 0x%02x, 0x%02x, 0x%02x}, {0x%02x, 0x%02x, 0x%02x, 0x%02x}, {0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x}}, \n", aMapName,
+	str_format(aBuf, sizeof(aBuf),
+		"\t{\"%s\", {0x%02x, 0x%02x, 0x%02x, 0x%02x}, {0x%02x, 0x%02x, 0x%02x, 0x%02x}, {0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x}},\n",
+		aMapName,
 		(MapCrc>>24)&0xff, (MapCrc>>16)&0xff, (MapCrc>>8)&0xff, MapCrc&0xff,
 		(MapSize>>24)&0xff, (MapSize>>16)&0xff, (MapSize>>8)&0xff, MapSize&0xff,
 		MapSha256.data[0], MapSha256.data[1], MapSha256.data[2], MapSha256.data[3], MapSha256.data[4], MapSha256.data[5], MapSha256.data[6], MapSha256.data[7],
 		MapSha256.data[8], MapSha256.data[9], MapSha256.data[10], MapSha256.data[11], MapSha256.data[12], MapSha256.data[13], MapSha256.data[14], MapSha256.data[15],
 		MapSha256.data[16], MapSha256.data[17], MapSha256.data[18], MapSha256.data[19], MapSha256.data[20], MapSha256.data[21], MapSha256.data[22], MapSha256.data[23],
 		MapSha256.data[24], MapSha256.data[25], MapSha256.data[26], MapSha256.data[27], MapSha256.data[28], MapSha256.data[29], MapSha256.data[30], MapSha256.data[31]);
-io_write(s_File, aBuf, str_length(aBuf));
+	io_write(s_File, aBuf, str_length(aBuf));
 
 	return 0;
 }
@@ -60,11 +62,12 @@ int main(int argc, const char **argv)
 	if(RegisterFail)
 		return -1;
 
-	s_File = s_pStorage->OpenFile("map_version.txt", IOFLAG_WRITE, 1);
+	const int StorageType = 1; // this tools assumes that the data-dir is the second storage path
+	s_File = s_pStorage->OpenFile("map_version.txt", IOFLAG_WRITE, StorageType);
 	if(s_File)
 	{
-		io_write(s_File, "static CMapVersion s_aMapVersionList[] = {\n", str_length("static CMapVersion s_aMapVersionList[] = {\n"));
-		s_pStorage->ListDirectory(1, "maps", MaplistCallback, 0);
+		io_write(s_File, "static CMapVersion s_aMapVersionList[] = {\n", str_length("static const CMapVersion s_aMapVersionList[] = {\n"));
+		s_pStorage->ListDirectory(StorageType, "maps", MaplistCallback, 0x0);
 		io_write(s_File, "};\n", str_length("};\n"));
 		io_close(s_File);
 	}


### PR DESCRIPTION
Remove space from end of lines of generated output.

Add `const` to generated output in accordance with #3044.

Add a comment explaining that the tool always uses the second storage path, which is assumed the default data dir.
I was getting an empty output, because my second storage path didn't have any maps in it.