### PR TITLE
Use default Visual Studio version in GitHub workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
             CFLAGS: -Wdeclaration-after-statement -Werror
             CXXFLAGS: -Werror
         - os: windows-latest
-          cmake-args: -G "Visual Studio 16 2019" -A x64
+          cmake-args: -A x64
           package-file: teeworlds-*-win64.zip
           env:
             CFLAGS: /WX


### PR DESCRIPTION
`Visual Studio 16 2019` will eventually be deprecated (`https://github.com/actions/virtual-environments/issues/4856`). However, not all github workflow servers work with `Visual Studio 17 2022` yet. I don't think we depend on any VS version specific behavior so we can leave the version unspecified and let the workflow use whatever works.