### PR TITLE
Prevent skins and skin parts with too long names from being loaded

### DIFF
--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -29,8 +29,18 @@ int CSkins::SkinPartScan(const char *pName, int IsDir, int DirType, void *pUser)
 	if(IsDir || !str_endswith(pName, ".png"))
 		return 0;
 
+	int PartNameSize, PartNameCount;
+	str_utf8_stats(pName, str_length(pName) - str_length(".png") + 1, IO_MAX_PATH_LENGTH, &PartNameSize, &PartNameCount);
+	if(PartNameSize >= MAX_SKIN_ARRAY_SIZE || PartNameCount > MAX_SKIN_LENGTH)
+	{
+		char aBuf[IO_MAX_PATH_LENGTH + 64];
+		str_format(aBuf, sizeof(aBuf), "failed to load skin part '%s': name too long", pName);
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "skins", aBuf);
+		return 0;
+	}
+
 	CSkinPart Part;
-	str_utf8_copy_num(Part.m_aName, pName, minimum(str_length(pName) - 3, int(sizeof(Part.m_aName))), MAX_SKIN_LENGTH);
+	str_copy(Part.m_aName, pName, minimum<int>(PartNameSize + 1, sizeof(Part.m_aName)));
 	if(pSelf->FindSkinPart(pSelf->m_ScanningPart, Part.m_aName, true) != -1)
 		return 0;
 

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -111,6 +111,16 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 
 	CSkins *pSelf = (CSkins *)pUser;
 
+	int SkinNameSize, SkinNameCount;
+	str_utf8_stats(pName, str_length(pName) - str_length(".json") + 1, IO_MAX_PATH_LENGTH, &SkinNameSize, &SkinNameCount);
+	if(SkinNameSize >= MAX_SKIN_ARRAY_SIZE || SkinNameCount > MAX_SKIN_LENGTH)
+	{
+		char aBuf[IO_MAX_PATH_LENGTH + 64];
+		str_format(aBuf, sizeof(aBuf), "failed to load skin '%s': name too long", pName);
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "skins", aBuf);
+		return 0;
+	}
+
 	// read file data into buffer
 	char aBuf[IO_MAX_PATH_LENGTH];
 	str_format(aBuf, sizeof(aBuf), "skins/%s", pName);
@@ -124,7 +134,7 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 
 	// init
 	CSkin Skin = pSelf->m_DummySkin;
-	str_utf8_copy_num(Skin.m_aName, pName, minimum(str_length(pName) - 4, int(sizeof(Skin.m_aName))), MAX_SKIN_LENGTH);
+	str_copy(Skin.m_aName, pName, minimum<int>(SkinNameSize + 1, sizeof(Skin.m_aName)));
 	if(pSelf->Find(Skin.m_aName, true) != -1)
 		return 0;
 	bool SpecialSkin = pName[0] == 'x' && pName[1] == '_';


### PR DESCRIPTION
Names of skins and skin parts longer than 96 non-null bytes or 24 characters are currently being truncated. This causes inconsistencies in the usage, for example you cannot delete skins with too long names and multiple skins/parts may end up having the same name prefix.

This is changed so skins and skin parts with too long names are not loaded at all.

Anyone currently using skins or parts with too long names, should rename them manually to fit the maximum length.

I found this out because the UI currently allows saving skins with too long names, which will be fixed in a separate PR.