### PR TITLE
Add Race default filter to Server Browser, allow all filters to be swapped

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -534,16 +534,19 @@ private:
 		IServerBrowser *m_pServerBrowser;
 
 		static CServerFilterInfo ms_FilterStandard;
+		static CServerFilterInfo ms_FilterRace;
 		static CServerFilterInfo ms_FilterFavorites;
 		static CServerFilterInfo ms_FilterAll;
 
 	public:
 		enum
 		{
-			FILTER_CUSTOM=0,
+			FILTER_CUSTOM = 0,
 			FILTER_ALL,
 			FILTER_STANDARD,
 			FILTER_FAVORITES,
+			FILTER_RACE,
+			NUM_FILTERS,
 		};
 
 		CButtonContainer m_DeleteButtonContainer;
@@ -577,7 +580,7 @@ private:
 	void LoadFilters();
 	void SaveFilters();
 	void RemoveFilter(int FilterIndex);
-	void Move(bool Up, int Filter);
+	void MoveFilter(bool Up, int Filter);
 	void InitDefaultFilters();
 
 	struct CColumn

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -174,7 +174,9 @@ void CMenus::LoadFilters()
 
 	if(pJsonData == 0)
 	{
-		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, pFilename, aError);
+		char aBuf[512];
+		str_format(aBuf, sizeof(aBuf), "failed to load filters from '%s': %s", pFilename, aError);
+		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
 		return;
 	}
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -237,7 +237,7 @@ void CMenus::LoadFilters()
 				{
 					if(rGametypeEntry[j].type == json_string)
 					{
-						str_copy(FilterInfo.m_aGametype[j], rGametypeEntry[j], sizeof(FilterInfo.m_aGametype[j]));
+						str_copy(FilterInfo.m_aGametype[j], rGametypeEntry[j].u.string.ptr, sizeof(FilterInfo.m_aGametype[j]));
 						FilterInfo.m_aGametypeExclusive[j] = false;
 					}
 				}
@@ -260,7 +260,7 @@ void CMenus::LoadFilters()
 			if(rSubStart["filter_serverlevel"].type == json_integer)
 				FilterInfo.m_ServerLevel = rSubStart["filter_serverlevel"].u.integer;
 			if(rSubStart["filter_address"].type == json_string)
-				str_copy(FilterInfo.m_aAddress, rSubStart["filter_address"], sizeof(FilterInfo.m_aAddress));
+				str_copy(FilterInfo.m_aAddress, rSubStart["filter_address"].u.string.ptr, sizeof(FilterInfo.m_aAddress));
 			if(rSubStart["filter_country"].type == json_integer)
 				FilterInfo.m_Country = rSubStart["filter_country"].u.integer;
 		}

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -709,7 +709,7 @@ void CMenus::RenderFilterHeader(CUIRect View, int FilterIndex)
 	EditButtons.VSplitRight(Spacing, &EditButtons, 0);
 	EditButtons.VSplitRight(ButtonHeight, &EditButtons, &Button);
 	Button.Margin(2.0f, &Button);
-	if(FilterIndex > 0 && (pFilter->Custom() > CBrowserFilter::FILTER_ALL || m_lFilters[FilterIndex-1].Custom() != CBrowserFilter::FILTER_STANDARD))
+	if(FilterIndex > 0)
 	{
 		if(DoButton_SpriteID(&pFilter->m_UpButtonContainer, IMAGE_TOOLICONS, SPRITE_TOOL_UP_A, false, &Button))
 		{
@@ -723,7 +723,7 @@ void CMenus::RenderFilterHeader(CUIRect View, int FilterIndex)
 	EditButtons.VSplitRight(Spacing, &EditButtons, 0);
 	EditButtons.VSplitRight(ButtonHeight, &EditButtons, &Button);
 	Button.Margin(2.0f, &Button);
-	if(FilterIndex >= 0 && FilterIndex < m_lFilters.size()-1 && (pFilter->Custom() != CBrowserFilter::FILTER_STANDARD || m_lFilters[FilterIndex+1].Custom() > CBrowserFilter::FILTER_ALL))
+	if(FilterIndex < m_lFilters.size() - 1)
 	{
 		if(DoButton_SpriteID(&pFilter->m_DownButtonContainer, IMAGE_TOOLICONS, SPRITE_TOOL_DOWN_A, false, &Button))
 		{


### PR DESCRIPTION
![screenshot_2022-02-10_20-24-34](https://user-images.githubusercontent.com/23437060/153481899-511be51f-40d5-4d4e-9ccf-1cf83558e595.png)

- Allow all filters to be swapped freely. Before, you could not move the All filter above the Teeworlds filter.
- Add Race filter utilizing the gametype filter. The gametype "Race" will always be added to the filter when loading and will also be added again if you use "Reset filter". However, I didn't really think it was worth it to add a lot of additional logic to prevent the gametype "Race" from being removed. Opinions?
- Ensure that newly added default filters are in the correct initial order.
- Fix error message when parsing the filters fails.

Closes #3031.