### PR TITLE
Remove spammy 'snap invalidate problem' debug message

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -640,15 +640,9 @@ const void *CClient::SnapGetItem(int SnapID, int Index, CSnapItem *pItem) const
 void CClient::SnapInvalidateItem(int SnapID, int Index)
 {
 	dbg_assert(SnapID >= 0 && SnapID < NUM_SNAPSHOT_TYPES, "invalid SnapID");
-	const CSnapshotItem *i = m_aSnapshots[SnapID]->m_pAltSnap->GetItem(Index);
-	if(i)
-	{
-		if((char *)i < (char *)m_aSnapshots[SnapID]->m_pAltSnap || (char *)i > (char *)m_aSnapshots[SnapID]->m_pAltSnap + m_aSnapshots[SnapID]->m_SnapSize)
-			m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "client", "snap invalidate problem");
-		if((char *)i >= (char *)m_aSnapshots[SnapID]->m_pSnap && (char *)i < (char *)m_aSnapshots[SnapID]->m_pSnap + m_aSnapshots[SnapID]->m_SnapSize)
-			m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "client", "snap invalidate problem");
+	const CSnapshotItem *pItem = m_aSnapshots[SnapID]->m_pAltSnap->GetItem(Index);
+	if(pItem)
 		m_aSnapshots[SnapID]->m_pAltSnap->InvalidateItem(Index);
-	}
 }
 
 const void *CClient::SnapFindItem(int SnapID, int Type, int ID) const


### PR DESCRIPTION
The message gets printed very often on some maps/servers (e.g. Multeasymap), which may lead to lag (#200), though I didn't notice it on my machine.

It also gets printed even more often when playing demos and skipping to a specific point, causing the game to hang for multiple seconds.

For debug purposes, this message was not very useful anyway, as "debug 1" will enable a more useful error message:

https://github.com/teeworlds/teeworlds/blob/05235cd6467df4f74dcc52e1aa698c83767930db/src/game/client/gameclient.cpp#L1147-L1158