### PR TITLE
Improve new version message contrast and wrapping

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -687,7 +687,6 @@ private:
 
 	// found in menus_start.cpp
 	void RenderStartMenu(CUIRect MainView);
-	void RenderLogo(CUIRect MainView);
 
 	// found in menus_ingame.cpp
 	void RenderGame(CUIRect MainView);

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -103,21 +103,19 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	CUIRect Version;
 	MainView.HSplitBottom(50.0f, 0, &Version);
 	Version.VMargin(50.0f, &Version);
-	char aBuf[64];
+	UI()->DoLabel(&Version, GAME_RELEASE_VERSION, 14.0f, TEXTALIGN_TR);
+
 	if(str_comp(Client()->LatestVersion(), "0") != 0)
 	{
+		char aBuf[64];
 		str_format(aBuf, sizeof(aBuf), Localize("Teeworlds %s is out! Download it at www.teeworlds.com!"), Client()->LatestVersion());
 		TextRender()->TextColor(1.0f, 0.4f, 0.4f, 1.0f);
-		UI()->DoLabel(&Version, aBuf, 14.0f, TEXTALIGN_CENTER);
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		TextRender()->TextSecondaryColor(0.0f, 0.0f, 0.0f, 0.5f);
+		UI()->DoLabel(&TopMenu, aBuf, 14.0f, TEXTALIGN_MC, TopMenu.w * 0.9f, true);
+		TextRender()->TextColor(CUI::ms_DefaultTextColor);
+		TextRender()->TextSecondaryColor(CUI::ms_DefaultTextOutlineColor);
 	}
-	UI()->DoLabel(&Version, GAME_RELEASE_VERSION, 14.0f, TEXTALIGN_RIGHT);
 
 	if(NewPage != -1)
 		SetMenuPage(NewPage);
-}
-
-void CMenus::RenderLogo(CUIRect MainView)
-{
-	
 }


### PR DESCRIPTION
Improve text wrapping and contrast (darken text outline color) of new version notice.

Before:

![screenshot_2022-02-04_21-04-02](https://user-images.githubusercontent.com/23437060/152610813-301d60e0-b45f-42e6-8f97-72b2326a4c8e.png)

After\*:

![screenshot_2022-02-04_21-23-58](https://user-images.githubusercontent.com/23437060/152610818-60b1656b-df11-4f8e-8212-914b21b91e5b.png)

\* It will only wrap correctly when #2996 is also merged, as that PR fixes word wrapping for multi line labels.