### PR TITLE
Show console command help and syntax at the same time as completions

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -503,7 +503,7 @@ void CGameConsole::OnRender()
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();
 
-	ConsoleHeight -= 22.0f;
+	ConsoleHeight -= 36.0f;
 
 	CInstance *pConsole = CurrentConsole();
 
@@ -513,9 +513,15 @@ void CGameConsole::OnRender()
 		float x = 3;
 		float y = ConsoleHeight - RowHeight - 5.0f;
 
+		static CTextCursor s_CompletionOptionsCursor;
+		s_CompletionOptionsCursor.Reset();
+		s_CompletionOptionsCursor.MoveTo(x+pConsole->m_CompletionRenderOffset, y+RowHeight+2.0f);
+		s_CompletionOptionsCursor.m_FontSize = FontSize;
+		s_CompletionOptionsCursor.m_MaxWidth = -1.0f;
+
 		static CTextCursor s_InfoCursor;
 		s_InfoCursor.Reset();
-		s_InfoCursor.MoveTo(x+pConsole->m_CompletionRenderOffset, y+RowHeight+2.0f);
+		s_InfoCursor.MoveTo(x, y + 2.0f * RowHeight + 4.0f);
 		s_InfoCursor.m_FontSize = FontSize;
 		s_InfoCursor.m_MaxWidth = -1.0f;
 
@@ -567,35 +573,37 @@ void CGameConsole::OnRender()
 			Info.m_Width = Screen.w;
 			Info.m_TotalWidth = 0.0f;
 			Info.m_pCurrentCmd = pConsole->m_aCompletionBuffer;
-			Info.m_pCursor = &s_InfoCursor;
+			Info.m_pCursor = &s_CompletionOptionsCursor;
 			m_pConsole->PossibleCommands(Info.m_pCurrentCmd, pConsole->m_CompletionFlagmask, m_ConsoleType != CGameConsole::CONSOLETYPE_LOCAL &&
 				Client()->RconAuthed() && Client()->UseTempRconCommands(), PossibleCommandsRenderCallback, &Info);
 
-			if(Info.m_EnumCount <= 0 && pConsole->m_IsCommand)
+			if(pConsole->m_IsCommand)
 			{
-				const bool MapCompletion = IsMapCommandPrefix(Info.m_pCurrentCmd);
-				const bool TuningCompletion = IsTuningCommandPrefix(Info.m_pCurrentCmd);
-				if(MapCompletion || TuningCompletion)
+				// argument completion
+				if(Info.m_EnumCount <= 0)
 				{
-					Info.m_WantedCompletion = pConsole->m_CompletionChosenArgument;
-					Info.m_EnumCount = 0;
-					Info.m_TotalWidth = 0.0f;
-					Info.m_pCurrentCmd = pConsole->m_aCompletionBufferArgument;
-					if(MapCompletion)
-						m_pConsole->PossibleMaps(Info.m_pCurrentCmd, PossibleCommandsRenderCallback, &Info);
-					else if(TuningCompletion)
-						m_pClient->m_Tuning.PossibleTunings(Info.m_pCurrentCmd, PossibleCommandsRenderCallback, &Info);
+					const bool MapCompletion = IsMapCommandPrefix(Info.m_pCurrentCmd);
+					const bool TuningCompletion = IsTuningCommandPrefix(Info.m_pCurrentCmd);
+					if(MapCompletion || TuningCompletion)
+					{
+						Info.m_WantedCompletion = pConsole->m_CompletionChosenArgument;
+						Info.m_EnumCount = 0;
+						Info.m_TotalWidth = 0.0f;
+						Info.m_pCurrentCmd = pConsole->m_aCompletionBufferArgument;
+						if(MapCompletion)
+							m_pConsole->PossibleMaps(Info.m_pCurrentCmd, PossibleCommandsRenderCallback, &Info);
+						else if(TuningCompletion)
+							m_pClient->m_Tuning.PossibleTunings(Info.m_pCurrentCmd, PossibleCommandsRenderCallback, &Info);
+					}
 				}
 
-				if(Info.m_EnumCount <= 0 && pConsole->m_IsCommand)
-				{
-					char aBuf[512];
-					str_format(aBuf, sizeof(aBuf), "Help: %s ", pConsole->m_aCommandHelp);
-					TextRender()->TextDeferred(Info.m_pCursor, aBuf, -1);
-					TextRender()->TextColor(0.75f, 0.75f, 0.75f, 1);
-					str_format(aBuf, sizeof(aBuf), "Syntax: %s %s", pConsole->m_aCommandName, pConsole->m_aCommandParams);
-					TextRender()->TextDeferred(Info.m_pCursor, aBuf, -1);
-				}
+				char aBuf[512];
+				TextRender()->TextColor(0.9f, 0.9f, 0.9f, 1.0f);
+				str_format(aBuf, sizeof(aBuf), "Help: %s    ", pConsole->m_aCommandHelp);
+				TextRender()->TextDeferred(&s_InfoCursor, aBuf, -1);
+				TextRender()->TextColor(0.7f, 0.7f, 0.7f, 1.0f);
+				str_format(aBuf, sizeof(aBuf), "Syntax: %s %s", pConsole->m_aCommandName, pConsole->m_aCommandParams);
+				TextRender()->TextDeferred(&s_InfoCursor, aBuf, -1);
 			}
 
 			// instant scrolling if distance too long
@@ -626,6 +634,7 @@ void CGameConsole::OnRender()
 		}
 		s_LastRender = Now;
 
+		TextRender()->DrawTextOutlined(&s_CompletionOptionsCursor);
 		TextRender()->DrawTextOutlined(&s_InfoCursor);
 
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);


### PR DESCRIPTION
I think it's useful to see the help already while scrolling through the completion options.

This also adds a bit of space between the help and the syntax.

## Before

![o1](https://user-images.githubusercontent.com/23437060/153299290-8cb6f579-dcf0-42ef-8689-afa78ae51eb5.png)
![o2](https://user-images.githubusercontent.com/23437060/153299293-17c009f2-0630-4186-a4cb-0e2ce4b1f9fc.png)
![o3](https://user-images.githubusercontent.com/23437060/153299296-4e5d7fcd-6a2b-4ee3-afa2-cc6ab9c7e754.png)
![o4](https://user-images.githubusercontent.com/23437060/153299297-ab9446b2-8442-45d9-bd48-51aaf2c4b290.png)
![o5](https://user-images.githubusercontent.com/23437060/153299300-62515ab3-d665-403b-8317-80aac5c5523b.png)

## After:

![n1](https://user-images.githubusercontent.com/23437060/153299314-10fe6ef1-3b17-404d-8a8c-990ad828d23a.png)
![n2](https://user-images.githubusercontent.com/23437060/153299319-118a164d-a047-4ba6-83a2-22ee7cdf188c.png)
![n3](https://user-images.githubusercontent.com/23437060/153299322-686820b7-0fae-4530-9270-dd950239c164.png)
![n4](https://user-images.githubusercontent.com/23437060/153299323-621e9e62-21fc-429c-8c6b-67380a00df31.png)
![n5](https://user-images.githubusercontent.com/23437060/153299324-45ab155b-f640-49d7-b302-09c2df62da99.png)
