### PR TITLE
Extract dbg_console_hide to hide console window (on windows):

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -281,6 +281,11 @@ void dbg_console_cleanup()
 {
 	SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), old_console_mode);
 }
+
+void dbg_console_hide()
+{
+	FreeConsole();
+}
 #endif
 /* */
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1598,6 +1598,7 @@ void dbg_logger_filehandle(IOHANDLE handle);
 #if defined(CONF_FAMILY_WINDOWS)
 void dbg_console_init();
 void dbg_console_cleanup();
+void dbg_console_hide();
 #endif
 
 typedef struct

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -44,11 +44,6 @@
 #include "serverbrowser.h"
 #include "client.h"
 
-#if defined(CONF_FAMILY_WINDOWS)
-	#define WIN32_LEAN_AND_MEAN
-	#include <windows.h>
-#endif
-
 #include "SDL.h"
 #ifdef main
 #undef main
@@ -2692,7 +2687,7 @@ int main(int argc, const char **argv) // ignore_convention
 	#endif
 	{
 		HideConsole = true;
-		FreeConsole();
+		dbg_console_hide();
 	}
 	else if(!QuickEditMode)
 		dbg_console_init();

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -30,11 +30,6 @@
 #include "register.h"
 #include "server.h"
 
-#if defined(CONF_FAMILY_WINDOWS)
-	#define WIN32_LEAN_AND_MEAN
-	#include <windows.h>
-#endif
-
 #include <signal.h>
 
 volatile sig_atomic_t InterruptSignaled = 0;
@@ -1850,7 +1845,7 @@ int main(int argc, const char **argv) // ignore_convention
 	{
 		if(str_comp("-s", argv[i]) == 0 || str_comp("--silent", argv[i]) == 0) // ignore_convention
 		{
-			ShowWindow(GetConsoleWindow(), SW_HIDE);
+			dbg_console_hide();
 			break;
 		}
 	}


### PR DESCRIPTION
The function combines the methods that were used in server and client.
Using `FreeConsole` in the client only hides the console that opens when the game is opened by clicking the executable.
Using `ShowWindow(GetConsoleWindow(), SW_HIDE)` will additionally hide the console window that is used to open teeworlds, if starting teeworlds from the command line.
If you want to open teeworlds without a console, from the console, you can use `start teeworlds`, which will keep the original console window open.

This makes it possible to remove the include of windows.h from server and client.