### PR TITLE
Close selected server browser filter before opening newly added filter

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1548,6 +1548,9 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 		static CButtonContainer s_AddFilter;
 		if(UI()->DoButtonLogic(&s_AddFilter, &Button))
 		{
+			CBrowserFilter *pSelectedFilter = GetSelectedBrowserFilter();
+			if(pSelectedFilter)
+				pSelectedFilter->Switch();
 			m_lFilters.add(CBrowserFilter(CBrowserFilter::FILTER_CUSTOM, s_aFilterName, ServerBrowser()));
 			m_lFilters[m_lFilters.size()-1].Switch();
 			s_aFilterName[0] = 0;


### PR DESCRIPTION
Close currently open server browser filter before opening a new filter added with "New filter". Otherwise two filters would be open at the same time, which is not intended and causes the scrollbar handle to become very small.