### PR TITLE
Clear IME when using left mouse button in UI editboxes

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -471,7 +471,16 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 
 	if(CheckActiveItem(pLineInput))
 	{
-		if(!MouseButton(0))
+		if(MouseButton(0))
+		{
+			if(pLineInput->IsActive() && (Input()->HasComposition() || Input()->GetCandidateCount()))
+			{
+				// Clear IME composition/candidates on mouse press
+				Input()->StopTextInput();
+				Input()->StartTextInput();
+			}
+		}
+		else
 		{
 			s_DoScroll = false;
 			s_SelectionStartOffset = -1;


### PR DESCRIPTION
Clear the active IME composition and candidates when the left mouse button is pressed while a UI editbox is active.
Using the mouse to change the cursor position while a composition is active is not intended and can currently cause text to be overridden by the composition.

In other programs on Windows, the mouse can be used to select the candidates. Clicking outside the candidate window will clear the IME or confirm the current composition, depending on the program being used. I chose the former alternative for Teeworlds, as this is easier to implement.