### PR TITLE
Improve usability when renaming demos and saving skins

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1522,12 +1522,12 @@ void CMenus::RenderMenu(CUIRect Screen)
 			CUIRect Yes, No;
 			BottomBar.VSplitMid(&No, &Yes, SpacingW);
 
-			static CButtonContainer s_ButtonAbort;
-			if(DoButton_Menu(&s_ButtonAbort, Localize("No"), 0, &No) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+			static CButtonContainer s_ButtonNo;
+			if(DoButton_Menu(&s_ButtonNo, Localize("No"), 0, &No) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 				m_Popup = POPUP_NONE;
 
-			static CButtonContainer s_ButtonTryAgain;
-			if(DoButton_Menu(&s_ButtonTryAgain, Localize("Yes"), !m_aSaveSkinName[0], &Yes) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+			static CButtonContainer s_ButtonYes;
+			if(DoButton_Menu(&s_ButtonYes, Localize("Yes"), !m_aSaveSkinName[0], &Yes) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 			{
 				if(m_aSaveSkinName[0] && m_aSaveSkinName[0] != 'x' && m_aSaveSkinName[1] != '_')
 				{

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1455,6 +1455,12 @@ void CMenus::RenderMenu(CUIRect Screen)
 			Box.HSplitTop(20.0f, &EditBox, &Box);
 
 			static CLineInput s_DemoNameInput(m_aCurrentDemoFile, sizeof(m_aCurrentDemoFile));
+			if(UI()->GetActiveItem() == m_aCurrentDemoFile) // initially activate input and select entire name
+			{
+				s_DemoNameInput.SetCursorOffset(s_DemoNameInput.GetLength());
+				s_DemoNameInput.SetSelection(0, s_DemoNameInput.GetLength());
+				UI()->SetActiveItem(&s_DemoNameInput);
+			}
 			UI()->DoEditBoxOption(&s_DemoNameInput, &EditBox, Localize("Name"), ButtonWidth);
 
 			// buttons
@@ -1504,6 +1510,12 @@ void CMenus::RenderMenu(CUIRect Screen)
 			Box.HSplitTop(20.0f, &EditBox, &Box);
 
 			static CLineInput s_SkinNameInput(m_aSaveSkinName, sizeof(m_aSaveSkinName));
+			if(UI()->GetActiveItem() == m_aSaveSkinName) // initially activate input and select entire name
+			{
+				s_SkinNameInput.SetCursorOffset(s_SkinNameInput.GetLength());
+				s_SkinNameInput.SetSelection(0, s_SkinNameInput.GetLength());
+				UI()->SetActiveItem(&s_SkinNameInput);
+			}
 			UI()->DoEditBoxOption(&s_SkinNameInput, &EditBox, Localize("Name"), ButtonWidth);
 
 			// buttons

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -653,10 +653,10 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		{
 			if(m_DemolistSelectedIndex >= 0)
 			{
-				UI()->SetActiveItem(0);
 				m_Popup = POPUP_RENAME_DEMO;
 				str_copy(m_aCurrentDemoFile, m_lDemos[m_DemolistSelectedIndex].m_aFilename,
 					minimum<int>(str_length(m_lDemos[m_DemolistSelectedIndex].m_aFilename) - str_length(".demo") + 1, sizeof(m_aCurrentDemoFile)));
+				UI()->SetActiveItem(m_aCurrentDemoFile); // marker to initially activate the input and select the text
 				return;
 			}
 		}

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -655,7 +655,8 @@ void CMenus::RenderDemoList(CUIRect MainView)
 			{
 				UI()->SetActiveItem(0);
 				m_Popup = POPUP_RENAME_DEMO;
-				str_copy(m_aCurrentDemoFile, m_lDemos[m_DemolistSelectedIndex].m_aFilename, sizeof(m_aCurrentDemoFile));
+				str_copy(m_aCurrentDemoFile, m_lDemos[m_DemolistSelectedIndex].m_aFilename,
+					minimum<int>(str_length(m_lDemos[m_DemolistSelectedIndex].m_aFilename) - str_length(".demo") + 1, sizeof(m_aCurrentDemoFile)));
 				return;
 			}
 		}

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1336,7 +1336,10 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 		BottomView.VSplitLeft(ButtonWidth, &Button, &BottomView);
 		static CButtonContainer s_CustomSkinSaveButton;
 		if(DoButton_Menu(&s_CustomSkinSaveButton, Localize("Save"), 0, &Button))
+		{
+			UI()->SetActiveItem(m_aSaveSkinName); // marker to initially activate the input and select the text
 			m_Popup = POPUP_SAVE_SKIN;
+		}
 		BottomView.VSplitLeft(SpacingW, 0, &BottomView);
 
 		BottomView.VSplitLeft(ButtonWidth, &Button, &BottomView);


### PR DESCRIPTION
- Strip the `.demo` extension before showing the name in the popup, as it will get added if it's missing and the user doesn't need to see it.
- Activate the line input and select the entire text when activating Rename demo and Save skin popups for better usability.