### PR TITLE
Minor refactoring: Move base/hash.h include from shared to kernel engine interface

### DIFF
--- a/src/engine/mapchecker.h
+++ b/src/engine/mapchecker.h
@@ -3,6 +3,8 @@
 #ifndef ENGINE_MAPCHECKER_H
 #define ENGINE_MAPCHECKER_H
 
+#include <base/hash.h>
+
 #include "kernel.h"
 
 class IMapChecker : public IInterface

--- a/src/engine/shared/mapchecker.h
+++ b/src/engine/shared/mapchecker.h
@@ -3,8 +3,6 @@
 #ifndef ENGINE_SHARED_MAPCHECKER_H
 #define ENGINE_SHARED_MAPCHECKER_H
 
-#include <base/hash.h>
-
 #include <engine/mapchecker.h>
 
 #include "memheap.h"


### PR DESCRIPTION
So `src/engine/mapchecker.h` can be included standalone. Otherwise `SHA256_DIGEST` would not be defined when only including this header.