### PR TITLE
Fix and refactor text input activation in demo rename and skin save popups, properly limit skin name input length

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -54,7 +54,8 @@ CMenus::CMenus()
 	m_NeedRestartSound = false;
 	m_NeedRestartPlayer = false;
 	m_TeePartSelected = SKINPART_BODY;
-	m_aSaveSkinName[0] = 0;
+	m_aSaveSkinName[0] = '\0';
+	m_SkinNameInput.SetBuffer(m_aSaveSkinName, sizeof(m_aSaveSkinName));
 	m_RefreshSkinSelector = true;
 	m_pSelectedSkin = 0;
 	m_MenuActive = true;
@@ -1504,14 +1505,7 @@ void CMenus::RenderMenu(CUIRect Screen)
 			Box.HSplitBottom(Box.h/2.0f, 0, &Box);
 			Box.HSplitTop(20.0f, &EditBox, &Box);
 
-			static CLineInput s_SkinNameInput(m_aSaveSkinName, sizeof(m_aSaveSkinName));
-			if(UI()->GetActiveItem() == m_aSaveSkinName) // initially activate input and select entire name
-			{
-				s_SkinNameInput.SetCursorOffset(s_SkinNameInput.GetLength());
-				s_SkinNameInput.SetSelection(0, s_SkinNameInput.GetLength());
-				UI()->SetActiveItem(&s_SkinNameInput);
-			}
-			UI()->DoEditBoxOption(&s_SkinNameInput, &EditBox, Localize("Name"), ButtonWidth);
+			UI()->DoEditBoxOption(&m_SkinNameInput, &EditBox, Localize("Name"), ButtonWidth);
 
 			// buttons
 			CUIRect Yes, No;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -73,6 +73,8 @@ CMenus::CMenus()
 	m_LastInput = time_get();
 
 	str_copy(m_aCurrentDemoFolder, "demos", sizeof(m_aCurrentDemoFolder));
+	m_aCurrentDemoFile[0] = '\0';
+	m_DemoNameInput.SetBuffer(m_aCurrentDemoFile, sizeof(m_aCurrentDemoFile));
 	m_aCallvoteReason[0] = 0;
 	m_aFilterString[0] = 0;
 
@@ -1454,14 +1456,7 @@ void CMenus::RenderMenu(CUIRect Screen)
 			Box.HSplitBottom(Box.h/2.0f, 0, &Box);
 			Box.HSplitTop(20.0f, &EditBox, &Box);
 
-			static CLineInput s_DemoNameInput(m_aCurrentDemoFile, sizeof(m_aCurrentDemoFile));
-			if(UI()->GetActiveItem() == m_aCurrentDemoFile) // initially activate input and select entire name
-			{
-				s_DemoNameInput.SetCursorOffset(s_DemoNameInput.GetLength());
-				s_DemoNameInput.SetSelection(0, s_DemoNameInput.GetLength());
-				UI()->SetActiveItem(&s_DemoNameInput);
-			}
-			UI()->DoEditBoxOption(&s_DemoNameInput, &EditBox, Localize("Name"), ButtonWidth);
+			UI()->DoEditBoxOption(&m_DemoNameInput, &EditBox, Localize("Name"), ButtonWidth);
 
 			// buttons
 			CUIRect Yes, No;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -55,7 +55,7 @@ CMenus::CMenus()
 	m_NeedRestartPlayer = false;
 	m_TeePartSelected = SKINPART_BODY;
 	m_aSaveSkinName[0] = '\0';
-	m_SkinNameInput.SetBuffer(m_aSaveSkinName, sizeof(m_aSaveSkinName));
+	m_SkinNameInput.SetBuffer(m_aSaveSkinName, sizeof(m_aSaveSkinName), MAX_SKIN_LENGTH);
 	m_RefreshSkinSelector = true;
 	m_pSelectedSkin = 0;
 	m_MenuActive = true;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -250,6 +250,7 @@ private:
 	bool m_NeedRestartSound;
 	int m_TeePartSelected;
 	char m_aSaveSkinName[MAX_SKIN_ARRAY_SIZE];
+	CLineInput m_SkinNameInput;
 
 	bool m_RefreshSkinSelector;
 	const CSkins::CSkin *m_pSelectedSkin;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -356,6 +356,7 @@ private:
 	sorted_array<CDemoItem> m_lDemos;
 	char m_aCurrentDemoFolder[IO_MAX_PATH_LENGTH];
 	char m_aCurrentDemoFile[IO_MAX_PATH_LENGTH];
+	CLineInput m_DemoNameInput;
 	int m_DemolistSelectedIndex;
 	bool m_DemolistSelectedIsDir;
 	int m_DemolistStorageType;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -654,9 +654,13 @@ void CMenus::RenderDemoList(CUIRect MainView)
 			if(m_DemolistSelectedIndex >= 0)
 			{
 				m_Popup = POPUP_RENAME_DEMO;
-				str_copy(m_aCurrentDemoFile, m_lDemos[m_DemolistSelectedIndex].m_aFilename,
-					minimum<int>(str_length(m_lDemos[m_DemolistSelectedIndex].m_aFilename) - str_length(".demo") + 1, sizeof(m_aCurrentDemoFile)));
-				UI()->SetActiveItem(m_aCurrentDemoFile); // marker to initially activate the input and select the text
+				char aFilename[IO_MAX_PATH_LENGTH];
+				str_copy(aFilename, m_lDemos[m_DemolistSelectedIndex].m_aFilename,
+					minimum<int>(str_length(m_lDemos[m_DemolistSelectedIndex].m_aFilename) - str_length(".demo") + 1, sizeof(aFilename)));
+				m_DemoNameInput.Set(aFilename);
+				m_DemoNameInput.SetCursorOffset(m_DemoNameInput.GetLength());
+				m_DemoNameInput.SetSelection(0, m_DemoNameInput.GetLength());
+				UI()->SetActiveItem(&m_DemoNameInput);
 				return;
 			}
 		}

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1337,7 +1337,9 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 		static CButtonContainer s_CustomSkinSaveButton;
 		if(DoButton_Menu(&s_CustomSkinSaveButton, Localize("Save"), 0, &Button))
 		{
-			UI()->SetActiveItem(m_aSaveSkinName); // marker to initially activate the input and select the text
+			m_SkinNameInput.SetCursorOffset(m_SkinNameInput.GetLength());
+			m_SkinNameInput.SetSelection(0, m_SkinNameInput.GetLength());
+			UI()->SetActiveItem(&m_SkinNameInput);
 			m_Popup = POPUP_SAVE_SKIN;
 		}
 		BottomView.VSplitLeft(SpacingW, 0, &BottomView);
@@ -1373,9 +1375,12 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 		if(s_CustomSkinMenu && m_pSelectedSkin)
 		{
 			if(m_pSelectedSkin->m_Flags&CSkins::SKINFLAG_STANDARD)
-				str_format(m_aSaveSkinName, sizeof(m_aSaveSkinName), "copy_%s", m_pSelectedSkin->m_aName);
+			{
+				m_SkinNameInput.Set("copy_");
+				m_SkinNameInput.Append(m_pSelectedSkin->m_aName);
+			}
 			else
-				str_copy(m_aSaveSkinName, m_pSelectedSkin->m_aName, sizeof(m_aSaveSkinName));
+				m_SkinNameInput.Set(m_pSelectedSkin->m_aName);
 		}
 	}
 


### PR DESCRIPTION
Cleanup the hacky input activation in the popups. Fixes that the selection was not being set to the full length when using the popup repeatedly, as the internal length field was not being updated.

Also limit the skin name input by the maximum number of unicode characters. It was previously possible to save skins with longer names, which causes issues. See #3103.