### PR TITLE
Initialze DragMoveOverlayRect to prevent crash

### DIFF
--- a/src/game/editor/editor2.cpp
+++ b/src/game/editor/editor2.cpp
@@ -1664,7 +1664,7 @@ void CEditor2::RenderMapEditorUiLayerGroups(CUIRect NavRect)
 	bool StartedMouseDragging = s_DragMove.m_IsDragging && OldIsMouseDragging == false;
 
 	bool DisplayDragMoveOverlay = s_DragMove.m_IsDragging && (DragMoveGroupListIndex >= 0 || DragMoveLayerListIndex >= 0);
-	CUIRect DragMoveOverlayRect;
+	CUIRect DragMoveOverlayRect = NavRect;
 	int DragMoveOffset = 0;
 	int DragMoveGroupIdOffset = 0; // for group dragging
 	// -----------------------


### PR DESCRIPTION
fix #3073 