### PR TITLE
Move CUIElementBase and CButtonContainer to UI

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -33,12 +33,6 @@
 #include "menus.h"
 #include "skins.h"
 
-CRenderTools *CMenus::CUIElementBase::m_pRenderTools = 0;
-CUI *CMenus::CUIElementBase::m_pUI = 0;
-IInput *CMenus::CUIElementBase::m_pInput = 0;
-IClient *CMenus::CUIElementBase::m_pClient = 0;
-CConfig *CMenus::CUIElementBase::m_pConfig = 0;
-
 CMenus::CMenus()
 {
 	m_Popup = POPUP_NONE;
@@ -85,17 +79,6 @@ CMenus::CMenus()
 	m_ActiveListBox = ACTLB_NONE;
 
 	m_PopupCountrySelection = -2;
-}
-
-float CMenus::CButtonContainer::GetFade(bool Checked, float Seconds)
-{
-	if(m_pUI->HotItem() == this || Checked)
-	{
-		m_FadeStartTime = m_pClient->LocalTime();
-		return 1.0f;
-	}
-
-	return maximum(0.0f, m_FadeStartTime -  m_pClient->LocalTime() + Seconds)/Seconds;
 }
 
 void CMenus::DoIcon(int ImageId, int SpriteId, const CUIRect *pRect, const vec4 *pColor)
@@ -1678,8 +1661,6 @@ bool CMenus::OnInput(IInput::CEvent e)
 
 void CMenus::OnConsoleInit()
 {
-	CUIElementBase::Init(this);
-
 	Console()->Register("play", "r[file]", CFGFLAG_CLIENT|CFGFLAG_STORE, Con_Play, this, "Play the file specified");
 }
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -34,30 +34,6 @@ public:
 
 class CMenus : public CComponent
 {
-public:
-	class CUIElementBase
-	{
-	protected:
-		static CRenderTools *m_pRenderTools;
-		static CUI *m_pUI;
-		static IInput *m_pInput;
-		static IClient *m_pClient;
-		static CConfig *m_pConfig;
-
-	public:
-		static void Init(CMenus *pMenus) { m_pRenderTools = pMenus->RenderTools(); m_pUI = pMenus->UI(); m_pInput = pMenus->Input(); m_pClient = pMenus->Client(); m_pConfig = pMenus->Config(); }
-	};
-
-	class CButtonContainer : public CUIElementBase
-	{
-		bool m_CleanBackground;
-		float m_FadeStartTime;
-	public:
-		CButtonContainer(bool CleanBackground = false) : m_FadeStartTime(0.0f) { m_CleanBackground = CleanBackground; }
-		float GetFade(bool Checked = false, float Seconds = 0.6f);
-		bool IsCleanBackground() const { return m_CleanBackground; }
-	};
-
 private:
 	typedef float (CMenus::*FDropdownCallback)(CUIRect View);
 

--- a/src/game/client/components/menus_callback.cpp
+++ b/src/game/client/components/menus_callback.cpp
@@ -12,7 +12,7 @@ typedef struct
 	const char *m_pCommand;
 	int m_KeyId;
 	int m_Modifier;
-	CMenus::CButtonContainer m_BC;
+	CButtonContainer m_BC;
 } CKeyInfo;
 
 static CKeyInfo gs_aKeys[] =

--- a/src/game/client/components/menus_listbox.cpp
+++ b/src/game/client/components/menus_listbox.cpp
@@ -33,11 +33,11 @@ void CMenus::CListBox::DoHeader(const CUIRect *pRect, const char *pTitle,
 
 	// background
 	View.HSplitTop(HeaderHeight+Spacing, &Header, 0);
-	Header.Draw(vec4(0.0f, 0.0f, 0.0f, m_pConfig->m_ClMenuAlpha/100.0f), 5.0f, m_BackgroundCorners&CUIRect::CORNER_T);
+	Header.Draw(vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), 5.0f, m_BackgroundCorners&CUIRect::CORNER_T);
 
 	// draw header
 	View.HSplitTop(HeaderHeight, &Header, &View);
-	m_pUI->DoLabel(&Header, pTitle, Header.h*CUI::ms_FontmodHeight*0.8f, TEXTALIGN_MC);
+	UI()->DoLabel(&Header, pTitle, Header.h*CUI::ms_FontmodHeight*0.8f, TEXTALIGN_MC);
 
 	View.HSplitTop(Spacing, &Header, &View);
 
@@ -59,7 +59,7 @@ bool CMenus::CListBox::DoFilter(float FilterHeight, float Spacing)
 
 	// background
 	View.HSplitTop(FilterHeight+Spacing, &Filter, 0);
-	Filter.Draw(vec4(0.0f, 0.0f, 0.0f, m_pConfig->m_ClMenuAlpha/100.0f), 5.0f, CUIRect::CORNER_NONE);
+	Filter.Draw(vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), 5.0f, CUIRect::CORNER_NONE);
 
 	// draw filter
 	View.HSplitTop(FilterHeight, &Filter, &View);
@@ -70,8 +70,8 @@ bool CMenus::CListBox::DoFilter(float FilterHeight, float Spacing)
 	CUIRect Label, EditBox;
 	Filter.VSplitLeft(Filter.w/5.0f, &Label, &EditBox);
 	Label.y += Spacing;
-	m_pUI->DoLabel(&Label, Localize("Search:"), FontSize, TEXTALIGN_CENTER);
-	bool Changed = m_pUI->DoEditBox(&m_FilterInput, &EditBox, FontSize);
+	UI()->DoLabel(&Label, Localize("Search:"), FontSize, TEXTALIGN_CENTER);
+	bool Changed = UI()->DoEditBox(&m_FilterInput, &EditBox, FontSize);
 
 	View.HSplitTop(Spacing, &Filter, &View);
 
@@ -98,7 +98,7 @@ void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, i
 	// background
 	m_BackgroundCorners = BackgroundCorners;
 	if(Background)
-		View.Draw(vec4(0.0f, 0.0f, 0.0f, m_pConfig->m_ClMenuAlpha/100.0f), 5.0f, m_BackgroundCorners&CUIRect::CORNER_B);
+		View.Draw(vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), 5.0f, m_BackgroundCorners&CUIRect::CORNER_B);
 
 	// draw footers
 	if(m_pBottomText)
@@ -106,7 +106,7 @@ void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, i
 		CUIRect Footer;
 		View.HSplitBottom(m_FooterHeight, &View, &Footer);
 		Footer.VSplitLeft(10.0f, 0, &Footer);
-		m_pUI->DoLabel(&Footer, m_pBottomText, Footer.h*CUI::ms_FontmodHeight*0.8f, TEXTALIGN_MC);
+		UI()->DoLabel(&Footer, m_pBottomText, Footer.h*CUI::ms_FontmodHeight*0.8f, TEXTALIGN_MC);
 	}
 
 	// setup the variables
@@ -124,9 +124,9 @@ void CMenus::CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, i
 	// handle input
 	if(!pActive || *pActive)
 	{
-		if(m_pUI->ConsumeHotkey(CUI::HOTKEY_DOWN))
+		if(UI()->ConsumeHotkey(CUI::HOTKEY_DOWN))
 			m_ListBoxNewSelOffset += 1;
-		if(m_pUI->ConsumeHotkey(CUI::HOTKEY_UP))
+		if(UI()->ConsumeHotkey(CUI::HOTKEY_UP))
 			m_ListBoxNewSelOffset -= 1;
 	}
 
@@ -174,7 +174,7 @@ CMenus::CListboxItem CMenus::CListBox::DoNextItem(const void *pId, bool Selected
 	CListboxItem Item = DoNextRow();
 	static bool s_ItemClicked = false;
 
-	if(Item.m_Visible && m_pUI->DoButtonLogic(pId, &Item.m_Rect))
+	if(Item.m_Visible && UI()->DoButtonLogic(pId, &Item.m_Rect))
 	{
 		s_ItemClicked = true;
 		m_ListBoxNewSelected = ThisItemIndex;
@@ -193,17 +193,17 @@ CMenus::CListboxItem CMenus::CListBox::DoNextItem(const void *pId, bool Selected
 		{
 			m_ListBoxDoneEvents = 1;
 
-			if(m_pUI->ConsumeHotkey(CUI::HOTKEY_ENTER) || (s_ItemClicked && m_pInput->MouseDoubleClick()))
+			if(UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (s_ItemClicked && Input()->MouseDoubleClick()))
 			{
 				m_ListBoxItemActivated = true;
-				m_pUI->SetActiveItem(0);
+				UI()->SetActiveItem(0);
 			}
 		}
 
 		CUIRect r = Item.m_Rect;
 		r.Draw(vec4(1, 1, 1, ProcessInput ? 0.5f : 0.33f));
 	}
-	/*else*/ if(m_pUI->HotItem() == pId && !m_ScrollRegion.IsAnimating())
+	/*else*/ if(UI()->HotItem() == pId && !m_ScrollRegion.IsAnimating())
 	{
 		CUIRect r = Item.m_Rect;
 		r.Draw(vec4(1, 1, 1, 0.33f));

--- a/src/game/client/components/menus_scrollregion.cpp
+++ b/src/game/client/components/menus_scrollregion.cpp
@@ -52,7 +52,7 @@ void CMenus::CScrollRegion::Begin(CUIRect* pClipRect, vec2* pOutOffset, CScrollR
 	if(m_Params.m_ClipBgColor.a > 0)
 		pClipRect->Draw(m_Params.m_ClipBgColor, 4.0f, HasScrollBar ? CUIRect::CORNER_L : CUIRect::CORNER_ALL);
 
-	m_pUI->ClipEnable(pClipRect);
+	UI()->ClipEnable(pClipRect);
 
 	m_ClipRect = *pClipRect;
 	m_ContentH = 0;
@@ -61,7 +61,7 @@ void CMenus::CScrollRegion::Begin(CUIRect* pClipRect, vec2* pOutOffset, CScrollR
 
 void CMenus::CScrollRegion::End()
 {
-	m_pUI->ClipDisable();
+	UI()->ClipDisable();
 
 	// only show scrollbar if content overflows
 	if(m_ContentH <= m_ClipRect.h)
@@ -73,17 +73,17 @@ void CMenus::CScrollRegion::End()
 
 	float AnimationDuration = 0.5f;
 
-	const bool IsPageScroll = m_pInput->KeyIsPressed(KEY_LALT) || m_pInput->KeyIsPressed(KEY_RALT);
-	if(m_pUI->MouseHovered(&RegionRect))
+	const bool IsPageScroll = Input()->KeyIsPressed(KEY_LALT) || Input()->KeyIsPressed(KEY_RALT);
+	if(UI()->MouseHovered(&RegionRect))
 	{
 		const float ScrollUnit = IsPageScroll ? m_ClipRect.h : m_Params.m_ScrollUnit;
-		if(m_pUI->KeyPress(KEY_MOUSE_WHEEL_UP))
+		if(UI()->KeyPress(KEY_MOUSE_WHEEL_UP))
 		{
 			m_AnimTime = AnimationDuration;
 			m_AnimInitScrollY = m_ScrollY;
 			m_AnimTargetScrollY -= ScrollUnit;
 		}
-		else if(m_pUI->KeyPress(KEY_MOUSE_WHEEL_DOWN))
+		else if(UI()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
 		{
 			m_AnimTime = AnimationDuration;
 			m_AnimInitScrollY = m_ScrollY;
@@ -114,7 +114,7 @@ void CMenus::CScrollRegion::End()
 
 	if(m_AnimTime > 0)
 	{
-		m_AnimTime -= m_pClient->RenderFrameTime();
+		m_AnimTime -= Client()->RenderFrameTime();
 		float AnimProgress = (1 - pow(m_AnimTime / AnimationDuration, 3)); // cubic ease out
 		m_ScrollY = m_AnimInitScrollY + (m_AnimTargetScrollY - m_AnimInitScrollY) * AnimProgress;
 	}
@@ -128,12 +128,12 @@ void CMenus::CScrollRegion::End()
 	bool Hovered = false;
 	bool Grabbed = false;
 	const void* pID = &m_ScrollY;
-	const bool InsideSlider = m_pUI->MouseHovered(&Slider);
-	const bool InsideRail = m_pUI->MouseHovered(&m_RailRect);
+	const bool InsideSlider = UI()->MouseHovered(&Slider);
+	const bool InsideRail = UI()->MouseHovered(&m_RailRect);
 
-	if(m_pUI->CheckActiveItem(pID) && m_pUI->MouseButton(0))
+	if(UI()->CheckActiveItem(pID) && UI()->MouseButton(0))
 	{
-		float MouseY = m_pUI->MouseY();
+		float MouseY = UI()->MouseY();
 		m_ScrollY += (MouseY - (Slider.y + m_SliderGrabPos.y)) / MaxSlider * MaxScroll;
 		m_SliderGrabPos.y = clamp(m_SliderGrabPos.y, 0.0f, SliderHeight);
 		m_AnimTargetScrollY = m_ScrollY;
@@ -142,29 +142,29 @@ void CMenus::CScrollRegion::End()
 	}
 	else if(InsideSlider)
 	{
-		m_pUI->SetHotItem(pID);
+		UI()->SetHotItem(pID);
 
-		if(!m_pUI->CheckActiveItem(pID) && m_pUI->MouseButtonClicked(0))
+		if(!UI()->CheckActiveItem(pID) && UI()->MouseButtonClicked(0))
 		{
-			m_pUI->SetActiveItem(pID);
-			m_SliderGrabPos.y = m_pUI->MouseY() - Slider.y;
+			UI()->SetActiveItem(pID);
+			m_SliderGrabPos.y = UI()->MouseY() - Slider.y;
 			m_AnimTargetScrollY = m_ScrollY;
 			m_AnimTime = 0;
 		}
 		Hovered = true;
 	}
-	else if(InsideRail && m_pUI->MouseButtonClicked(0))
+	else if(InsideRail && UI()->MouseButtonClicked(0))
 	{
-		m_ScrollY += (m_pUI->MouseY() - (Slider.y+Slider.h/2)) / MaxSlider * MaxScroll;
-		m_pUI->SetActiveItem(pID);
+		m_ScrollY += (UI()->MouseY() - (Slider.y+Slider.h/2)) / MaxSlider * MaxScroll;
+		UI()->SetActiveItem(pID);
 		m_SliderGrabPos.y = Slider.h/2;
 		m_AnimTargetScrollY = m_ScrollY;
 		m_AnimTime = 0;
 		Hovered = true;
 	}
-	else if(m_pUI->CheckActiveItem(pID) && !m_pUI->MouseButton(0))
+	else if(UI()->CheckActiveItem(pID) && !UI()->MouseButton(0))
 	{
-		m_pUI->SetActiveItem(0);
+		UI()->SetActiveItem(0);
 	}
 
 	m_ScrollY = clamp(m_ScrollY, 0.0f, MaxScroll);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -351,7 +351,7 @@ void CGameClient::OnInit()
 	m_pGraphics = Kernel()->RequestInterface<IGraphics>();
 
 	// propagate pointers
-	m_UI.Init(Config(), Graphics(), Input(), TextRender());
+	m_UI.Init(Kernel());
 	m_RenderTools.Init(Config(), Graphics());
 
 	int64 Start = time_get();
@@ -602,6 +602,8 @@ void CGameClient::StartRendering()
 
 void CGameClient::OnRender()
 {
+	CUIElementBase::Init(UI()); // update static pointer because game and editor use separate UI
+
 	// update the local character and spectate position
 	UpdatePositions();
 

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -101,6 +101,33 @@ public:
 } const ScrollBarColorFunction;
 
 
+class CUIElementBase
+{
+private:
+	static class CUI *s_pUI;
+
+public:
+	static void Init(CUI *pUI) { s_pUI = pUI; }
+
+	class CUI *UI() const { return s_pUI; }
+	class IClient *Client() const;
+	class CConfig *Config() const;
+	class IGraphics *Graphics() const;
+	class IInput *Input() const;
+	class ITextRender *TextRender() const;
+};
+
+class CButtonContainer : public CUIElementBase
+{
+	bool m_CleanBackground;
+	float m_FadeStartTime;
+public:
+	CButtonContainer(bool CleanBackground = false) : m_FadeStartTime(0.0f) { m_CleanBackground = CleanBackground; }
+	float GetFade(bool Checked = false, float Seconds = 0.6f);
+	bool IsCleanBackground() const { return m_CleanBackground; }
+};
+
+
 class CUI
 {
 	enum
@@ -145,6 +172,7 @@ class CUI
 	} m_aPopupMenus[MAX_POPUP_MENUS];
 	unsigned m_NumPopupMenus;
 
+	class IClient *m_pClient;
 	class CConfig *m_pConfig;
 	class IGraphics *m_pGraphics;
 	class IInput *m_pInput;
@@ -162,8 +190,8 @@ public:
 	static const float ms_ListheaderHeight;
 	static const float ms_FontmodHeight;
 
-	// TODO: Refactor: Fill this in
-	void Init(class CConfig *pConfig, class IGraphics *pGraphics, class IInput *pInput, class ITextRender *pTextRender);
+	void Init(class IKernel *pKernel);
+	class IClient *Client() const { return m_pClient; }
 	class CConfig *Config() const { return m_pConfig; }
 	class IGraphics *Graphics() const { return m_pGraphics; }
 	class IInput *Input() const { return m_pInput; }

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4242,7 +4242,7 @@ void CEditor::Init()
 	m_pGraphics = Kernel()->RequestInterface<IGraphics>();
 	m_pTextRender = Kernel()->RequestInterface<ITextRender>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
-	m_UI.Init(m_pConfig, m_pGraphics, m_pInput, m_pTextRender);
+	m_UI.Init(Kernel());
 	m_RenderTools.Init(m_pConfig, m_pGraphics);
 	m_Map.m_pEditor = this;
 
@@ -4383,6 +4383,8 @@ void CEditor::UpdateAndRender()
 	else
 		m_AnimateTime = 0;
 	ms_pUiGotContext = 0;
+
+	CUIElementBase::Init(UI()); // update static pointer because game and editor use separate UI
 	UI()->StartCheck();
 
 	for(int i = 0; i < Input()->NumEvents(); i++)


### PR DESCRIPTION
- Move `CUIElementBase` and `CButtonContainer` from `CMenus` to UI.
  - Game and editor have separate `CUI` instances but `CUIElementBase` has a static reference to `CUI`. This reference is always updated at the beginning of the game/editor render method (by calling `CUIElementBase::Init` again), to ensure that the correct CUI is being used.
- Use the accessor methods (like `UI()`) instead of the underlying pointers in the UI element implementations.
- Only pass kernel to `CUI::Init` to reduce long list of arguments.