### PR TITLE
Improve macOS performance, explicitly disable notch area on macOS

### DIFF
--- a/other/bundle/client/Info.plist.in
+++ b/other/bundle/client/Info.plist.in
@@ -20,5 +20,7 @@
 		<string>com.TeeworldsClient.app</string>
 		<key>NSHighResolutionCapable</key>
 		<true/>
+		<key>NSQualityOfService</key>
+		<string>NSQualityOfServiceUserInteractive</string>
 	</dict>
 </plist>

--- a/other/bundle/client/Info.plist.in
+++ b/other/bundle/client/Info.plist.in
@@ -20,6 +20,8 @@
 		<string>com.TeeworldsClient.app</string>
 		<key>NSHighResolutionCapable</key>
 		<true/>
+		<key>NSPrefersDisplaySafeAreaCompatibilityMode</key>
+		<true/>
 		<key>NSQualityOfService</key>
 		<string>NSQualityOfServiceUserInteractive</string>
 	</dict>

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -525,7 +525,12 @@ void *thread_init(void (*threadfunc)(void *), void *u)
 #if defined(CONF_FAMILY_UNIX)
 	{
 		pthread_t id;
-		if(pthread_create(&id, NULL, thread_run, data) != 0)
+		pthread_attr_t attr;
+		pthread_attr_init(&attr);
+#if defined(CONF_PLATFORM_MACOS)
+		pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INTERACTIVE, 0);
+#endif
+		if(pthread_create(&id, &attr, thread_run, data) != 0)
 		{
 			return 0;
 		}


### PR DESCRIPTION
- Improve performance on macOS by setting the QoS class to interactive. See benchmarks in https://github.com/ddnet/ddnet/pull/4627.
- Prevent timer from being hidden behind notch area by explicitly disabling the notch area for fullscreen.