### PR TITLE
Expose Storage in gamecontext

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4,6 +4,7 @@
 
 #include <engine/shared/config.h>
 #include <engine/shared/memheap.h>
+#include <engine/storage.h>
 #include <engine/map.h>
 
 #include <generated/server_data.h>
@@ -1554,6 +1555,7 @@ void CGameContext::OnInit()
 	m_pServer = Kernel()->RequestInterface<IServer>();
 	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
+	m_pStorage = Kernel()->RequestInterface<IStorage>();
 	m_World.SetGameServer(this);
 	m_Events.SetGameServer(this);
 	m_CommandManager.Init(m_pConsole, this, NewCommandHook, RemoveCommandHook);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -39,6 +39,7 @@ class CGameContext : public IGameServer
 	IServer *m_pServer;
 	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
+	class IStorage *m_pStorage;
 	CLayers m_Layers;
 	CCollision m_Collision;
 	CNetObjHandler m_NetObjHandler;
@@ -77,6 +78,7 @@ public:
 	IServer *Server() const { return m_pServer; }
 	class CConfig *Config() { return m_pConfig; }
 	class IConsole *Console() { return m_pConsole; }
+	class IStorage *Storage() { return m_pStorage; }
 	CCollision *Collision() { return &m_Collision; }
 	CTuningParams *Tuning() { return &m_Tuning; }
 


### PR DESCRIPTION
This allows server modders to use GameServer()->Storage() in their own
game controller without touching other source code

Standard game controllers do no file IO but modders love to do that :) Would be nice if they could just hack away in ``game/server/gamemodes/mod.cpp`` using the teeworlds Storage system.