### PR TITLE
Text Selection and IME support! 🎉

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,7 +385,7 @@ endif()
 
 if(TARGET_OS STREQUAL "windows")
   set(PLATFORM_CLIENT)
-  set(PLATFORM_CLIENT_LIBS opengl32 winmm)
+  set(PLATFORM_CLIENT_LIBS opengl32 winmm imm32)
   set(PLATFORM_LIBS ws2_32) # Windows sockets
 elseif(TARGET_OS STREQUAL "mac")
   find_library(CARBON Carbon)

--- a/bam.lua
+++ b/bam.lua
@@ -276,6 +276,7 @@ function GenerateWindowsSettings(settings, conf, target_arch, compiler)
 	settings.link.extrafiles:Add(manifests.client)
 	settings.link.libs:Add("opengl32")
 	settings.link.libs:Add("winmm")
+	settings.link.libs:Add("imm32")
 	BuildClient(settings)
 
 	-- Content

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -25,6 +25,14 @@
 	#define SDL_JOYSTICK_AXIS_MAX 32767
 #endif
 
+// for platform specific features that aren't available or are broken in SDL
+#include "SDL_syswm.h"
+
+#if defined(CONF_FAMILY_WINDOWS)
+#include <windows.h>
+#include <imm.h>
+#endif
+
 void CInput::AddEvent(char *pText, int Key, int Flags)
 {
 	if(m_NumEvents != INPUT_BUFFER_SIZE)
@@ -58,6 +66,12 @@ CInput::CInput()
 	m_MouseDoubleClick = false;
 
 	m_NumEvents = 0;
+
+	m_CompositionLength = COMP_LENGTH_INACTIVE;
+	m_CompositionCursor = 0;
+	m_CompositionSelectedLength = 0;
+	m_CandidateCount = 0;
+	m_CandidateSelectedIndex = -1;
 }
 
 CInput::~CInput()
@@ -69,10 +83,11 @@ CInput::~CInput()
 
 void CInput::Init()
 {
+	StopTextInput();
+
 	m_pGraphics = Kernel()->RequestInterface<IEngineGraphics>();
 	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
-	// FIXME: unicode handling: use SDL_StartTextInput/SDL_StopTextInput on inputs
 
 	MouseModeRelative();
 
@@ -315,6 +330,25 @@ void CInput::SetClipboardText(const char *pText)
 	SDL_SetClipboardText(pText);
 }
 
+void CInput::StartTextInput()
+{
+	// enable system messages for ime
+	SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
+	SDL_StartTextInput();
+}
+
+void CInput::StopTextInput()
+{
+	SDL_StopTextInput();
+	// disable system messages for performance
+	SDL_EventState(SDL_SYSWMEVENT, SDL_DISABLE);
+	m_CompositionLength = COMP_LENGTH_INACTIVE;
+	m_CompositionCursor = 0;
+	m_aComposition[0] = 0;
+	m_CompositionSelectedLength = 0;
+	m_CandidateCount = 0;
+}
+
 void CInput::Clear()
 {
 	mem_zero(m_aInputState, sizeof(m_aInputState));
@@ -454,6 +488,16 @@ void CInput::HandleJoystickHatMotionEvent(const SDL_Event &Event)
 	}
 }
 
+void CInput::SetCompositionWindowPosition(float X, float Y, float H)
+{
+	SDL_Rect Rect;
+	Rect.x = X / m_pGraphics->ScreenHiDPIScale();
+	Rect.y = Y / m_pGraphics->ScreenHiDPIScale();
+	Rect.h = H / m_pGraphics->ScreenHiDPIScale();
+	Rect.w = 0;
+	SDL_SetTextInputRect(&Rect);
+}
+
 int CInput::Update()
 {
 	// keep the counter between 1..0xFFFF, 0 means not pressed
@@ -478,7 +522,41 @@ int CInput::Update()
 		int Action = IInput::FLAG_PRESS;
 		switch(Event.type)
 		{
+			// handle text editing candidate
+			case SDL_SYSWMEVENT:
+				ProcessSystemMessage(Event.syswm.msg);
+				break;
+
+			// handle on the spot text editing
+			case SDL_TEXTEDITING:
+			{
+				m_CompositionLength = str_length(Event.edit.text);
+				if(m_CompositionLength)
+				{
+					str_copy(m_aComposition, Event.edit.text, sizeof(m_aComposition));
+					m_CompositionCursor = 0;
+					for(int i = 0; i < Event.edit.start; i++)
+						m_CompositionCursor = str_utf8_forward(m_aComposition, m_CompositionCursor);
+					int CompositionEnd = m_CompositionCursor;
+					for(int i = 0; i < Event.edit.length; i++)
+						CompositionEnd = str_utf8_forward(m_aComposition, CompositionEnd);
+					m_CompositionSelectedLength = CompositionEnd - m_CompositionCursor;
+					AddEvent(0, 0, IInput::FLAG_TEXT);
+				}
+				else
+				{
+					m_aComposition[0] = '\0';
+					m_CompositionLength = 0;
+					m_CompositionCursor = 0;
+					m_CompositionSelectedLength = 0;
+				}
+				break;
+			}
 			case SDL_TEXTINPUT:
+				m_aComposition[0] = 0;
+				m_CompositionLength = COMP_LENGTH_INACTIVE;
+				m_CompositionCursor = 0;
+				m_CompositionSelectedLength = 0;
 				AddEvent(Event.text.text, 0, IInput::FLAG_TEXT);
 				break;
 
@@ -554,7 +632,7 @@ int CInput::Update()
 				return 1;
 		}
 
-		if(Key >= 0)
+		if(Key >= 0 && !HasComposition())
 		{
 			if((Action&IInput::FLAG_PRESS) && Key < g_MaxKeys && Scancode >= 0 && Scancode < g_MaxKeys)
 			{
@@ -565,8 +643,64 @@ int CInput::Update()
 		}
 	}
 
+	if(m_CompositionLength == 0)
+		m_CompositionLength = COMP_LENGTH_INACTIVE;
+
 	return 0;
 }
 
+void CInput::ProcessSystemMessage(SDL_SysWMmsg *pMsg)
+{
+#if defined(CONF_FAMILY_WINDOWS)
+	// Todo SDL: remove this after SDL2 supports IME candidates
+	if(pMsg->subsystem == SDL_SYSWM_WINDOWS)
+	{
+		if(pMsg->msg.win.msg != WM_IME_NOTIFY)
+			return;
+
+		switch(pMsg->msg.win.wParam)
+		{
+			case IMN_OPENCANDIDATE:
+			case IMN_CHANGECANDIDATE:
+			{
+				HWND WindowHandle = pMsg->msg.win.hwnd;
+				HIMC ImeContext = ImmGetContext(WindowHandle);
+				DWORD CandidateCount;
+				DWORD Size = ImmGetCandidateListCountW(ImeContext, &CandidateCount);
+				LPCANDIDATELIST CandidateList = NULL;
+				if(Size > 0)
+				{
+					CandidateList = (LPCANDIDATELIST)mem_alloc(Size);
+					Size = ImmGetCandidateListW(ImeContext, 0, CandidateList, Size);
+				}
+				if(CandidateList && Size > 0)
+				{
+					m_CandidateCount = 0;
+					for(DWORD i = CandidateList->dwPageStart; i < CandidateList->dwCount && m_CandidateCount < (int)CandidateList->dwPageSize; i++)
+					{
+						LPCWSTR Candidate = (LPCWSTR)((DWORD_PTR)CandidateList + CandidateList->dwOffset[i]);
+						WideCharToMultiByte(CP_UTF8, 0, Candidate, -1, m_aaCandidates[m_CandidateCount], MAX_CANDIDATE_ARRAY_SIZE, "?", NULL);
+						m_aaCandidates[m_CandidateCount][MAX_CANDIDATE_ARRAY_SIZE - 1] = '\0';
+						m_CandidateCount++;
+					}
+					m_CandidateSelectedIndex = CandidateList->dwSelection - CandidateList->dwPageStart;
+				}
+				else
+				{
+					m_CandidateCount = 0;
+					m_CandidateSelectedIndex = -1;
+				}
+				mem_free(CandidateList);
+				ImmReleaseContext(WindowHandle, ImeContext);
+				break;
+			}
+			case IMN_CLOSECANDIDATE:
+				m_CandidateCount = 0;
+				m_CandidateSelectedIndex = -1;
+				break;
+		}
+	}
+#endif
+}
 
 IEngineInput *CreateEngineInput() { return new CInput; }

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -66,6 +66,15 @@ private:
 
 	bool m_MouseDoubleClick;
 
+	// ime support
+	char m_aComposition[MAX_COMPOSITION_ARRAY_SIZE];
+	int m_CompositionCursor;
+	int m_CompositionSelectedLength;
+	int m_CompositionLength;
+	char m_aaCandidates[MAX_CANDIDATES][MAX_CANDIDATE_ARRAY_SIZE];
+	int m_CandidateCount;
+	int m_CandidateSelectedIndex;
+
 	void AddEvent(char *pText, int Key, int Flags);
 	void Clear();
 	bool IsEventValid(CEvent *pEvent) const { return pEvent->m_InputCount == m_InputCounter; }
@@ -83,6 +92,9 @@ private:
 
 	void ClearKeyStates();
 	bool KeyState(int Key) const;
+
+	void ProcessSystemMessage(SDL_SysWMmsg *pMsg);
+
 public:
 	CInput();
 	~CInput();
@@ -104,6 +116,17 @@ public:
 
 	const char *GetClipboardText();
 	void SetClipboardText(const char *pText);
-};
 
+	void StartTextInput();
+	void StopTextInput();
+	const char *GetComposition() const { return m_aComposition; }
+	bool HasComposition() const { return m_CompositionLength != COMP_LENGTH_INACTIVE; }
+	int GetCompositionCursor() const { return m_CompositionCursor; }
+	int GetCompositionSelectedLength() const { return m_CompositionSelectedLength; }
+	int GetCompositionLength() const { return m_CompositionLength; }
+	const char *GetCandidate(int Index) const { return m_aaCandidates[Index]; }
+	int GetCandidateCount() const { return m_CandidateCount; }
+	int GetCandidateSelectedIndex() const { return m_CandidateSelectedIndex; }
+	void SetCompositionWindowPosition(float X, float Y, float H);
+};
 #endif

--- a/src/engine/client/textrender.h
+++ b/src/engine/client/textrender.h
@@ -213,6 +213,7 @@ public:
 	void DrawTextOutlined(CTextCursor *pCursor, float Alpha, int StartGlyph, int NumGlyphs);
 	void DrawTextShadowed(CTextCursor *pCursor, vec2 ShadowOffset, float Alpha, int StartGlyph, int NumGlyphs);
 
+	int CharToGlyph(CTextCursor *pCursor, int NumChars, float *pLineWidth = 0);
 	vec2 CaretPosition(CTextCursor *pCursor, int NumChars);
 };
 

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -17,7 +17,7 @@ public:
 	public:
 		int m_Flags;
 		int m_Key;
-		char m_aText[32];
+		char m_aText[32*UTF8_BYTE_LENGTH+1];
 		int m_InputCount;
 	};
 
@@ -38,10 +38,18 @@ public:
 		FLAG_RELEASE=2,
 		FLAG_REPEAT=4,
 		FLAG_TEXT=8,
+		FLAG_TEXTEDIT=16,
 
 		CURSOR_NONE = 0,
 		CURSOR_MOUSE,
 		CURSOR_JOYSTICK,
+
+		MAX_CANDIDATES = 16,
+		MAX_CANDIDATE_LENGTH = 16,
+		MAX_CANDIDATE_ARRAY_SIZE=MAX_CANDIDATE_LENGTH*UTF8_BYTE_LENGTH+1,
+		MAX_COMPOSITION_ARRAY_SIZE = 32, // SDL2 limitation
+
+		COMP_LENGTH_INACTIVE = -1
 	};
 
 	// events
@@ -91,6 +99,19 @@ public:
 	// clipboard
 	virtual const char *GetClipboardText() = 0;
 	virtual void SetClipboardText(const char *pText) = 0;
+
+	// text editing
+	virtual void StartTextInput() = 0;
+	virtual void StopTextInput() = 0;
+	virtual const char *GetComposition() const = 0;
+	virtual bool HasComposition() const = 0;
+	virtual int GetCompositionCursor() const = 0;
+	virtual int GetCompositionSelectedLength() const = 0;
+	virtual int GetCompositionLength() const = 0;
+	virtual const char *GetCandidate(int Index) const = 0;
+	virtual int GetCandidateCount() const = 0;
+	virtual int GetCandidateSelectedIndex() const = 0;
+	virtual void SetCompositionWindowPosition(float X, float Y, float H) = 0;
 
 	int CursorRelative(float *pX, float *pY)
 	{

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -138,6 +138,7 @@ public:
 		if (StringVersion < 0 || m_StringVersion != StringVersion)
 		{
 			m_Width = 0;
+			m_Height = 0;
 			m_NextLineAdvanceY = 0;
 			m_Advance = vec2(0, 0);
 			m_LineCount = 1;
@@ -215,6 +216,7 @@ public:
 	virtual void DrawTextShadowed(CTextCursor *pCursor, vec2 ShadowOffset, float Alpha = 1.0f, int StartGlyph = 0, int NumGlyphs = -1) = 0;
 
 	// QoL APIs
+	virtual int CharToGlyph(CTextCursor *pCursor, int NumChars, float *pLineWidth = 0) = 0;
 	virtual vec2 CaretPosition(CTextCursor *pCursor, int NumChars) = 0;
 };
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -888,25 +888,27 @@ void CChat::OnRender()
 		s_CategoryCursor.MoveTo(x + IconOffsetX + ClientIDWidth, y);
 		TextRender()->DrawTextOutlined(&s_CategoryCursor);
 
-		static CTextCursor m_InputCursor(InputFontSize);
 		vec2 CursorPosition = s_CategoryCursor.CursorPosition();
 		CursorPosition.x += s_CategoryCursor.Width() + 4.0f;
 		CursorPosition.y -= (InputFontSize-CategoryFontSize)*0.5f;
-		m_InputCursor.m_MaxWidth = Width-190.0f-s_CategoryCursor.Width();
-		m_InputCursor.Reset();
+
+		// cache buffered text and only reset when switching modes
+		static CTextCursor m_BufferedCursor(InputFontSize);
+		m_BufferedCursor.Reset(m_Mode);
 
 		//render buffered text
 		if(m_Mode == CHAT_NONE)
 		{
+			m_BufferedCursor.MoveTo(CursorPosition);
+
 			//calculate WidthLimit
-			m_InputCursor.MoveTo(CursorPosition);
-			m_InputCursor.m_MaxWidth = LineWidth+x+3.0f-s_CategoryCursor.Width();
-			m_InputCursor.m_MaxLines = 1;
-			m_InputCursor.m_Flags = TEXTFLAG_ELLIPSIS;
+			m_BufferedCursor.m_MaxWidth = LineWidth+x+3.0f-s_CategoryCursor.Width();
+			m_BufferedCursor.m_MaxLines = 1;
+			m_BufferedCursor.m_Flags = TEXTFLAG_ELLIPSIS;
 
 			//add dots when string excesses length
 			TextRender()->TextColor(1.0f, 1.0f, 1.0f, Blend);
-			TextRender()->TextOutlined(&m_InputCursor, m_Input.GetString(), -1);
+			TextRender()->TextOutlined(&m_BufferedCursor, m_Input.GetString(), -1);
 
 			//render helper annotation
 			static CTextCursor s_InfoCursor(CategoryFontSize*0.75f);
@@ -932,22 +934,37 @@ void CChat::OnRender()
 		{
 			m_Input.Activate(CHAT); // ensure the input is active
 
-			float ScrollOffset = m_Input.GetScrollOffset();
-			m_InputCursor.MoveTo(CursorPosition.x, CursorPosition.y - ScrollOffset);
-			m_InputCursor.m_MaxLines = -1;
-			m_InputCursor.m_Flags = TEXTFLAG_WORD_WRAP;
+			CTextCursor *pCursor = m_Input.GetCursor();
+			pCursor->m_FontSize = InputFontSize;
+			pCursor->m_MaxWidth = Width-190.0f-s_CategoryCursor.Width();
 
-			// Render normal text
-			TextRender()->TextDeferred(&m_InputCursor, m_Input.GetString(), -1);
+			float ScrollOffset = m_Input.GetScrollOffset();
+			pCursor->MoveTo(CursorPosition.x, CursorPosition.y - ScrollOffset);
+			pCursor->m_MaxLines = -1;
+			pCursor->m_Flags = TEXTFLAG_WORD_WRAP;
 
 			//Render command autocomplete option hint
-			if(IsTypingCommand() && m_CommandManager.CommandCount() - m_FilteredCount && m_SelectedCommand >= 0)
+			if(IsTypingCommand() && m_CommandManager.CommandCount() - m_FilteredCount && m_SelectedCommand >= 0 && pCursor->LineCount() == 1)
 			{
+				static CTextCursor m_HintCursor(InputFontSize);
+
+				m_HintCursor.Reset();
+				m_HintCursor.MoveTo(pCursor->CursorPosition());
+				m_HintCursor.m_MaxWidth = Width-190.0f-s_CategoryCursor.Width();
+				m_HintCursor.m_MaxLines = 1;
+				m_HintCursor.m_Flags = TEXTFLAG_ELLIPSIS;
+
 				const CCommandManager::CCommand *pCommand = m_CommandManager.GetCommand(m_SelectedCommand);
-				if(str_length(pCommand->m_aName)+1 > str_length(m_Input.GetString()))
+				int InputLength = str_length(m_Input.GetString());
+				if(str_length(pCommand->m_aName)+1 > InputLength)
 				{
-					TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.5f);
-					TextRender()->TextDeferred(&m_InputCursor, pCommand->m_aName + str_length(m_Input.GetString())-1, -1);
+					// fake render input text again (for correct kerning)
+					TextRender()->TextDeferred(&m_HintCursor, m_Input.GetString(), InputLength);
+					int SkipGlyphs = m_HintCursor.GlyphCount();
+
+					// render actual completion text
+					TextRender()->TextDeferred(&m_HintCursor, pCommand->m_aName+InputLength-1, -1);
+					TextRender()->DrawTextOutlined(&m_HintCursor, 0.5f, SkipGlyphs);
 				}
 			}
 
@@ -963,19 +980,19 @@ void CChat::OnRender()
 			}
 
 			const float Spacing = 1.0f;
-			const CUIRect ClippingRect = { CursorPosition.x-Spacing, CursorPosition.y-Spacing, m_InputCursor.m_MaxWidth+2*Spacing, 2*InputFontSize+3*Spacing };
+			const CUIRect ClippingRect = { CursorPosition.x-Spacing, CursorPosition.y-Spacing, pCursor->m_MaxWidth+2*Spacing, 2*InputFontSize+3*Spacing };
 			const float XScale = Graphics()->ScreenWidth()/Width;
 			const float YScale = Graphics()->ScreenHeight()/Height;
 			Graphics()->ClipEnable((int)(ClippingRect.x*XScale), (int)(ClippingRect.y*YScale), (int)(ClippingRect.w*XScale), (int)(ClippingRect.h*YScale));
-			m_Input.Render(&m_InputCursor);
+			m_Input.Render();
 			Graphics()->ClipDisable();
 
 			// scroll to keep the caret inside the clipping rect
-			float CaretPositionY = TextRender()->CaretPosition(&m_InputCursor, m_Input.GetCursorOffset()).y+InputFontSize/2.0f;
+			const float CaretPositionY = m_Input.GetCaretPosition().y + InputFontSize * 0.5f;
 			if(CaretPositionY < ClippingRect.y)
-				m_Input.SetScrollOffset(maximum(0.0f, ScrollOffset-InputFontSize));
-			else if(CaretPositionY > ClippingRect.y+ClippingRect.h)
-				m_Input.SetScrollOffset(ScrollOffset+InputFontSize);
+				m_Input.SetScrollOffset(maximum(0.0f, ScrollOffset - InputFontSize));
+			else if(CaretPositionY + InputFontSize * 0.35f > ClippingRect.y + ClippingRect.h)
+				m_Input.SetScrollOffset(ScrollOffset + InputFontSize);
 		}
 	}
 

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -125,7 +125,8 @@ public:
 
 	bool IsActive() const { return m_Mode != CHAT_NONE; }
 	void AddLine(const char *pLine, int ClientID = SERVER_MSG, int Mode = CHAT_NONE, int TargetID = -1);
-	void EnableMode(int Mode, const char* pText = NULL);
+	void Disable();
+	void EnableMode(int Mode, const char *pText = 0x0);
 	void Say(int Mode, const char *pLine);
 	void ClearChatBuffer();
 	const char* GetCommandName(int Mode) const;

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -500,16 +500,8 @@ void CGameConsole::OnRender()
 
 		x = s_PromptCursor.AdvancePosition().x;
 
-		//hide rcon password
-		char aInputString[256];
-		str_copy(aInputString, pConsole->m_Input.GetString(), sizeof(aInputString));
-		if(m_ConsoleType == CONSOLETYPE_REMOTE && (Client()->State() == IClient::STATE_ONLINE || Client()->State() == IClient::STATE_LOADING) && !Client()->RconAuthed())
-		{
-			for(int i = 0; i < pConsole->m_Input.GetLength(); ++i)
-				aInputString[i] = '*';
-		}
-
 		// render console input (wrap line)
+		pConsole->m_Input.SetHidden(m_ConsoleType == CONSOLETYPE_REMOTE && (Client()->State() == IClient::STATE_ONLINE || Client()->State() == IClient::STATE_LOADING) && !Client()->RconAuthed());
 		CTextCursor *pInputCursor = pConsole->m_Input.GetCursor();
 		pInputCursor->m_Align = TEXTALIGN_BL;
 		pInputCursor->m_MaxLines = -1;

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -480,11 +480,8 @@ void CGameConsole::OnRender()
 		s_InfoCursor.m_MaxWidth = -1.0f;
 
 		// render prompt
-		static CTextCursor s_Cursor;
-		s_Cursor.Reset();
-		s_Cursor.MoveTo(x, y);
-		s_Cursor.m_FontSize = FontSize;
-		s_Cursor.m_MaxLines = -1;
+		static CTextCursor s_PromptCursor(FontSize);
+		s_PromptCursor.MoveTo(x, y);
 		const char *pPrompt = "> ";
 		if(m_ConsoleType == CONSOLETYPE_REMOTE)
 		{
@@ -498,9 +495,10 @@ void CGameConsole::OnRender()
 			else
 				pPrompt = "NOT CONNECTED> ";
 		}
-		TextRender()->TextOutlined(&s_Cursor, pPrompt, -1);
+		s_PromptCursor.Reset((int64)pPrompt);
+		TextRender()->TextOutlined(&s_PromptCursor, pPrompt, -1);
 
-		x = s_Cursor.AdvancePosition().x;
+		x = s_PromptCursor.AdvancePosition().x;
 
 		//hide rcon password
 		char aInputString[256];
@@ -512,13 +510,17 @@ void CGameConsole::OnRender()
 		}
 
 		// render console input (wrap line)
-		s_Cursor.Reset();
-		s_Cursor.m_MaxWidth = Screen.w - 10.0f - x;
-		TextRender()->TextDeferred(&s_Cursor, aInputString, -1);
-		y -= (s_Cursor.LineCount() - 1) * FontSize;
-		s_Cursor.MoveTo(x, y);
+		CTextCursor *pInputCursor = pConsole->m_Input.GetCursor();
+		pInputCursor->m_Align = TEXTALIGN_BL;
+		pInputCursor->m_MaxLines = -1;
+		pInputCursor->m_FontSize = FontSize;
+		pInputCursor->m_MaxWidth = Screen.w - 10.0f - x;
+		pInputCursor->MoveTo(x, y + FontSize * 1.35f);
+
 		pConsole->m_Input.Activate(CONSOLE); // ensure the input is active
-		pConsole->m_Input.Render(&s_Cursor);
+		pConsole->m_Input.Render();
+
+		y -= (pInputCursor->LineCount() - 1) * FontSize;
 
 		// render possible commands
 		if(m_ConsoleType == CONSOLETYPE_LOCAL || Client()->RconAuthed())
@@ -568,6 +570,11 @@ void CGameConsole::OnRender()
 		TextRender()->TextColor(1,1,1,1);
 
 		//	render log (actual page, wrap lines)
+		static CTextCursor s_Cursor;
+		s_Cursor.Reset();
+		s_Cursor.MoveTo(x, y);
+		s_Cursor.m_FontSize = FontSize;
+		s_Cursor.m_MaxLines = -1;
 
 		CInstance::CBacklogEntry *pEntry = pConsole->m_Backlog.Last();
 		float OffsetY = 0.0f;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1288,7 +1288,8 @@ void CMenus::RenderMenu(CUIRect Screen)
 			CUIRect EditBox;
 			Box.HSplitTop(20.0f, &EditBox, &Box);
 			static CLineInput s_PasswordInput(Config()->m_Password, sizeof(Config()->m_Password));
-			UI()->DoEditBoxOption(&s_PasswordInput, &EditBox, Localize("Password"), ButtonWidth, true);
+			s_PasswordInput.SetHidden(true);
+			UI()->DoEditBoxOption(&s_PasswordInput, &EditBox, Localize("Password"), ButtonWidth);
 
 			Box.HSplitTop(2.0f, 0, &Box);
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1158,7 +1158,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	UI()->DoLabel(&Label, Localize("Search:"), FontSize, TEXTALIGN_LEFT);
 	EditBox.VSplitRight(EditBox.h, &EditBox, &Button);
 	static CLineInput s_FilterInput(Config()->m_BrFilterString, sizeof(Config()->m_BrFilterString));
-	if(UI()->DoEditBox(&s_FilterInput, &EditBox, FontSize, false, CUIRect::CORNER_L))
+	if(UI()->DoEditBox(&s_FilterInput, &EditBox, FontSize, CUIRect::CORNER_L))
 	{
 		Client()->ServerBrowserUpdate();
 		ServerBrowserFilterOnUpdate();
@@ -1553,7 +1553,7 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 	Button.VSplitLeft(60.0f, &Icon, &Button);
 	static char s_aFilterName[32] = { 0 };
 	static CLineInput s_FilterInput(s_aFilterName, sizeof(s_aFilterName));
-	UI()->DoEditBox(&s_FilterInput, &Icon, FontSize, false, CUIRect::CORNER_L);
+	UI()->DoEditBox(&s_FilterInput, &Icon, FontSize, CUIRect::CORNER_L);
 	Button.Draw(vec4(1.0f, 1.0f, 1.0f, 0.25f), 5.0f, CUIRect::CORNER_R);
 	Button.VSplitLeft(Button.h, &Icon, &Label);
 	Label.HMargin(2.0f, &Label);
@@ -1720,7 +1720,7 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 
 		static char s_aGametype[16] = { 0 };
 		static CLineInput s_GametypeInput(s_aGametype, sizeof(s_aGametype));
-		UI()->DoEditBox(&s_GametypeInput, &EditBox, FontSize, false, CUIRect::CORNER_L);
+		UI()->DoEditBox(&s_GametypeInput, &EditBox, FontSize, CUIRect::CORNER_L);
 
 		static CButtonContainer s_AddInclusiveGametype;
 		if(DoButton_Menu(&s_AddInclusiveGametype, "+", 0, &AddIncButton, 0, 0) && s_aGametype[0])

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -790,7 +790,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 				Label.y += 2.0f;
 				UI()->DoLabel(&Label, pReasonLabel, FontSize, TEXTALIGN_LEFT);
 				static CLineInput s_ReasonInput(m_aCallvoteReason, sizeof(m_aCallvoteReason));
-				UI()->DoEditBox(&s_ReasonInput, &Reason, FontSize, false, CUIRect::CORNER_L);
+				UI()->DoEditBox(&s_ReasonInput, &Reason, FontSize, CUIRect::CORNER_L);
 
 				// clear button
 				static CButtonContainer s_ClearButton;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -17,6 +17,7 @@
 #include <generated/client_data.h>
 
 #include <game/version.h>
+#include "lineinput.h"
 #include "localization.h"
 #include "render.h"
 
@@ -612,6 +613,8 @@ void CGameClient::OnRender()
 
 	// clear all events/input for this frame
 	Input()->Clear();
+
+	CLineInput::RenderCandidates();
 }
 
 void CGameClient::OnRelease()

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1687,6 +1687,10 @@ vec2 CGameClient::GetCharPos(int ClientID, bool Predicted) const
 void CGameClient::OnActivateEditor()
 {
 	OnRelease();
+
+	CLineInput *pActiveInput = CLineInput::GetActiveInput();
+	if(pActiveInput)
+		pActiveInput->Deactivate();
 }
 
 void CGameClient::CClientData::UpdateBotRenderInfo(CGameClient *pGameClient, int ClientID)

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -13,6 +13,9 @@ IInput *CLineInput::s_pInput = 0;
 ITextRender *CLineInput::s_pTextRender = 0;
 IGraphics *CLineInput::s_pGraphics = 0;
 
+CLineInput *CLineInput::s_pActiveInput = 0;
+EInputPriority CLineInput::s_ActiveInputPriority = NONE;
+
 void CLineInput::SetBuffer(char *pStr, int MaxSize, int MaxChars)
 {
 	if(m_pStr && m_pStr == pStr)
@@ -293,11 +296,11 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 	return m_WasChanged;
 }
 
-void CLineInput::Render(CTextCursor *pCursor, bool Active)
+void CLineInput::Render(CTextCursor *pCursor)
 {
 	s_pTextRender->DrawTextOutlined(pCursor);
 
-	if(Active)
+	if(IsActive())
 	{
 		const int VAlign = pCursor->m_Align&TEXTALIGN_MASK_VERT;
 
@@ -351,4 +354,34 @@ void CLineInput::Render(CTextCursor *pCursor, bool Active)
 			s_pTextRender->DrawTextOutlined(&s_MarkerCursor);
 		}
 	}
+}
+
+void CLineInput::Activate(EInputPriority Priority)
+{
+	if(IsActive())
+		return;
+	if(s_ActiveInputPriority != NONE && Priority < s_ActiveInputPriority)
+		return; // do not replace a higher priority input
+	if(s_pActiveInput)
+		s_pActiveInput->OnDeactivate();
+	s_pActiveInput = this;
+	s_pActiveInput->OnActivate();
+	s_ActiveInputPriority = Priority;
+}
+
+void CLineInput::Deactivate()
+{
+	if(!IsActive())
+		return;
+	s_pActiveInput->OnDeactivate();
+	s_pActiveInput = 0x0;
+	s_ActiveInputPriority = NONE;
+}
+
+void CLineInput::OnActivate()
+{
+}
+
+void CLineInput::OnDeactivate()
+{
 }

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -1,13 +1,17 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <algorithm>
+
 #include <engine/keys.h>
 #include <engine/input.h>
 #include <engine/textrender.h>
+#include <engine/graphics.h>
 
 #include "lineinput.h"
 
 IInput *CLineInput::s_pInput = 0;
 ITextRender *CLineInput::s_pTextRender = 0;
+IGraphics *CLineInput::s_pGraphics = 0;
 
 void CLineInput::SetBuffer(char *pStr, int MaxSize, int MaxChars)
 {
@@ -27,66 +31,110 @@ void CLineInput::SetBuffer(char *pStr, int MaxSize, int MaxChars)
 void CLineInput::Clear()
 {
 	mem_zero(m_pStr, m_MaxSize);
-	m_Len = 0;
-	m_CursorPos = 0;
-	m_NumChars = 0;
+	UpdateStrData();
 }
 
 void CLineInput::Set(const char *pString)
 {
 	str_copy(m_pStr, pString, m_MaxSize);
 	UpdateStrData();
-	m_CursorPos = m_Len;
+	SetCursorOffset(m_Len);
+}
+
+void CLineInput::SetRange(const char *pString, int Begin, int End)
+{
+	if(Begin > End)
+		std::swap(Begin, End);
+	Begin = clamp(Begin, 0, m_Len);
+	End = clamp(End, 0, m_Len);
+
+	int RemovedCharSize, RemovedCharCount;
+	str_utf8_stats(m_pStr + Begin, End - Begin + 1, m_MaxChars, &RemovedCharSize, &RemovedCharCount);
+
+	int AddedCharSize, AddedCharCount;
+	str_utf8_stats(pString, m_MaxSize - m_Len + RemovedCharSize, m_MaxChars - m_NumChars + RemovedCharCount, &AddedCharSize, &AddedCharCount);
+
+	if(RemovedCharSize || AddedCharSize)
+	{
+		if(AddedCharSize < RemovedCharSize)
+		{
+			if(AddedCharSize)
+				mem_copy(m_pStr + Begin, pString, AddedCharSize);
+			mem_move(m_pStr + Begin + AddedCharSize, m_pStr + Begin + RemovedCharSize, m_Len - Begin - AddedCharSize);
+		}
+		else if(AddedCharSize > RemovedCharSize)
+			mem_move(m_pStr + End + AddedCharSize - RemovedCharSize, m_pStr + End, m_Len - End);
+
+		if(AddedCharSize >= RemovedCharSize)
+			mem_copy(m_pStr + Begin, pString, AddedCharSize);
+
+		m_CursorPos = End - RemovedCharSize + AddedCharSize;
+		m_Len += AddedCharSize - RemovedCharSize;
+		m_NumChars += AddedCharCount - RemovedCharCount;
+		m_WasChanged = true;
+		m_pStr[m_Len] = '\0';
+		m_SelectionStart = m_SelectionEnd = m_CursorPos;
+	}
+}
+
+void CLineInput::Insert(const char *pString, int Begin)
+{
+	SetRange(pString, Begin, Begin);
 }
 
 void CLineInput::Append(const char *pString)
 {
-	// gather string stats
-	int CharCount = 0;
-	int CharSize = 0;
-	while(pString[CharSize])
-	{
-		int NewCharSize = str_utf8_forward(pString, CharSize);
-		if(NewCharSize != CharSize)
-		{
-			++CharCount;
-			CharSize = NewCharSize;
-		}
-	}
-
-	// add new string
-	if(CharCount && m_Len + CharSize < m_MaxSize && m_CursorPos + CharSize < m_MaxSize && m_NumChars + CharCount <= m_MaxChars)
-	{
-		mem_move(m_pStr + m_CursorPos + CharSize, m_pStr + m_CursorPos, m_Len - m_CursorPos + 1); // +1 == null term
-		for(int i = 0; i < CharSize; i++)
-			m_pStr[m_CursorPos + i] = pString[i];
-		m_CursorPos += CharSize;
-		m_Len += CharSize;
-		m_NumChars += CharCount;
-		m_WasChanged = true;
-	}
+	Insert(pString, m_Len);
 }
 
 void CLineInput::UpdateStrData()
 {
-	m_Len = str_length(m_pStr);
+	str_utf8_stats(m_pStr, m_MaxSize, m_MaxChars, &m_Len, &m_NumChars);
 	if(m_CursorPos < 0 || m_CursorPos > m_Len)
-		m_CursorPos = m_Len;
-	m_NumChars = 0;
-	int Offset = 0;
-	while(m_pStr[Offset])
+		SetCursorOffset(m_CursorPos);
+}
+
+void CLineInput::MoveCursor(EMoveDirection Direction, bool MoveWord, const char *pStr, int MaxSize, int *pCursorPos)
+{
+	// Check whether cursor position is initially on space or non-space character.
+	// When forwarding, check character to the right of the cursor position.
+	// When rewinding, check character to the left of the cursor position (rewind first).
+	int PeekCursorPos = Direction == FORWARD ? *pCursorPos : str_utf8_rewind(pStr, *pCursorPos);
+	const char *pTemp = pStr + PeekCursorPos;
+	bool AnySpace = str_utf8_is_whitespace(str_utf8_decode(&pTemp));
+	bool AnyWord = !AnySpace;
+	while(true)
 	{
-		Offset = str_utf8_forward(m_pStr, Offset);
-		++m_NumChars;
+		if(Direction == FORWARD)
+			*pCursorPos = str_utf8_forward(pStr, *pCursorPos);
+		else
+			*pCursorPos = str_utf8_rewind(pStr, *pCursorPos);
+		if(!MoveWord || *pCursorPos <= 0 || *pCursorPos >= MaxSize)
+			break;
+		PeekCursorPos = Direction == FORWARD ? *pCursorPos : str_utf8_rewind(pStr, *pCursorPos);
+		pTemp = pStr + PeekCursorPos;
+		const bool CurrentSpace = str_utf8_is_whitespace(str_utf8_decode(&pTemp));
+		const bool CurrentWord = !CurrentSpace;
+		if(Direction == FORWARD && AnySpace && !CurrentSpace)
+			break; // Forward: Stop when next (right) character is non-space after seeing at least one space character.
+		else if(Direction == REWIND && AnyWord && !CurrentWord)
+			break; // Rewind: Stop when next (left) character is space after seeing at least one non-space character.
+		AnySpace |= CurrentSpace;
+		AnyWord |= CurrentWord;
 	}
 }
 
-bool CLineInput::MoveWordStop(char c)
+void CLineInput::SetCursorOffset(int Offset)
 {
-	// jump to spaces and special ASCII characters
-	return ((32 <= c && c <= 47) || //  !"#$%&'()*+,-./
-			(58 <= c && c <= 64) || // :;<=>?@
-			(91 <= c && c <= 96));  // [\]^_`
+	m_SelectionStart = m_SelectionEnd = m_CursorPos = clamp(Offset, 0, m_Len);
+}
+
+void CLineInput::SetSelection(int Start, int End)
+{
+	if(Start > End)
+		std::swap(Start, End);
+	m_SelectionStart = clamp(Start, 0, m_Len);
+	m_SelectionEnd = clamp(End, 0, m_Len);
 }
 
 bool CLineInput::ProcessInput(const IInput::CEvent &Event)
@@ -94,78 +142,154 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 	// update derived attributes to handle external changes to the buffer
 	UpdateStrData();
 
-	int OldCursorPos = m_CursorPos;
+	const int OldCursorPos = m_CursorPos;
+	const bool Selecting = s_pInput->KeyIsPressed(KEY_LSHIFT) || s_pInput->KeyIsPressed(KEY_RSHIFT);
+	const int SelectionLength = GetSelectionLength();
 
 	if(Event.m_Flags&IInput::FLAG_TEXT && !(KEY_LCTRL <= Event.m_Key && Event.m_Key <= KEY_RGUI))
-		Append(Event.m_aText);
+		SetRange(Event.m_aText, m_SelectionStart, m_SelectionEnd);
 
 	if(Event.m_Flags&IInput::FLAG_PRESS)
 	{
-		int Key = Event.m_Key;
+		const bool CtrlPressed = s_pInput->KeyIsPressed(KEY_LCTRL) || s_pInput->KeyIsPressed(KEY_RCTRL);
 
-		bool MoveWord = false;
 #ifdef CONF_PLATFORM_MACOSX
-		if(s_pInput->KeyIsPressed(KEY_LALT) || s_pInput->KeyIsPressed(KEY_RALT))
+		const bool MoveWord = s_pInput->KeyIsPressed(KEY_LALT) || s_pInput->KeyIsPressed(KEY_RALT);
 #else
-		if(s_pInput->KeyIsPressed(KEY_LCTRL) || s_pInput->KeyIsPressed(KEY_RCTRL))
+		const bool MoveWord = CtrlPressed;
 #endif
-			MoveWord = true;
 
-		if(Key == KEY_BACKSPACE && m_CursorPos > 0)
+		if(Event.m_Key == KEY_BACKSPACE)
 		{
-			int NewCursorPos = m_CursorPos;
-			do
+			if(SelectionLength && !MoveWord)
 			{
-				NewCursorPos = str_utf8_rewind(m_pStr, NewCursorPos);
-				m_NumChars -= 1;
-			} while(MoveWord && NewCursorPos > 0 && !MoveWordStop(m_pStr[NewCursorPos - 1]));
-			int CharSize = m_CursorPos-NewCursorPos;
-			mem_move(m_pStr+NewCursorPos, m_pStr+m_CursorPos, m_Len - NewCursorPos - CharSize + 1); // +1 == null term
-			m_CursorPos = NewCursorPos;
-			m_Len -= CharSize;
-			m_WasChanged = true;
+				SetRange("", m_SelectionStart, m_SelectionEnd);
+			}
+			else
+			{
+				// If in MoveWord-mode, backspace will delete the word before the selection
+				if(SelectionLength)
+					m_SelectionEnd = m_CursorPos = m_SelectionStart;
+				if(m_CursorPos > 0)
+				{
+					int NewCursorPos = m_CursorPos;
+					MoveCursor(REWIND, MoveWord, m_pStr, m_Len, &NewCursorPos);
+					SetRange("", NewCursorPos, m_CursorPos);
+				}
+				m_SelectionStart = m_SelectionEnd = m_CursorPos;
+			}
 		}
-		else if(Key == KEY_DELETE && m_CursorPos < m_Len)
+		else if(Event.m_Key == KEY_DELETE)
 		{
-			int EndCursorPos = m_CursorPos;
-			do
+			if(SelectionLength && !MoveWord)
 			{
-				EndCursorPos = str_utf8_forward(m_pStr, EndCursorPos);
-				m_NumChars -= 1;
-			} while(MoveWord && EndCursorPos < m_Len && !MoveWordStop(m_pStr[EndCursorPos - 1]));
-			int CharSize = EndCursorPos - m_CursorPos;
-			mem_move(m_pStr + m_CursorPos, m_pStr + m_CursorPos + CharSize, m_Len - m_CursorPos - CharSize + 1); // +1 == null term
-			m_Len -= CharSize;
-			m_WasChanged = true;
+				SetRange("", m_SelectionStart, m_SelectionEnd);
+			}
+			else
+			{
+				// If in MoveWord-mode, delete will delete the word after the selection
+				if(SelectionLength)
+					m_SelectionStart = m_CursorPos = m_SelectionEnd;
+				if(m_CursorPos < m_Len)
+				{
+					int EndCursorPos = m_CursorPos;
+					MoveCursor(FORWARD, MoveWord, m_pStr, m_Len, &EndCursorPos);
+					SetRange("", m_CursorPos, EndCursorPos);
+				}
+				m_SelectionStart = m_SelectionEnd = m_CursorPos;
+			}
 		}
-		else if(Key == KEY_LEFT && m_CursorPos > 0)
+		else if(Event.m_Key == KEY_LEFT)
 		{
-			do
+			if(SelectionLength && !Selecting)
 			{
-				m_CursorPos = str_utf8_rewind(m_pStr, m_CursorPos);
-			} while(MoveWord && m_CursorPos > 0 && !MoveWordStop(m_pStr[m_CursorPos - 1]));
+				m_CursorPos = m_SelectionStart;
+			}
+			else if(m_CursorPos > 0)
+			{
+				MoveCursor(REWIND, MoveWord, m_pStr, m_Len, &m_CursorPos);
+				if(Selecting)
+				{
+					if(m_SelectionStart == OldCursorPos) // expand start first
+						m_SelectionStart = m_CursorPos;
+					else if(m_SelectionEnd == OldCursorPos)
+						m_SelectionEnd = m_CursorPos;
+				}
+			}
+
+			if(!Selecting)
+				m_SelectionStart = m_SelectionEnd = m_CursorPos;
 		}
-		else if(Key == KEY_RIGHT && m_CursorPos < m_Len)
+		else if(Event.m_Key == KEY_RIGHT)
 		{
-			do
+			if(SelectionLength && !Selecting)
 			{
-				m_CursorPos = str_utf8_forward(m_pStr, m_CursorPos);
-			} while(MoveWord && m_CursorPos < m_Len && !MoveWordStop(m_pStr[m_CursorPos - 1]));
+				m_CursorPos = m_SelectionEnd;
+			}
+			else if(m_CursorPos < m_Len)
+			{
+				MoveCursor(FORWARD, MoveWord, m_pStr, m_Len, &m_CursorPos);
+				if(Selecting)
+				{
+					if(m_SelectionEnd == OldCursorPos) // expand end first
+						m_SelectionEnd = m_CursorPos;
+					else if(m_SelectionStart == OldCursorPos)
+						m_SelectionStart = m_CursorPos;
+				}
+			}
+
+			if(!Selecting)
+				m_SelectionStart = m_SelectionEnd = m_CursorPos;
 		}
-		else if(Key == KEY_HOME)
+		else if(Event.m_Key == KEY_HOME)
+		{
+			if(Selecting)
+			{
+				if(SelectionLength && m_CursorPos == m_SelectionEnd)
+					m_SelectionEnd = m_SelectionStart;
+			}
+			else
+				m_SelectionEnd = 0;
 			m_CursorPos = 0;
-		else if(Key == KEY_END)
-			m_CursorPos = m_Len;
-		else if((s_pInput->KeyIsPressed(KEY_LCTRL) || s_pInput->KeyIsPressed(KEY_RCTRL)) && Key == KEY_V)
+			m_SelectionStart = 0;
+		}
+		else if(Event.m_Key == KEY_END)
 		{
-			// paste clipboard to cursor
+			if(Selecting)
+			{
+				if(SelectionLength && m_CursorPos == m_SelectionStart)
+					m_SelectionStart = m_SelectionEnd;
+			}
+			else
+				m_SelectionStart = m_Len;
+			m_CursorPos = m_Len;
+			m_SelectionEnd = m_Len;
+		}
+		else if(CtrlPressed && Event.m_Key == KEY_V)
+		{
 			const char *pClipboardText = s_pInput->GetClipboardText();
 			if(pClipboardText)
-				Append(pClipboardText);
+				SetRange(pClipboardText, m_SelectionStart, m_SelectionEnd);
+		}
+		else if(CtrlPressed && (Event.m_Key == KEY_C || Event.m_Key == KEY_X) && SelectionLength)
+		{
+			char *pSelection = m_pStr + m_SelectionStart;
+			char TempChar = pSelection[SelectionLength];
+			pSelection[SelectionLength] = '\0';
+			s_pInput->SetClipboardText(pSelection);
+			pSelection[SelectionLength] = TempChar;
+			if(Event.m_Key == KEY_X)
+				SetRange("", m_SelectionStart, m_SelectionEnd);
+		}
+		else if(CtrlPressed && Event.m_Key == KEY_A)
+		{
+			m_SelectionStart = 0;
+			m_SelectionEnd = m_CursorPos = m_Len;
 		}
 	}
 
 	m_WasChanged |= OldCursorPos != m_CursorPos;
+	m_WasChanged |= SelectionLength != GetSelectionLength();
 	return m_WasChanged;
 }
 
@@ -173,14 +297,58 @@ void CLineInput::Render(CTextCursor *pCursor, bool Active)
 {
 	s_pTextRender->DrawTextOutlined(pCursor);
 
-	if(Active && (2*time_get()/time_freq())%2)
+	if(Active)
 	{
-		static CTextCursor s_MarkerCursor;
-		s_MarkerCursor.Reset();
-		s_MarkerCursor.m_FontSize = pCursor->m_FontSize;
-		s_MarkerCursor.m_Align = (pCursor->m_Align&TEXTALIGN_MASK_VERT) | TEXTALIGN_CENTER;
-		s_pTextRender->TextDeferred(&s_MarkerCursor, "｜", -1);
-		s_MarkerCursor.MoveTo(s_pTextRender->CaretPosition(pCursor, GetCursorOffset()));
-		s_pTextRender->DrawTextOutlined(&s_MarkerCursor);
+		const int VAlign = pCursor->m_Align&TEXTALIGN_MASK_VERT;
+
+		// render selection
+		if(GetSelectionLength())
+		{
+			const vec2 StartPos = s_pTextRender->CaretPosition(pCursor, GetSelectionStart());
+			const vec2 EndPos = s_pTextRender->CaretPosition(pCursor, GetSelectionEnd());
+			const float LineHeight = pCursor->BaseLineY()/pCursor->LineCount();
+			const float VAlignOffset =
+				(VAlign == TEXTALIGN_TOP) ? -1.0f :
+				(VAlign == TEXTALIGN_MIDDLE) ? LineHeight/2 :
+				/* TEXTALIGN_BOTTOM */ LineHeight - 1.0f;
+			s_pGraphics->TextureClear();
+			s_pGraphics->QuadsBegin();
+			s_pGraphics->SetColor(0.3f, 0.3f, 0.3f, 0.3f);
+			if(StartPos.y < EndPos.y) // multi line selection
+			{
+				CTextBoundingBox BoundingBox = pCursor->BoundingBox();
+				int NumQuads = 0;
+				IGraphics::CQuadItem aSelectionQuads[3];
+				aSelectionQuads[NumQuads++] = IGraphics::CQuadItem(StartPos.x, StartPos.y - VAlignOffset, BoundingBox.Right() - StartPos.x, LineHeight);
+				const float SecondSegmentY = StartPos.y - VAlignOffset + LineHeight;
+				if(EndPos.y - StartPos.y > LineHeight)
+				{
+					const float MiddleSegmentHeight = EndPos.y - StartPos.y - LineHeight;
+					aSelectionQuads[NumQuads++] = IGraphics::CQuadItem(BoundingBox.x, SecondSegmentY, BoundingBox.w, MiddleSegmentHeight);
+					aSelectionQuads[NumQuads++] = IGraphics::CQuadItem(BoundingBox.x, SecondSegmentY + MiddleSegmentHeight, EndPos.x - BoundingBox.x, LineHeight);
+				}
+				else
+					aSelectionQuads[NumQuads++] = IGraphics::CQuadItem(BoundingBox.x, SecondSegmentY, EndPos.x - BoundingBox.x, LineHeight);
+				s_pGraphics->QuadsDrawTL(aSelectionQuads, NumQuads);
+			}
+			else // single line selection
+			{
+				IGraphics::CQuadItem SelectionQuad(StartPos.x, StartPos.y - VAlignOffset, EndPos.x - StartPos.x, LineHeight);
+				s_pGraphics->QuadsDrawTL(&SelectionQuad, 1);
+			}
+			s_pGraphics->QuadsEnd();
+		}
+
+		// render blinking caret
+		if((2*time_get()/time_freq())%2)
+		{
+			static CTextCursor s_MarkerCursor;
+			s_MarkerCursor.Reset();
+			s_MarkerCursor.m_FontSize = pCursor->m_FontSize;
+			s_MarkerCursor.m_Align = VAlign | TEXTALIGN_CENTER;
+			s_pTextRender->TextDeferred(&s_MarkerCursor, "｜", -1);
+			s_MarkerCursor.MoveTo(s_pTextRender->CaretPosition(pCursor, GetCursorOffset()));
+			s_pTextRender->DrawTextOutlined(&s_MarkerCursor);
+		}
 	}
 }

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -15,6 +15,8 @@ class CLineInput
 	int m_NumChars;
 
 	int m_CursorPos;
+	int m_SelectionStart;
+	int m_SelectionEnd;
 
 	float m_ScrollOffset;
 
@@ -22,12 +24,18 @@ class CLineInput
 
 	static class IInput *s_pInput;
 	static class ITextRender *s_pTextRender;
+	static class IGraphics *s_pGraphics;
 
 	void UpdateStrData();
-	static bool MoveWordStop(char c);
+	enum EMoveDirection
+	{
+		FORWARD,
+		REWIND
+	};
+	static void MoveCursor(EMoveDirection Direction, bool MoveWord, const char *pStr, int MaxSize, int *pCursorPos);
 
 public:
-	static void Init(class IInput *pInput, class ITextRender *pTextRender) { s_pInput = pInput; s_pTextRender = pTextRender; }
+	static void Init(class IInput *pInput, class ITextRender *pTextRender, class IGraphics *pGraphics) { s_pInput = pInput; s_pTextRender = pTextRender; s_pGraphics = pGraphics; }
 
 	CLineInput() : m_pStr(0) { SetBuffer(0, 0, 0); }
 	CLineInput(char *pStr, int MaxSize) : m_pStr(0)  { SetBuffer(pStr, MaxSize, MaxSize); }
@@ -38,6 +46,8 @@ public:
 
 	void Clear();
 	void Set(const char *pString);
+	void SetRange(const char *pString, int Begin, int End);
+	void Insert(const char *pString, int Begin);
 	void Append(const char *pString);
 
 	const char *GetString() const { return m_pStr; }
@@ -47,7 +57,11 @@ public:
 	int GetNumChars() const { return m_NumChars; }
 
 	int GetCursorOffset() const { return m_CursorPos; }
-	void SetCursorOffset(int Offset) { m_CursorPos = Offset > m_Len ? m_Len : Offset < 0 ? 0 : Offset; }
+	void SetCursorOffset(int Offset);
+	int GetSelectionStart() const { return m_SelectionStart; }
+	int GetSelectionEnd() const { return m_SelectionEnd; }
+	int GetSelectionLength() const { return m_SelectionEnd - m_SelectionStart; }
+	void SetSelection(int Start, int End);
 
 	// used either for vertical or horizontal scrolling
 	float GetScrollOffset() const { return m_ScrollOffset; }

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -23,6 +23,10 @@ class CLineInput
 	static CLineInput *s_pActiveInput;
 	static EInputPriority s_ActiveInputPriority;
 
+	static vec2 s_CompositionWindowPosition;
+	static float s_CompositionLineHeight;
+
+	class CTextCursor m_TextCursor;
 	char *m_pStr;
 	int m_MaxSize;
 	int m_MaxChars;
@@ -34,6 +38,7 @@ class CLineInput
 	int m_SelectionEnd;
 
 	float m_ScrollOffset;
+	vec2 m_CaretPosition;
 
 	bool m_WasChanged;
 
@@ -44,12 +49,15 @@ class CLineInput
 		REWIND
 	};
 	static void MoveCursor(EMoveDirection Direction, bool MoveWord, const char *pStr, int MaxSize, int *pCursorPos);
+	static void SetCompositionWindowPosition(vec2 Anchor, float LineHeight);
+	void DrawSelection(float HeightWeight, int Start, int End, vec4 Color);
 
 	void OnActivate();
 	void OnDeactivate();
 
 public:
 	static void Init(class IInput *pInput, class ITextRender *pTextRender, class IGraphics *pGraphics) { s_pInput = pInput; s_pTextRender = pTextRender; s_pGraphics = pGraphics; }
+	static void RenderCandidates();
 
 	static CLineInput *GetActiveInput() { return s_pActiveInput; }
 
@@ -66,6 +74,7 @@ public:
 	void Insert(const char *pString, int Begin);
 	void Append(const char *pString);
 
+	class CTextCursor *GetCursor() { return &m_TextCursor; }
 	const char *GetString() const { return m_pStr; }
 	int GetMaxSize() const { return m_MaxSize; }
 	int GetMaxChars() const { return m_MaxChars; }
@@ -83,10 +92,13 @@ public:
 	float GetScrollOffset() const { return m_ScrollOffset; }
 	void SetScrollOffset(float ScrollOffset) { m_ScrollOffset = ScrollOffset; }
 
+	vec2 GetCaretPosition() const { return m_CaretPosition; } // only updated while the input is active
+
 	bool ProcessInput(const IInput::CEvent &Event);
 	bool WasChanged() { bool Changed = m_WasChanged; m_WasChanged = false; return Changed; }
 
-	void Render(class CTextCursor *pCursor);
+	void Render();
+
 	bool IsActive() const { return GetActiveInput() == this; }
 	void Activate(EInputPriority Priority);
 	void Deactivate();

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -5,9 +5,24 @@
 
 #include <engine/input.h>
 
+enum EInputPriority
+{
+	NONE = 0,
+	UI,
+	CHAT,
+	CONSOLE,
+};
+
 // line input helper
 class CLineInput
 {
+	static class IInput *s_pInput;
+	static class ITextRender *s_pTextRender;
+	static class IGraphics *s_pGraphics;
+
+	static CLineInput *s_pActiveInput;
+	static EInputPriority s_ActiveInputPriority;
+
 	char *m_pStr;
 	int m_MaxSize;
 	int m_MaxChars;
@@ -22,10 +37,6 @@ class CLineInput
 
 	bool m_WasChanged;
 
-	static class IInput *s_pInput;
-	static class ITextRender *s_pTextRender;
-	static class IGraphics *s_pGraphics;
-
 	void UpdateStrData();
 	enum EMoveDirection
 	{
@@ -34,12 +45,17 @@ class CLineInput
 	};
 	static void MoveCursor(EMoveDirection Direction, bool MoveWord, const char *pStr, int MaxSize, int *pCursorPos);
 
+	void OnActivate();
+	void OnDeactivate();
+
 public:
 	static void Init(class IInput *pInput, class ITextRender *pTextRender, class IGraphics *pGraphics) { s_pInput = pInput; s_pTextRender = pTextRender; s_pGraphics = pGraphics; }
 
+	static CLineInput *GetActiveInput() { return s_pActiveInput; }
+
 	CLineInput() : m_pStr(0) { SetBuffer(0, 0, 0); }
-	CLineInput(char *pStr, int MaxSize) : m_pStr(0)  { SetBuffer(pStr, MaxSize, MaxSize); }
-	CLineInput(char *pStr, int MaxSize, int MaxChars) : m_pStr(0)  { SetBuffer(pStr, MaxSize, MaxChars); }
+	CLineInput(char *pStr, int MaxSize) : m_pStr(0) { SetBuffer(pStr, MaxSize, MaxSize); }
+	CLineInput(char *pStr, int MaxSize, int MaxChars) : m_pStr(0) { SetBuffer(pStr, MaxSize, MaxChars); }
 
 	void SetBuffer(char *pStr, int MaxSize) { SetBuffer(pStr, MaxSize, MaxSize); }
 	void SetBuffer(char *pStr, int MaxSize, int MaxChars);
@@ -70,7 +86,10 @@ public:
 	bool ProcessInput(const IInput::CEvent &Event);
 	bool WasChanged() { bool Changed = m_WasChanged; m_WasChanged = false; return Changed; }
 
-	void Render(class CTextCursor *pCursor, bool Active);
+	void Render(class CTextCursor *pCursor);
+	bool IsActive() const { return GetActiveInput() == this; }
+	void Activate(EInputPriority Priority);
+	void Deactivate();
 };
 
 #endif

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -26,6 +26,8 @@ class CLineInput
 	static vec2 s_CompositionWindowPosition;
 	static float s_CompositionLineHeight;
 
+	static char s_aStars[128];
+
 	class CTextCursor m_TextCursor;
 	char *m_pStr;
 	int m_MaxSize;
@@ -40,6 +42,7 @@ class CLineInput
 	float m_ScrollOffset;
 	vec2 m_CaretPosition;
 
+	bool m_Hidden;
 	bool m_WasChanged;
 
 	void UpdateStrData();
@@ -76,6 +79,7 @@ public:
 
 	class CTextCursor *GetCursor() { return &m_TextCursor; }
 	const char *GetString() const { return m_pStr; }
+	const char *GetDisplayedString();
 	int GetMaxSize() const { return m_MaxSize; }
 	int GetMaxChars() const { return m_MaxChars; }
 	int GetLength() const { return m_Len; }
@@ -88,11 +92,17 @@ public:
 	int GetSelectionLength() const { return m_SelectionEnd - m_SelectionStart; }
 	void SetSelection(int Start, int End);
 
+	int OffsetFromActualToDisplay(int ActualOffset) const;
+	int OffsetFromDisplayToActual(int DisplayOffset) const;
+
 	// used either for vertical or horizontal scrolling
 	float GetScrollOffset() const { return m_ScrollOffset; }
 	void SetScrollOffset(float ScrollOffset) { m_ScrollOffset = ScrollOffset; }
 
 	vec2 GetCaretPosition() const { return m_CaretPosition; } // only updated while the input is active
+
+	bool IsHidden() const { return m_Hidden; }
+	void SetHidden(bool Hidden) { m_Hidden = Hidden; }
 
 	bool ProcessInput(const IInput::CEvent &Event);
 	bool WasChanged() { bool Changed = m_WasChanged; m_WasChanged = false; return Changed; }

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -338,6 +338,10 @@ void CUI::DoLabelHighlighted(const CUIRect *pRect, const char *pText, const char
 
 bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, bool Hidden, int Corners, const IButtonColorFunction *pColorFunction)
 {
+	CTextCursor *pCursor = pLineInput->GetCursor();
+	pCursor->m_FontSize = FontSize;
+	pCursor->m_Align = TEXTALIGN_ML;
+
 	const bool Inside = MouseHovered(pRect);
 	const bool Active = LastActiveItem() == pLineInput;
 	const bool Changed = pLineInput->WasChanged();
@@ -494,13 +498,8 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 	pRect->Draw(pColorFunction->GetColor(Active, Inside), 5.0f, Corners);
 	ClipEnable(pRect);
 	Textbox.x -= ScrollOffset;
-	static CTextCursor s_TextCursor;
-	s_TextCursor.Reset();
-	s_TextCursor.m_FontSize = FontSize;
-	s_TextCursor.m_Align = TEXTALIGN_ML;
-	s_TextCursor.MoveTo(Textbox.x, Textbox.y + Textbox.h/2.0f);
-	TextRender()->TextDeferred(&s_TextCursor, pDisplayStr, -1);
-	pLineInput->Render(&s_TextCursor);
+	pCursor->MoveTo(Textbox.x, Textbox.y + Textbox.h/2.0f);
+	pLineInput->Render();
 	ClipDisable();
 
 	return Changed;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -123,7 +123,6 @@ class CUI
 	unsigned m_LastMouseButtons;
 
 	unsigned m_HotkeysPressed;
-	CLineInput *m_pActiveInput;
 
 	CUIRect m_Screen;
 
@@ -215,7 +214,7 @@ public:
 	bool ConsumeHotkey(unsigned Hotkey);
 	void ClearHotkeys() { m_HotkeysPressed = 0; }
 	bool OnInput(const IInput::CEvent &e);
-	bool IsInputActive() const { return m_pActiveInput != 0; }
+	bool IsInputActive() const { return CLineInput::GetActiveInput() != 0; }
 
 	const CUIRect *Screen();
 	float PixelSize();

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -234,8 +234,8 @@ public:
 	void DoLabelHighlighted(const CUIRect *pRect, const char *pText, const char *pHighlighted, float FontSize, const vec4 &TextColor, const vec4 &HighlightColor);
 
 	// editboxes
-	bool DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, bool Hidden = false, int Corners = CUIRect::CORNER_ALL, const IButtonColorFunction *pColorFunction = &DarkButtonColorFunction);
-	void DoEditBoxOption(CLineInput *pLineInput, const CUIRect *pRect, const char *pStr, float VSplitVal, bool Hidden = false);
+	bool DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners = CUIRect::CORNER_ALL, const IButtonColorFunction *pColorFunction = &DarkButtonColorFunction);
+	void DoEditBoxOption(CLineInput *pLineInput, const CUIRect *pRect, const char *pStr, float VSplitVal);
 
 	// scrollbars
 	float DoScrollbarV(const void *pID, const CUIRect *pRect, float Current);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4451,6 +4451,8 @@ void CEditor::UpdateAndRender()
 	UI()->FinishCheck();
 	UI()->ClearHotkeys();
 	Input()->Clear();
+
+	CLineInput::RenderCandidates();
 }
 
 IEditor *CreateEditor() { return new CEditor; }

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -777,7 +777,7 @@ public:
 	int DoButton_Menu(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
 	int DoButton_MenuItem(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags=0, const char *pToolTip=0);
 
-	bool DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize) { return UI()->DoEditBox(pLineInput, pRect, FontSize, false, CUIRect::CORNER_ALL, &LightButtonColorFunction); }
+	bool DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize) { return UI()->DoEditBox(pLineInput, pRect, FontSize, CUIRect::CORNER_ALL, &LightButtonColorFunction); }
 
 	void RenderBackground(CUIRect View, IGraphics::CTextureHandle Texture, float Size, float Brightness);
 


### PR DESCRIPTION
# Text Selection

![sel](https://user-images.githubusercontent.com/23437060/102012211-5a310100-3d49-11eb-9249-18139eecaa48.png)

Implement keyboard-based text selection for console, chat and editboxes.
Implement mouse-based selection for editboxes.
Closes #12. Closes #1851. Closes #2706.

Word skipping (when holding Ctrl) is overhauled to be consistent with the Windows / Firefox experience that I took as reference.

Password/Hidden input rendering and handling of unicode strings is fixed in the process.

# Input method editor

https://user-images.githubusercontent.com/23437060/152878286-a234a55d-6b3d-4f60-b123-7cafefac64dc.mp4

Thanks to @TsFreddie, there is also IME support on Windows. The candidate window is drawn ingame.

Short guide on how to use it:

1. Install the language pack/keyboard layout for the language you'd like to use in the Windows settings.
2. First try using the IME in notepad, as you may need to setup some hotkeys first to be able to use it in a fullscreen application.
3. Switch to the new keyboard layout while the application is open. On newer Windows versions, you can switch between installed keyboards with Windows+Space, which also works in fullscreen applications.
If that doesn't work, you can configure a different hotkey in the language settings (the default should be Alt+Shift).
4. Try typing. Press Ctrl+Space to toggle the IME and type again. If the hotkey didn't work, you first need to configure it in the IME settings.

## Technical

This PR includes all and only the text input/selection and IME changes from #2825.

However, this PR has been further steamlined to remove some dubious changes:

- Instead of using a stack for active inputs (d59b9d1e2d030a87affcca01120d65b10f975465), only one active input is tracked because that's enough.
- The UI is not made into a singleton engine component (dc60c2ad72055ffdf5722913ee5a2d7222a48914).

Instead, the second commit of this PR adds the necessary logic to track input activation and deactivation for IME usage while ensuring that the correct input should be active at all times.