### PR TITLE
Implement asynchronous logging (rebased and fixed)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1719,6 +1719,7 @@ add_custom_target(everything DEPENDS ${TARGETS_OWN})
 
 if(GTEST_FOUND OR DOWNLOAD_GTEST)
   set_src(TESTS GLOB src/test
+    aio.cpp
     bytes_be.cpp
     compression.cpp
     datafile.cpp

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -64,16 +64,44 @@ IOHANDLE io_stdin() { return (IOHANDLE)stdin; }
 IOHANDLE io_stdout() { return (IOHANDLE)stdout; }
 IOHANDLE io_stderr() { return (IOHANDLE)stderr; }
 
-static DBG_LOGGER loggers[16];
+typedef struct
+{
+	DBG_LOGGER logger;
+	DBG_LOGGER_FINISH finish;
+	void *user;
+} DBG_LOGGER_DATA;
+
+static DBG_LOGGER_DATA loggers[16];
 static int num_loggers = 0;
 
 static NETSTATS network_stats = {0};
 
 static NETSOCKET invalid_socket = {NETTYPE_INVALID, -1, -1};
 
-void dbg_logger(DBG_LOGGER logger)
+static void dbg_logger_finish(void)
 {
-	loggers[num_loggers++] = logger;
+	int i;
+	for(i = 0; i < num_loggers; i++)
+	{
+		if(loggers[i].finish)
+		{
+			loggers[i].finish(loggers[i].user);
+		}
+	}
+}
+
+void dbg_logger(DBG_LOGGER logger, DBG_LOGGER_FINISH finish, void *user)
+{
+	DBG_LOGGER_DATA data;
+	if(num_loggers == 0)
+	{
+		atexit(dbg_logger_finish);
+	}
+	data.logger = logger;
+	data.finish = finish;
+	data.user = user;
+	loggers[num_loggers] = data;
+	num_loggers++;
 }
 
 void dbg_assert_imp(const char *filename, int line, int test, const char *msg)
@@ -114,11 +142,11 @@ void dbg_msg(const char *sys, const char *fmt, ...)
 	va_end(args);
 
 	for(i = 0; i < num_loggers; i++)
-		loggers[i](str);
+		loggers[i].logger(str, loggers[i].user);
 }
 
 #if defined(CONF_FAMILY_WINDOWS)
-static void logger_win_console(const char *line)
+static void logger_win_console(const char *line, void *user)
 {
 	#define _MAX_LENGTH 1024
 	#define _MAX_LENGTH_ERROR (_MAX_LENGTH+32)
@@ -205,14 +233,14 @@ static void logger_win_console(const char *line)
 }
 #endif
 
-static void logger_stdout(const char *line)
+static void logger_stdout(const char *line, void *user)
 {
 	printf("%s\n", line);
 	fflush(stdout);
 }
 
 #if defined(CONF_FAMILY_WINDOWS)
-static void logger_win_debugger(const char *line)
+static void logger_win_debugger(const char *line, void *user)
 {
 	WCHAR wBuffer[512];
 	MultiByteToWideChar(CP_UTF8, 0, line, -1, wBuffer, sizeof(wBuffer) / sizeof(WCHAR));
@@ -221,12 +249,27 @@ static void logger_win_debugger(const char *line)
 }
 #endif
 
-static IOHANDLE logfile = 0;
-static void logger_file(const char *line)
+static void logger_file(const char *line, void *user)
 {
-	io_write(logfile, line, str_length(line));
-	io_write_newline(logfile);
-	io_flush(logfile);
+	ASYNCIO *logfile = (ASYNCIO *)user;
+	aio_lock(logfile);
+	aio_write_unlocked(logfile, line, strlen(line));
+	aio_write_newline_unlocked(logfile);
+	aio_unlock(logfile);
+}
+
+static void logger_stdout_finish(void *user)
+{
+	ASYNCIO *logfile = (ASYNCIO *)user;
+	aio_wait(logfile);
+	aio_free(logfile);
+}
+
+static void logger_file_finish(void *user)
+{
+	ASYNCIO *logfile = (ASYNCIO *)user;
+	aio_close(logfile);
+	logger_stdout_finish(user);
 }
 
 void dbg_logger_stdout()
@@ -234,34 +277,27 @@ void dbg_logger_stdout()
 #if defined(CONF_FAMILY_WINDOWS)
 	if(GetFileType(GetStdHandle(STD_OUTPUT_HANDLE)) == FILE_TYPE_CHAR)
 	{
-		dbg_logger(logger_win_console);
+		dbg_logger(logger_win_console, 0, 0);
 		return;
 	}
 #endif
-	dbg_logger(logger_stdout);
+	dbg_logger(logger_stdout, 0, 0);
 }
 
 void dbg_logger_debugger()
 {
 #if defined(CONF_FAMILY_WINDOWS)
-	dbg_logger(logger_win_debugger);
+	dbg_logger(logger_win_debugger, 0, 0);
 #endif
 }
 
 void dbg_logger_file(const char *filename)
 {
-	IOHANDLE handle = io_open(filename, IOFLAG_WRITE);
-	if(handle)
-		dbg_logger_filehandle(handle);
+	IOHANDLE logfile = io_open(filename, IOFLAG_WRITE);
+	if(logfile)
+		dbg_logger(logger_file, logger_file_finish, aio_new(logfile));
 	else
 		dbg_msg("dbg/logger", "failed to open '%s' for logging", filename);
-}
-
-void dbg_logger_filehandle(IOHANDLE handle)
-{
-	logfile = handle;
-	if(logfile)
-		dbg_logger(logger_file);
 }
 
 #if defined(CONF_FAMILY_WINDOWS)

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -291,13 +291,9 @@ void dbg_logger_debugger()
 #endif
 }
 
-void dbg_logger_file(const char *filename)
+void dbg_logger_file(IOHANDLE logfile)
 {
-	IOHANDLE logfile = io_open(filename, IOFLAG_WRITE);
-	if(logfile)
-		dbg_logger(logger_file, logger_file_finish, aio_new(logfile));
-	else
-		dbg_msg("dbg/logger", "failed to open '%s' for logging", filename);
+	dbg_logger(logger_file, logger_file_finish, aio_new(logfile));
 }
 
 #if defined(CONF_FAMILY_WINDOWS)

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -605,7 +605,7 @@ static void aio_handle_free_and_unlock(ASYNCIO *aio)
 	if(do_free)
 	{
 		free(aio->buffer);
-		semaphore_destroy(&aio->sphore);
+		sphore_destroy(&aio->sphore);
 		lock_destroy(aio->lock);
 		free(aio);
 	}
@@ -635,7 +635,7 @@ static void aio_thread(void *user)
 				break;
 			}
 			lock_unlock(aio->lock);
-			semaphore_wait(&aio->sphore);
+			sphore_wait(&aio->sphore);
 			lock_wait(aio->lock);
 			continue;
 		}
@@ -680,13 +680,13 @@ ASYNCIO *aio_new(IOHANDLE io)
 	}
 	aio->io = io;
 	aio->lock = lock_create();
-	semaphore_init(&aio->sphore);
+	sphore_init(&aio->sphore);
 	aio->thread = 0;
 
 	aio->buffer = malloc(ASYNC_BUFSIZE);
 	if(!aio->buffer)
 	{
-		semaphore_destroy(&aio->sphore);
+		sphore_destroy(&aio->sphore);
 		lock_destroy(aio->lock);
 		free(aio);
 		return 0;
@@ -702,7 +702,7 @@ ASYNCIO *aio_new(IOHANDLE io)
 	if(!aio->thread)
 	{
 		free(aio->buffer);
-		semaphore_destroy(&aio->sphore);
+		sphore_destroy(&aio->sphore);
 		lock_destroy(aio->lock);
 		free(aio);
 		return 0;
@@ -739,7 +739,7 @@ void aio_lock(ASYNCIO *aio)
 void aio_unlock(ASYNCIO *aio)
 {
 	lock_unlock(aio->lock);
-	semaphore_signal(&aio->sphore);
+	sphore_signal(&aio->sphore);
 }
 
 void aio_write_unlocked(ASYNCIO *aio, const void *buffer, unsigned size)
@@ -840,7 +840,7 @@ void aio_close(ASYNCIO *aio)
 	lock_wait(aio->lock);
 	aio->finish = ASYNCIO_CLOSE;
 	lock_unlock(aio->lock);
-	semaphore_signal(&aio->sphore);
+	sphore_signal(&aio->sphore);
 }
 
 void aio_wait(ASYNCIO *aio)
@@ -854,7 +854,7 @@ void aio_wait(ASYNCIO *aio)
 		aio->finish = ASYNCIO_EXIT;
 	}
 	lock_unlock(aio->lock);
-	semaphore_signal(&aio->sphore);
+	sphore_signal(&aio->sphore);
 	thread_wait(thread);
 }
 
@@ -1036,15 +1036,15 @@ void lock_unlock(LOCK lock)
 }
 
 #if defined(CONF_FAMILY_UNIX) && !defined(CONF_PLATFORM_MACOS) // this should be CONF_POSIX_SEM but bam can't run C programs
-void semaphore_init(SEMAPHORE *sem) { sem_init(sem, 0, 0); }
-void semaphore_wait(SEMAPHORE *sem) { sem_wait(sem); }
-void semaphore_signal(SEMAPHORE *sem) { sem_post(sem); }
-void semaphore_destroy(SEMAPHORE *sem) { sem_destroy(sem); }
+void sphore_init(SEMAPHORE *sem) { sem_init(sem, 0, 0); }
+void sphore_wait(SEMAPHORE *sem) { sem_wait(sem); }
+void sphore_signal(SEMAPHORE *sem) { sem_post(sem); }
+void sphore_destroy(SEMAPHORE *sem) { sem_destroy(sem); }
 #elif defined(CONF_FAMILY_WINDOWS)
-void semaphore_init(SEMAPHORE *sem) { *sem = CreateSemaphore(0, 0, 10000, 0); }
-void semaphore_wait(SEMAPHORE *sem) { WaitForSingleObject((HANDLE)*sem, INFINITE); }
-void semaphore_signal(SEMAPHORE *sem) { ReleaseSemaphore((HANDLE)*sem, 1, NULL); }
-void semaphore_destroy(SEMAPHORE *sem) { CloseHandle((HANDLE)*sem); }
+void sphore_init(SEMAPHORE *sem) { *sem = CreateSemaphore(0, 0, 10000, 0); }
+void sphore_wait(SEMAPHORE *sem) { WaitForSingleObject((HANDLE)*sem, INFINITE); }
+void sphore_signal(SEMAPHORE *sem) { ReleaseSemaphore((HANDLE)*sem, 1, NULL); }
+void sphore_destroy(SEMAPHORE *sem) { CloseHandle((HANDLE)*sem); }
 #else
 typedef struct SEMINTERNAL
 {
@@ -1054,7 +1054,7 @@ typedef struct SEMINTERNAL
 	pthread_cond_t c_nzcond;
 } SEMINTERNAL;
 
-void semaphore_init(SEMAPHORE *sem)
+void sphore_init(SEMAPHORE *sem)
 {
 	*sem = mem_alloc(sizeof(**sem));
 
@@ -1065,7 +1065,7 @@ void semaphore_init(SEMAPHORE *sem)
 	pthread_cond_init(&(*sem)->c_nzcond, 0);
 }
 
-void semaphore_wait(SEMAPHORE *sem)
+void sphore_wait(SEMAPHORE *sem)
 {
 	lock_wait((*sem)->c_lock);
 
@@ -1082,7 +1082,7 @@ void semaphore_wait(SEMAPHORE *sem)
 	lock_unlock((*sem)->c_lock);
 }
 
-void semaphore_signal(SEMAPHORE *sem)
+void sphore_signal(SEMAPHORE *sem)
 {
 	lock_wait((*sem)->c_lock);
 
@@ -1093,7 +1093,7 @@ void semaphore_signal(SEMAPHORE *sem)
 	lock_unlock((*sem)->c_lock);
 }
 
-void semaphore_destroy(SEMAPHORE *sem)
+void sphore_destroy(SEMAPHORE *sem)
 {
 	pthread_cond_destroy(&(*sem)->c_nzcond);
 	lock_destroy((*sem)->c_lock);

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -679,20 +679,71 @@ void lock_unlock(LOCK lock)
 #endif
 }
 
-#if !defined(CONF_PLATFORM_MACOS)
-	#if defined(CONF_FAMILY_UNIX)
-	void semaphore_init(SEMAPHORE *sem) { sem_init(sem, 0, 0); }
-	void semaphore_wait(SEMAPHORE *sem) { sem_wait(sem); }
-	void semaphore_signal(SEMAPHORE *sem) { sem_post(sem); }
-	void semaphore_destroy(SEMAPHORE *sem) { sem_destroy(sem); }
-	#elif defined(CONF_FAMILY_WINDOWS)
-	void semaphore_init(SEMAPHORE *sem) { *sem = CreateSemaphore(0, 0, 10000, 0); }
-	void semaphore_wait(SEMAPHORE *sem) { WaitForSingleObject((HANDLE)*sem, INFINITE); }
-	void semaphore_signal(SEMAPHORE *sem) { ReleaseSemaphore((HANDLE)*sem, 1, NULL); }
-	void semaphore_destroy(SEMAPHORE *sem) { CloseHandle((HANDLE)*sem); }
-	#else
-		#error not implemented on this platform
-	#endif
+#if defined(CONF_FAMILY_UNIX) && !defined(CONF_PLATFORM_MACOS) // this should be CONF_POSIX_SEM but bam can't run C programs
+void semaphore_init(SEMAPHORE *sem) { sem_init(sem, 0, 0); }
+void semaphore_wait(SEMAPHORE *sem) { sem_wait(sem); }
+void semaphore_signal(SEMAPHORE *sem) { sem_post(sem); }
+void semaphore_destroy(SEMAPHORE *sem) { sem_destroy(sem); }
+#elif defined(CONF_FAMILY_WINDOWS)
+void semaphore_init(SEMAPHORE *sem) { *sem = CreateSemaphore(0, 0, 10000, 0); }
+void semaphore_wait(SEMAPHORE *sem) { WaitForSingleObject((HANDLE)*sem, INFINITE); }
+void semaphore_signal(SEMAPHORE *sem) { ReleaseSemaphore((HANDLE)*sem, 1, NULL); }
+void semaphore_destroy(SEMAPHORE *sem) { CloseHandle((HANDLE)*sem); }
+#else
+typedef struct SEMINTERNAL
+{
+	int count;
+	int waiters;
+	LOCK c_lock;
+	pthread_cond_t c_nzcond;
+} SEMINTERNAL;
+
+void semaphore_init(SEMAPHORE *sem)
+{
+	*sem = mem_alloc(sizeof(**sem));
+
+	(*sem)->count = 0;
+	(*sem)->waiters = 0;
+
+	(*sem)->c_lock = lock_create();
+	pthread_cond_init(&(*sem)->c_nzcond, 0);
+}
+
+void semaphore_wait(SEMAPHORE *sem)
+{
+	lock_wait((*sem)->c_lock);
+
+	(*sem)->waiters++;
+	int result = 0;
+	while((*sem)->count == 0)
+		result = pthread_cond_wait(&(*sem)->c_nzcond, (LOCKINTERNAL *)(*sem)->c_lock);
+
+	(*sem)->waiters--;
+
+	if(!result)
+		(*sem)->count--;
+
+	lock_unlock((*sem)->c_lock);
+}
+
+void semaphore_signal(SEMAPHORE *sem)
+{
+	lock_wait((*sem)->c_lock);
+
+	if((*sem)->waiters)
+		pthread_cond_signal(&(*sem)->c_nzcond);
+
+	(*sem)->count++;
+	lock_unlock((*sem)->c_lock);
+}
+
+void semaphore_destroy(SEMAPHORE *sem)
+{
+	pthread_cond_destroy(&(*sem)->c_nzcond);
+	lock_destroy((*sem)->c_lock);
+	mem_free(*sem);
+}
+
 #endif
 
 

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -502,6 +502,326 @@ int io_flush(IOHANDLE io)
 	return 0;
 }
 
+int io_error(IOHANDLE io)
+{
+	return ferror((FILE*)io);
+}
+
+#define ASYNC_BUFSIZE 8 * 1024
+#define ASYNC_LOCAL_BUFSIZE 64 * 1024
+
+struct ASYNCIO
+{
+	LOCK lock;
+	IOHANDLE io;
+	SEMAPHORE sphore;
+	void *thread;
+
+	unsigned char *buffer;
+	unsigned int buffer_size;
+	unsigned int read_pos;
+	unsigned int write_pos;
+
+	int error;
+	unsigned char finish;
+	unsigned char refcount;
+};
+
+enum
+{
+	ASYNCIO_RUNNING,
+	ASYNCIO_CLOSE,
+	ASYNCIO_EXIT,
+};
+
+struct BUFFERS
+{
+	unsigned char *buf1;
+	unsigned int len1;
+	unsigned char *buf2;
+	unsigned int len2;
+};
+
+static void buffer_ptrs(ASYNCIO *aio, struct BUFFERS *buffers)
+{
+	mem_zero(buffers, sizeof(*buffers));
+	if(aio->read_pos < aio->write_pos)
+	{
+		buffers->buf1 = aio->buffer + aio->read_pos;
+		buffers->len1 = aio->write_pos - aio->read_pos;
+	}
+	else if(aio->read_pos > aio->write_pos)
+	{
+		buffers->buf1 = aio->buffer + aio->read_pos;
+		buffers->len1 = aio->buffer_size - aio->read_pos;
+		buffers->buf2 = aio->buffer;
+		buffers->len2 = aio->write_pos;
+	}
+}
+
+static void aio_handle_free_and_unlock(ASYNCIO *aio)
+{
+	int do_free;
+	aio->refcount--;
+
+	do_free = aio->refcount == 0;
+	lock_unlock(aio->lock);
+	if(do_free)
+	{
+		free(aio->buffer);
+		semaphore_destroy(&aio->sphore);
+		lock_destroy(aio->lock);
+		free(aio);
+	}
+}
+
+static void aio_thread(void *user)
+{
+	ASYNCIO *aio = user;
+
+	lock_wait(aio->lock);
+	while(1)
+	{
+		struct BUFFERS buffers;
+		int result_io_error;
+		unsigned char local_buffer[ASYNC_LOCAL_BUFSIZE];
+		unsigned int local_buffer_len = 0;
+
+		if(aio->read_pos == aio->write_pos)
+		{
+			if(aio->finish != ASYNCIO_RUNNING)
+			{
+				if(aio->finish == ASYNCIO_CLOSE)
+				{
+					io_close(aio->io);
+				}
+				aio_handle_free_and_unlock(aio);
+				break;
+			}
+			lock_unlock(aio->lock);
+			semaphore_wait(&aio->sphore);
+			lock_wait(aio->lock);
+			continue;
+		}
+
+		buffer_ptrs(aio, &buffers);
+		if(buffers.buf1)
+		{
+			if(buffers.len1 > sizeof(local_buffer) - local_buffer_len)
+			{
+				buffers.len1 = sizeof(local_buffer) - local_buffer_len;
+			}
+			mem_copy(local_buffer + local_buffer_len, buffers.buf1, buffers.len1);
+			local_buffer_len += buffers.len1;
+			if(buffers.buf2)
+			{
+				if(buffers.len2 > sizeof(local_buffer) - local_buffer_len)
+				{
+					buffers.len2 = sizeof(local_buffer) - local_buffer_len;
+				}
+				mem_copy(local_buffer + local_buffer_len, buffers.buf2, buffers.len2);
+				local_buffer_len += buffers.len2;
+			}
+		}
+		aio->read_pos = (aio->read_pos + buffers.len1 + buffers.len2) % aio->buffer_size;
+		lock_unlock(aio->lock);
+
+		io_write(aio->io, local_buffer, local_buffer_len);
+		io_flush(aio->io);
+		result_io_error = io_error(aio->io);
+
+		lock_wait(aio->lock);
+		aio->error = result_io_error;
+	}
+}
+
+ASYNCIO *aio_new(IOHANDLE io)
+{
+	ASYNCIO *aio = malloc(sizeof(*aio));
+	if(!aio)
+	{
+		return 0;
+	}
+	aio->io = io;
+	aio->lock = lock_create();
+	semaphore_init(&aio->sphore);
+	aio->thread = 0;
+
+	aio->buffer = malloc(ASYNC_BUFSIZE);
+	if(!aio->buffer)
+	{
+		semaphore_destroy(&aio->sphore);
+		lock_destroy(aio->lock);
+		free(aio);
+		return 0;
+	}
+	aio->buffer_size = ASYNC_BUFSIZE;
+	aio->read_pos = 0;
+	aio->write_pos = 0;
+	aio->error = 0;
+	aio->finish = ASYNCIO_RUNNING;
+	aio->refcount = 2;
+
+	aio->thread = thread_init(aio_thread, aio);
+	if(!aio->thread)
+	{
+		free(aio->buffer);
+		semaphore_destroy(&aio->sphore);
+		lock_destroy(aio->lock);
+		free(aio);
+		return 0;
+	}
+	return aio;
+}
+
+static unsigned int buffer_len(ASYNCIO *aio)
+{
+	if(aio->write_pos >= aio->read_pos)
+	{
+		return aio->write_pos - aio->read_pos;
+	}
+	else
+	{
+		return aio->buffer_size + aio->write_pos - aio->read_pos;
+	}
+}
+
+static unsigned int next_buffer_size(unsigned int cur_size, unsigned int need_size)
+{
+	while(cur_size < need_size)
+	{
+		cur_size *= 2;
+	}
+	return cur_size;
+}
+
+void aio_lock(ASYNCIO *aio)
+{
+	lock_wait(aio->lock);
+}
+
+void aio_unlock(ASYNCIO *aio)
+{
+	lock_unlock(aio->lock);
+	semaphore_signal(&aio->sphore);
+}
+
+void aio_write_unlocked(ASYNCIO *aio, const void *buffer, unsigned size)
+{
+	unsigned int remaining;
+	remaining = aio->buffer_size - buffer_len(aio);
+
+	// Don't allow full queue to distinguish between empty and full queue.
+	if(size < remaining)
+	{
+		unsigned int remaining_contiguous = aio->buffer_size - aio->write_pos;
+		if(size > remaining_contiguous)
+		{
+			mem_copy(aio->buffer + aio->write_pos, buffer, remaining_contiguous);
+			size -= remaining_contiguous;
+			buffer = ((unsigned char *)buffer) + remaining_contiguous;
+			aio->write_pos = 0;
+		}
+		mem_copy(aio->buffer + aio->write_pos, buffer, size);
+		aio->write_pos = (aio->write_pos + size) % aio->buffer_size;
+	}
+	else
+	{
+		// Add 1 so the new buffer isn't completely filled.
+		unsigned int new_written = buffer_len(aio) + size + 1;
+		unsigned int next_size = next_buffer_size(aio->buffer_size, new_written);
+		unsigned int next_len = 0;
+		unsigned char *next_buffer = malloc(next_size);
+
+		struct BUFFERS buffers;
+		buffer_ptrs(aio, &buffers);
+		if(buffers.buf1)
+		{
+			mem_copy(next_buffer + next_len, buffers.buf1, buffers.len1);
+			next_len += buffers.len1;
+			if(buffers.buf2)
+			{
+				mem_copy(next_buffer + next_len, buffers.buf2, buffers.len2);
+				next_len += buffers.len2;
+			}
+		}
+		mem_copy(next_buffer + next_len, buffer, size);
+		next_len += size;
+
+		free(aio->buffer);
+		aio->buffer = next_buffer;
+		aio->buffer_size = next_size;
+		aio->read_pos = 0;
+		aio->write_pos = next_len;
+	}
+}
+
+void aio_write(ASYNCIO *aio, const void *buffer, unsigned size)
+{
+	aio_lock(aio);
+	aio_write_unlocked(aio, buffer, size);
+	aio_unlock(aio);
+}
+
+void aio_write_newline_unlocked(ASYNCIO *aio)
+{
+#if defined(CONF_FAMILY_WINDOWS)
+	aio_write_unlocked(aio, "\r\n", 2);
+#else
+	aio_write_unlocked(aio, "\n", 1);
+#endif
+}
+
+void aio_write_newline(ASYNCIO *aio)
+{
+	aio_lock(aio);
+	aio_write_newline_unlocked(aio);
+	aio_unlock(aio);
+}
+
+int aio_error(ASYNCIO *aio)
+{
+	int result;
+	lock_wait(aio->lock);
+	result = aio->error;
+	lock_unlock(aio->lock);
+	return result;
+}
+
+void aio_free(ASYNCIO *aio)
+{
+	lock_wait(aio->lock);
+	if(aio->thread)
+	{
+		thread_detach(aio->thread);
+		aio->thread = 0;
+	}
+	aio_handle_free_and_unlock(aio);
+}
+
+void aio_close(ASYNCIO *aio)
+{
+	lock_wait(aio->lock);
+	aio->finish = ASYNCIO_CLOSE;
+	lock_unlock(aio->lock);
+	semaphore_signal(&aio->sphore);
+}
+
+void aio_wait(ASYNCIO *aio)
+{
+	void *thread;
+	lock_wait(aio->lock);
+	thread = aio->thread;
+	aio->thread = 0;
+	if(aio->finish == ASYNCIO_RUNNING)
+	{
+		aio->finish = ASYNCIO_EXIT;
+	}
+	lock_unlock(aio->lock);
+	semaphore_signal(&aio->sphore);
+	thread_wait(thread);
+}
+
 struct THREAD_RUN
 {
 	void (*threadfunc)(void *);

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1731,7 +1731,7 @@ void dbg_logger(DBG_LOGGER logger, DBG_LOGGER_FINISH finish, void *user);
 
 void dbg_logger_stdout();
 void dbg_logger_debugger();
-void dbg_logger_file(const char *filename);
+void dbg_logger_file(IOHANDLE logfile);
 
 #if defined(CONF_FAMILY_WINDOWS)
 void dbg_console_init();

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -623,10 +623,10 @@ void lock_unlock(LOCK lock);
 	typedef struct SEMINTERNAL *SEMAPHORE;
 #endif
 
-void semaphore_init(SEMAPHORE *sem);
-void semaphore_wait(SEMAPHORE *sem);
-void semaphore_signal(SEMAPHORE *sem);
-void semaphore_destroy(SEMAPHORE *sem);
+void sphore_init(SEMAPHORE *sem);
+void sphore_wait(SEMAPHORE *sem);
+void sphore_signal(SEMAPHORE *sem);
+void sphore_destroy(SEMAPHORE *sem);
 
 /* Group: Timer */
 #ifdef __GNUC__

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1725,13 +1725,13 @@ int net_socket_read_wait(NETSOCKET sock, int time);
 void swap_endian(void *data, unsigned elem_size, unsigned num);
 
 
-typedef void (*DBG_LOGGER)(const char *line);
-void dbg_logger(DBG_LOGGER logger);
+typedef void (*DBG_LOGGER)(const char *line, void *user);
+typedef void (*DBG_LOGGER_FINISH)(void *user);
+void dbg_logger(DBG_LOGGER logger, DBG_LOGGER_FINISH finish, void *user);
 
 void dbg_logger_stdout();
 void dbg_logger_debugger();
 void dbg_logger_file(const char *filename);
-void dbg_logger_filehandle(IOHANDLE handle);
 
 #if defined(CONF_FAMILY_WINDOWS)
 void dbg_console_init();

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -370,6 +370,17 @@ int io_close(IOHANDLE io);
 */
 int io_flush(IOHANDLE io);
 
+/*
+	Function: io_error
+		Checks whether an error occurred during I/O with the file.
+
+	Parameters:
+		io - Handle to the file.
+
+	Returns:
+		Returns nonzero on error, 0 otherwise.
+*/
+int io_error(IOHANDLE io);
 
 /*
 	Function: io_stdin
@@ -389,6 +400,135 @@ IOHANDLE io_stdout();
 */
 IOHANDLE io_stderr();
 
+/* Group: Asychronous I/O */
+
+typedef struct ASYNCIO ASYNCIO;
+/*
+	Function: aio_new
+		Wraps a <IOHANDLE> for asynchronous writing.
+
+	Parameters:
+		io - Handle to the file.
+
+	Returns:
+		Returns the handle for asynchronous writing.
+
+*/
+ASYNCIO *aio_new(IOHANDLE io);
+
+/*
+	Function: aio_lock
+		Locks the ASYNCIO structure so it can't be written into by
+		other threads.
+
+	Parameters:
+		aio - Handle to the file.
+*/
+void aio_lock(ASYNCIO *aio);
+
+/*
+	Function: aio_unlock
+		Unlocks the ASYNCIO structure after finishing the contiguous
+		write.
+
+	Parameters:
+		aio - Handle to the file.
+*/
+void aio_unlock(ASYNCIO *aio);
+
+/*
+	Function: aio_write
+		Queues a chunk of data for writing.
+
+	Parameters:
+		aio - Handle to the file.
+		buffer - Pointer to the data that should be written.
+		size - Number of bytes to write.
+
+*/
+void aio_write(ASYNCIO *aio, const void *buffer, unsigned size);
+
+/*
+	Function: aio_write_newline
+		Queues a newline for writing.
+
+	Parameters:
+		aio - Handle to the file.
+
+*/
+void aio_write_newline(ASYNCIO *aio);
+
+/*
+	Function: aio_write_unlocked
+		Queues a chunk of data for writing. The ASYNCIO struct must be
+		locked using `aio_lock` first.
+
+	Parameters:
+		aio - Handle to the file.
+		buffer - Pointer to the data that should be written.
+		size - Number of bytes to write.
+
+*/
+void aio_write_unlocked(ASYNCIO *aio, const void *buffer, unsigned size);
+
+/*
+	Function: aio_write_newline_unlocked
+		Queues a newline for writing. The ASYNCIO struct must be locked
+		using `aio_lock` first.
+
+	Parameters:
+		aio - Handle to the file.
+
+*/
+void aio_write_newline_unlocked(ASYNCIO *aio);
+
+/*
+	Function: aio_error
+		Checks whether errors have occurred during the asynchronous
+		writing.
+
+		Call this function regularly to see if there are errors. Call
+		this function after <aio_wait> to see if the process of writing
+		to the file succeeded.
+
+	Parameters:
+		aio - Handle to the file.
+
+	Returns:
+		Returns 0 if no error occurred, and nonzero on error.
+
+*/
+int aio_error(ASYNCIO *aio);
+
+/*
+	Function: aio_close
+		Queues file closing.
+
+	Parameters:
+		aio - Handle to the file.
+
+*/
+void aio_close(ASYNCIO *aio);
+
+/*
+	Function: aio_wait
+		Wait for the asynchronous operations to complete.
+
+	Parameters:
+		aio - Handle to the file.
+
+*/
+void aio_wait(ASYNCIO *aio);
+
+/*
+	Function: aio_free
+		Frees the resources associated to the asynchronous file handle.
+
+	Parameters:
+		aio - Handle to the file.
+
+*/
+void aio_free(ASYNCIO *aio);
 
 /* Group: Threads */
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -474,21 +474,19 @@ void lock_unlock(LOCK lock);
 
 /* Group: Semaphores */
 
-#if !defined(CONF_PLATFORM_MACOS)
-	#if defined(CONF_FAMILY_UNIX)
-		#include <semaphore.h>
-		typedef sem_t SEMAPHORE;
-	#elif defined(CONF_FAMILY_WINDOWS)
-		typedef void* SEMAPHORE;
-	#else
-		#error missing sempahore implementation
-	#endif
-
-	void semaphore_init(SEMAPHORE *sem);
-	void semaphore_wait(SEMAPHORE *sem);
-	void semaphore_signal(SEMAPHORE *sem);
-	void semaphore_destroy(SEMAPHORE *sem);
+#if defined(CONF_FAMILY_UNIX) && !defined(CONF_PLATFORM_MACOS)
+	#include <semaphore.h>
+	typedef sem_t SEMAPHORE;
+#elif defined(CONF_FAMILY_WINDOWS)
+	typedef void* SEMAPHORE;
+#else
+	typedef struct SEMINTERNAL *SEMAPHORE;
 #endif
+
+void semaphore_init(SEMAPHORE *sem);
+void semaphore_wait(SEMAPHORE *sem);
+void semaphore_signal(SEMAPHORE *sem);
+void semaphore_destroy(SEMAPHORE *sem);
 
 /* Group: Timer */
 #ifdef __GNUC__

--- a/src/base/tl/threading.h
+++ b/src/base/tl/threading.h
@@ -65,21 +65,15 @@
 	#error missing atomic implementation for this compiler
 #endif
 
-#if defined(CONF_PLATFORM_MACOS)
-	/*
-		use semaphore provided by SDL on macos
-	*/
-#else
-	class semaphore
-	{
-		SEMAPHORE sem;
-	public:
-		semaphore() { semaphore_init(&sem); }
-		~semaphore() { semaphore_destroy(&sem); }
-		void wait() { semaphore_wait(&sem); }
-		void signal() { semaphore_signal(&sem); }
-	};
-#endif
+class semaphore
+{
+	SEMAPHORE sem;
+public:
+	semaphore() { semaphore_init(&sem); }
+	~semaphore() { semaphore_destroy(&sem); }
+	void wait() { semaphore_wait(&sem); }
+	void signal() { semaphore_signal(&sem); }
+};
 
 class lock
 {

--- a/src/base/tl/threading.h
+++ b/src/base/tl/threading.h
@@ -69,10 +69,10 @@ class semaphore
 {
 	SEMAPHORE sem;
 public:
-	semaphore() { semaphore_init(&sem); }
-	~semaphore() { semaphore_destroy(&sem); }
-	void wait() { semaphore_wait(&sem); }
-	void signal() { semaphore_signal(&sem); }
+	semaphore() { sphore_init(&sem); }
+	~semaphore() { sphore_destroy(&sem); }
+	void wait() { sphore_wait(&sem); }
+	void signal() { sphore_signal(&sem); }
 };
 
 class lock

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -8,16 +8,6 @@
 #if defined(CONF_PLATFORM_MACOS)
 	#include <objc/objc-runtime.h>
 
-	class semaphore
-	{
-		SDL_sem *sem;
-	public:
-		semaphore() { sem = SDL_CreateSemaphore(0); }
-		~semaphore() { SDL_DestroySemaphore(sem); }
-		void wait() { SDL_SemWait(sem); }
-		void signal() { SDL_SemPost(sem); }
-	};
-
 	class CAutoreleasePool
 	{
 	private:

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -99,14 +99,18 @@ public:
 		// open logfile if needed
 		if(m_pConfig->m_Logfile[0])
 		{
-			char aBuf[32];
+			char aTimestamp[32];
 			if(m_pConfig->m_LogfileTimestamp)
-				str_timestamp(aBuf, sizeof(aBuf));
+				str_timestamp(aTimestamp, sizeof(aTimestamp));
 			else
-				aBuf[0] = 0;
+				aTimestamp[0] = 0;
 			char aLogFilename[128];
-			str_format(aLogFilename, sizeof(aLogFilename), "dumps/%s%s.txt", m_pConfig->m_Logfile, aBuf);
-			dbg_logger_file(aLogFilename);
+			str_format(aLogFilename, sizeof(aLogFilename), "dumps/%s%s.txt", m_pConfig->m_Logfile, aTimestamp);
+			IOHANDLE Handle = m_pStorage->OpenFile(aLogFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+			if(Handle)
+				dbg_logger_file(Handle);
+			else
+				dbg_msg("engine/logfile", "failed to open '%s' for logging", aLogFilename);
 		}
 	}
 

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -104,13 +104,9 @@ public:
 				str_timestamp(aBuf, sizeof(aBuf));
 			else
 				aBuf[0] = 0;
-			char aLogFilename[128];			
+			char aLogFilename[128];
 			str_format(aLogFilename, sizeof(aLogFilename), "dumps/%s%s.txt", m_pConfig->m_Logfile, aBuf);
-			IOHANDLE Handle = m_pStorage->OpenFile(aLogFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
-			if(Handle)
-				dbg_logger_filehandle(Handle);
-			else
-				dbg_msg("engine/logfile", "failed to open '%s' for logging", aLogFilename);
+			dbg_logger_file(aLogFilename);
 		}
 	}
 

--- a/src/test/aio.cpp
+++ b/src/test/aio.cpp
@@ -1,0 +1,146 @@
+#include "test.h"
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+
+static const int BUF_SIZE = 64 * 1024;
+
+class Async : public ::testing::Test
+{
+protected:
+	ASYNCIO *m_pAio;
+	CTestInfo m_Info;
+	bool Delete;
+
+	void SetUp()
+	{
+		IOHANDLE File = io_open(m_Info.m_aFilename, IOFLAG_WRITE);
+		ASSERT_TRUE(File);
+		m_pAio = aio_new(File);
+		Delete = false;
+	}
+
+	~Async()
+	{
+		if(Delete)
+		{
+			fs_remove(m_Info.m_aFilename);
+		}
+	}
+
+	void Write(const char *pText)
+	{
+		aio_write(m_pAio, pText, str_length(pText));
+	}
+
+	void Expect(const char *pOutput)
+	{
+		aio_close(m_pAio);
+		aio_wait(m_pAio);
+		aio_free(m_pAio);
+
+		char aBuf[BUF_SIZE];
+		IOHANDLE File = io_open(m_Info.m_aFilename, IOFLAG_READ);
+		ASSERT_TRUE(File);
+		int Read = io_read(File, aBuf, sizeof(aBuf));
+		io_close(File);
+
+		ASSERT_EQ(str_length(pOutput), Read);
+		ASSERT_TRUE(mem_comp(aBuf, pOutput, Read) == 0);
+		Delete = true;
+	}
+};
+
+TEST_F(Async, Empty)
+{
+	Expect("");
+}
+
+TEST_F(Async, Simple)
+{
+	static const char TEXT[] = "a\n";
+	Write(TEXT);
+	Expect(TEXT);
+}
+
+TEST_F(Async, Long)
+{
+	char aText[BUF_SIZE + 1];
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		aText[i] = 'a';
+	}
+	aText[sizeof(aText) - 1] = 0;
+	Write(aText);
+	Expect(aText);
+}
+
+TEST_F(Async, Pieces)
+{
+	char aText[BUF_SIZE + 1];
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		aText[i] = 'a';
+	}
+	aText[sizeof(aText) - 1] = 0;
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		Write("a");
+	}
+	Expect(aText);
+}
+
+TEST_F(Async, Mixed)
+{
+	char aText[BUF_SIZE + 1];
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		aText[i] = 'a' + i % 26;
+	}
+	aText[sizeof(aText) - 1] = 0;
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		char w = 'a' + i % 26;
+		aio_write(m_pAio, &w, 1);
+	}
+	Expect(aText);
+}
+
+TEST_F(Async, NonDivisor)
+{
+	static const int NUM_LETTERS = 13;
+	static const int SIZE = BUF_SIZE / NUM_LETTERS * NUM_LETTERS;
+	char aText[SIZE + 1];
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		aText[i] = 'a' + i % NUM_LETTERS;
+	}
+	aText[sizeof(aText) - 1] = 0;
+	for(unsigned i = 0; i < (sizeof(aText) - 1) / NUM_LETTERS; i++)
+	{
+		Write("abcdefghijklm");
+	}
+	Expect(aText);
+}
+
+TEST_F(Async, Transaction)
+{
+	static const int NUM_LETTERS = 13;
+	static const int SIZE = BUF_SIZE / NUM_LETTERS * NUM_LETTERS;
+	char aText[SIZE + 1];
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		aText[i] = 'a' + i % NUM_LETTERS;
+	}
+	aText[sizeof(aText) - 1] = 0;
+	for(unsigned i = 0; i < (sizeof(aText) - 1) / NUM_LETTERS; i++)
+	{
+		aio_lock(m_pAio);
+		for(char c = 'a'; c < 'a' + NUM_LETTERS; c++)
+		{
+			aio_write_unlocked(m_pAio, &c, 1);
+		}
+		aio_unlock(m_pAio);
+	}
+	Expect(aText);
+}

--- a/src/test/thread.cpp
+++ b/src/test/thread.cpp
@@ -61,7 +61,7 @@ struct SemTestStruct
 static void SemThread(void *pUser)
 {
 	struct SemTestStruct *pContext = (struct SemTestStruct *)pUser;
-	semaphore_wait(&pContext->sem);
+	sphore_wait(&pContext->sem);
 	lock_wait(pContext->k_lock);
 	pContext->k--;
 	lock_unlock(pContext->k_lock);
@@ -70,7 +70,7 @@ static void SemThread(void *pUser)
 TEST(Thread, Semaphore)
 {
 	struct SemTestStruct Context;
-	semaphore_init(&Context.sem);
+	sphore_init(&Context.sem);
 	Context.k_lock = lock_create();
 	Context.k = 5;
 
@@ -79,7 +79,7 @@ TEST(Thread, Semaphore)
 		apThreads[i] = thread_init(SemThread, &Context);
 
 	for(int i = 0; i < 3; i++)
-		semaphore_signal(&Context.sem);
+		sphore_signal(&Context.sem);
 
 	for(int i = 0; i < 3; i++)
 		thread_wait(apThreads[i]);
@@ -87,5 +87,5 @@ TEST(Thread, Semaphore)
 	EXPECT_EQ(Context.k, 2);
 
 	lock_destroy(Context.k_lock);
-	semaphore_destroy(&Context.sem);
+	sphore_destroy(&Context.sem);
 }

--- a/src/test/thread.cpp
+++ b/src/test/thread.cpp
@@ -50,3 +50,42 @@ TEST(Thread, Lock)
 	thread_wait(pThread);
 	thread_destroy(pThread);
 }
+
+struct SemTestStruct
+{
+	SEMAPHORE sem;
+	LOCK k_lock;
+	int k;
+};
+
+static void SemThread(void *pUser)
+{
+	struct SemTestStruct *pContext = (struct SemTestStruct *)pUser;
+	semaphore_wait(&pContext->sem);
+	lock_wait(pContext->k_lock);
+	pContext->k--;
+	lock_unlock(pContext->k_lock);
+}
+
+TEST(Thread, Semaphore)
+{
+	struct SemTestStruct Context;
+	semaphore_init(&Context.sem);
+	Context.k_lock = lock_create();
+	Context.k = 5;
+
+	void *apThreads[3];
+	for(int i = 0; i < 3; i++)
+		apThreads[i] = thread_init(SemThread, &Context);
+
+	for(int i = 0; i < 3; i++)
+		semaphore_signal(&Context.sem);
+
+	for(int i = 0; i < 3; i++)
+		thread_wait(apThreads[i]);
+
+	EXPECT_EQ(Context.k, 2);
+
+	lock_destroy(Context.k_lock);
+	semaphore_destroy(&Context.sem);
+}


### PR DESCRIPTION
Rebased and fixed #2533 by @Learath2 and @heinrich5991.

This also readds the storage lookup for the logfile, which was accidentally removed, hence the logfile name was being interpreted as an absolute path instead.

Closes #200.