### PR TITLE
Adjust windows header usage to fix compilation with VS2019

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -25,14 +25,14 @@
 	#define SDL_JOYSTICK_AXIS_MAX 32767
 #endif
 
-// for platform specific features that aren't available or are broken in SDL
-#include "SDL_syswm.h"
-
 #if defined(CONF_FAMILY_WINDOWS)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <imm.h>
 #endif
+
+// for platform specific features that aren't available or are broken in SDL
+#include "SDL_syswm.h"
 
 void CInput::AddEvent(char *pText, int Key, int Flags)
 {

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -29,6 +29,7 @@
 #include "SDL_syswm.h"
 
 #if defined(CONF_FAMILY_WINDOWS)
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <imm.h>
 #endif


### PR DESCRIPTION
Closes #3076. Does this fix all errors and warnings with VS2019 for you @AssassinTee?