### PR TITLE
Improve performance when server browser entries are added

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1772,8 +1772,7 @@ void CClient::Update()
 	MasterServer()->Update();
 
 	// update the server browser
-	m_ServerBrowser.Update(m_ResortServerBrowser);
-	m_ResortServerBrowser = false;
+	m_ServerBrowser.Update();
 
 	// update gameclient
 	if(!m_EditorActive)
@@ -2404,7 +2403,7 @@ void CClient::Con_AddDemoMarker(IConsole::IResult *pResult, void *pUserData)
 
 void CClient::ServerBrowserUpdate()
 {
-	m_ResortServerBrowser = true;
+	m_ServerBrowser.RequestResort();
 }
 
 void CClient::ConchainServerBrowserUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -103,7 +103,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	bool m_AutoStatScreenshotRecycle;
 	bool m_EditorActive;
 	bool m_SoundInitFailed;
-	bool m_ResortServerBrowser;
 	bool m_RecordGameMessage;
 
 	int m_AckGameTick;

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -164,7 +164,7 @@ void CServerBrowser::Set(const NETADDR &Addr, int SetType, int Token, const CSer
 	}
 
 	if(pEntry)
-		m_ServerBrowserFilter.Sort(m_aServerlist[m_ActServerlistType].m_ppServerlist, m_aServerlist[m_ActServerlistType].m_NumServers, CServerBrowserFilter::RESORT_FLAG_FORCE);
+		RequestResort();
 }
 
 void CServerBrowser::Update()

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -74,6 +74,7 @@ CServerBrowser::CServerBrowser()
 	m_NeedRefresh = false;
 	m_RefreshFlags = 0;
 	m_InfoUpdated = false;
+	m_NeedResort = false;
 
 	// the token is to keep server refresh separated from each other
 	m_CurrentLanToken = 1;
@@ -166,7 +167,7 @@ void CServerBrowser::Set(const NETADDR &Addr, int SetType, int Token, const CSer
 		m_ServerBrowserFilter.Sort(m_aServerlist[m_ActServerlistType].m_ppServerlist, m_aServerlist[m_ActServerlistType].m_NumServers, CServerBrowserFilter::RESORT_FLAG_FORCE);
 }
 
-void CServerBrowser::Update(bool ForceResort)
+void CServerBrowser::Update()
 {
 	int64 Timeout = time_freq();
 	int64 Now = time_get();
@@ -260,11 +261,12 @@ void CServerBrowser::Update(bool ForceResort)
 				pEntry->m_Info.m_Favorite = true;
 
 			if(i == m_ActServerlistType)
-				ForceResort = true;
+				m_NeedResort = true;
 		}
 	}
 
-	m_ServerBrowserFilter.Sort(m_aServerlist[m_ActServerlistType].m_ppServerlist, m_aServerlist[m_ActServerlistType].m_NumServers, ForceResort ? CServerBrowserFilter::RESORT_FLAG_FORCE : 0);
+	m_ServerBrowserFilter.Sort(m_aServerlist[m_ActServerlistType].m_ppServerlist, m_aServerlist[m_ActServerlistType].m_NumServers, m_NeedResort ? CServerBrowserFilter::RESORT_FLAG_FORCE : 0);
+	m_NeedResort = false;
 }
 
 // interface functions

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -71,7 +71,7 @@ CServerBrowser::CServerBrowser()
 	m_pLastReqServer = 0;
 	m_NumRequests = 0;
 
-	m_NeedRefresh = 0;
+	m_NeedRefresh = false;
 	m_RefreshFlags = 0;
 	m_InfoUpdated = false;
 
@@ -178,7 +178,7 @@ void CServerBrowser::Update(bool ForceResort)
 	{
 		CNetChunk Packet;
 
-		m_NeedRefresh = 0;
+		m_NeedRefresh = false;
 		m_InfoUpdated = false;
 
 		mem_zero(&Packet, sizeof(Packet));
@@ -330,7 +330,7 @@ void CServerBrowser::Refresh(int RefreshFlags)
 		m_pLastReqServer = 0;
 		m_NumRequests = 0;
 
-		m_NeedRefresh = 1;
+		m_NeedRefresh = true;
 		for(int i = 0; i < m_ServerBrowserFavorites.m_NumFavoriteServers; i++)
 			if(m_ServerBrowserFavorites.m_aFavoriteServers[i].m_State >= CServerBrowserFavorites::FAVSTATE_ADDR)
 				Set(m_ServerBrowserFavorites.m_aFavoriteServers[i].m_Addr, SET_FAV_ADD, -1, 0);

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -96,7 +96,7 @@ private:
 	CServerEntry *m_pLastReqServer;
 	int m_NumRequests;
 
-	int m_NeedRefresh;
+	bool m_NeedRefresh;
 	bool m_InfoUpdated;
 
 	// the token is to keep server refresh separated from each other

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -21,7 +21,7 @@ public:
 	CServerBrowser();
 	void Init(class CNetClient *pClient, const char *pNetVersion);
 	void Set(const NETADDR &Addr, int SetType, int Token, const CServerInfo *pInfo);
-	void Update(bool ForceResort);	
+	void Update();
 
 	// interface functions
 	int GetType() { return m_ActServerlistType; }
@@ -31,6 +31,7 @@ public:
 	bool IsRefreshingMasters() const { return m_pMasterServer->IsRefreshing(); }
 	bool WasUpdated(bool Purge);
 	int LoadingProgression() const;
+	void RequestResort() { m_NeedResort = true; }
 
 	int NumServers() const { return m_aServerlist[m_ActServerlistType].m_NumServers; }
 	int NumPlayers() const { return m_aServerlist[m_ActServerlistType].m_NumPlayers; }
@@ -98,6 +99,7 @@ private:
 
 	bool m_NeedRefresh;
 	bool m_InfoUpdated;
+	bool m_NeedResort;
 
 	// the token is to keep server refresh separated from each other
 	int m_CurrentLanToken;

--- a/src/engine/client/serverbrowser_filter.cpp
+++ b/src/engine/client/serverbrowser_filter.cpp
@@ -165,16 +165,11 @@ void CServerBrowserFilter::CServerFilter::Filter()
 
 			if(!Filtered && Config()->m_BrFilterString[0] != 0)
 			{
-				int MatchFound = 0;
-
 				m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit = 0;
 
 				// match against server name
 				if(str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aName, Config()->m_BrFilterString))
-				{
-					MatchFound = 1;
 					m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit |= IServerBrowser::QUICK_SERVERNAME;
-				}
 
 				// match against players
 				for(int p = 0; p < m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_NumClients; p++)
@@ -182,7 +177,6 @@ void CServerBrowserFilter::CServerFilter::Filter()
 					if(str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aClients[p].m_aName, Config()->m_BrFilterString) ||
 						str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aClients[p].m_aClan, Config()->m_BrFilterString))
 					{
-						MatchFound = 1;
 						m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit |= IServerBrowser::QUICK_PLAYER;
 						break;
 					}
@@ -190,19 +184,13 @@ void CServerBrowserFilter::CServerFilter::Filter()
 
 				// match against map
 				if(str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aMap, Config()->m_BrFilterString))
-				{
-					MatchFound = 1;
 					m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit |= IServerBrowser::QUICK_MAPNAME;
-				}
 
 				// match against game type
 				if(str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aGameType, Config()->m_BrFilterString))
-				{
-					MatchFound = 1;
 					m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit |= IServerBrowser::QUICK_GAMETYPE;
-				}
 
-				if(!MatchFound)
+				if(!m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit)
 					Filtered = 1;
 			}
 		}

--- a/src/engine/client/serverbrowser_filter.cpp
+++ b/src/engine/client/serverbrowser_filter.cpp
@@ -88,7 +88,7 @@ void CServerBrowserFilter::CServerFilter::Filter()
 	// filter the servers
 	for(int i = 0; i < NumServers; i++)
 	{
-		int Filtered = 0;
+		bool Filtered = false;
 
 		int RelevantClientCount = (m_FilterInfo.m_SortHash&IServerBrowser::FILTER_SPECTATORS) ? m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_NumPlayers : m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_NumClients;
 		if(m_FilterInfo.m_SortHash&IServerBrowser::FILTER_BOTS)
@@ -99,26 +99,26 @@ void CServerBrowserFilter::CServerFilter::Filter()
 		}
 
 		if(m_FilterInfo.m_SortHash&IServerBrowser::FILTER_EMPTY && RelevantClientCount == 0)
-			Filtered = 1;
+			Filtered = true;
 		else if(m_FilterInfo.m_SortHash&IServerBrowser::FILTER_FULL && ((m_FilterInfo.m_SortHash&IServerBrowser::FILTER_SPECTATORS && m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_NumPlayers == m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_MaxPlayers) ||
 				m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_NumClients == m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_MaxClients))
-			Filtered = 1;
+			Filtered = true;
 		else if(m_FilterInfo.m_SortHash&IServerBrowser::FILTER_PW && m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_Flags&IServerBrowser::FLAG_PASSWORD)
-			Filtered = 1;
+			Filtered = true;
 		else if(m_FilterInfo.m_SortHash&IServerBrowser::FILTER_FAVORITE && !m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_Favorite)
-			Filtered = 1;
+			Filtered = true;
 		else if(m_FilterInfo.m_SortHash&IServerBrowser::FILTER_PURE && !(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_Flags&IServerBrowser::FLAG_PURE))
-			Filtered = 1;
+			Filtered = true;
 		else if(m_FilterInfo.m_SortHash&IServerBrowser::FILTER_PURE_MAP &&  !(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_Flags&IServerBrowser::FLAG_PUREMAP))
-			Filtered = 1;
+			Filtered = true;
 		else if(m_FilterInfo.m_Ping < m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_Latency)
-			Filtered = 1;
+			Filtered = true;
 		else if(m_FilterInfo.m_SortHash&IServerBrowser::FILTER_COMPAT_VERSION && str_comp_num(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aVersion, m_pServerBrowserFilter->m_aNetVersion, 3) != 0)
-			Filtered = 1;
+			Filtered = true;
 		else if(m_FilterInfo.m_aAddress[0] && !str_find_nocase(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aAddress, m_FilterInfo.m_aAddress))
-			Filtered = 1;
+			Filtered = true;
 		else if(m_FilterInfo.IsLevelFiltered(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_ServerLevel))
-			Filtered = 1;
+			Filtered = true;
 		else
 		{
 			if(m_FilterInfo.m_aGametype[0][0])
@@ -151,13 +151,13 @@ void CServerBrowserFilter::CServerFilter::Filter()
 
 			if(!Filtered && m_FilterInfo.m_SortHash&IServerBrowser::FILTER_COUNTRY)
 			{
-				Filtered = 1;
+				Filtered = true;
 				// match against player country
 				for(int p = 0; p < m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_NumClients; p++)
 				{
 					if(m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_aClients[p].m_Country == m_FilterInfo.m_Country)
 					{
-						Filtered = 0;
+						Filtered = false;
 						break;
 					}
 				}
@@ -191,11 +191,11 @@ void CServerBrowserFilter::CServerFilter::Filter()
 					m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit |= IServerBrowser::QUICK_GAMETYPE;
 
 				if(!m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_QuickSearchHit)
-					Filtered = 1;
+					Filtered = true;
 			}
 		}
 
-		if(Filtered == 0)
+		if(!Filtered)
 		{
 			// check for friend
 			m_pServerBrowserFilter->m_ppServerlist[i]->m_Info.m_FriendState = CContactInfo::CONTACT_NO;


### PR DESCRIPTION
The server list was being filtered and resorted for every new entry being added.
Now the resort is deferred until the next update call, so multiple entries being added in the same frame will not cause significant lags.

There is only a minor FPS drop now when refreshing the server browser with `br_max_requests 250`, 20 server filters and using the quick search at the same time. Closes #3051.