### PR TITLE
Fix integer overflow of snapshot delta item size

### DIFF
--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <algorithm>
+#include <limits.h>
 
 #include <base/tl/algorithm.h>
 
@@ -370,6 +371,8 @@ int CSnapshotDelta::UnpackDelta(const CSnapshot *pFrom, CSnapshot *pTo, const vo
 		{
 			if(pData+1 > pEnd)
 				return -2;
+			if(*pData < 0 || *pData > INT_MAX / 4)
+				return -3;
 			ItemSize = (*pData++) * 4;
 		}
 


### PR DESCRIPTION
Fixes

```
src/engine/shared/snapshot.cpp:373:13: runtime error: signed integer overflow: 1661611014 * 4 cannot be represented in type 'int'
    #0 0x56377a580246 in CSnapshotDelta::UnpackDelta(CSnapshot const*, CSnapshot*, void const*, int) src/engine/shared/snapshot.cpp:373
    #1 0x563779c540d3 in CClient::ProcessServerPacket(CNetChunk*) src/engine/client/client.cpp:1465
    #2 0x563779c5a5fc in CClient::PumpNetwork() src/engine/client/client.cpp:1599
    #3 0x563779c622ce in CClient::Update() src/engine/client/client.cpp:1769
    #4 0x563779c774d2 in CClient::Run() src/engine/client/client.cpp:2112
    #5 0x563779c92c74 in main src/engine/client/client.cpp:2712
    #6 0x7fbf393bb0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #7 0x563779b0e15d in _start (/teeworlds/build/x86_64/debug/teeworlds+0x121815d)
```