### PR TITLE
Update to latest version of bam in CI to fix VS detection

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -118,7 +118,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: matricks/bam
-        ref: 07fbb5543c692f6b9a7f09e48c64e2368349a3a8
+        ref: 8cd08744c37666830d439ab54016c9d228c63b68
         path: ./bam
 
     - name: Prepare Linux


### PR DESCRIPTION
Update from https://github.com/matricks/bam/commit/07fbb5543c692f6b9a7f09e48c64e2368349a3a8 to https://github.com/matricks/bam/commit/8cd08744c37666830d439ab54016c9d228c63b68.

See failed run at https://github.com/teeworlds/teeworlds/runs/5158854530. The real error message `You need Microsoft Visual Studio 8, 9, 10, 11, 12, 13 or 15 installed` was hidden in the Prepare Windows group, as the bam init fails to indicate its failure to the CI.