### PR TITLE
Add more checks for packers/unpackers, add tests, refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1736,6 +1736,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     hash.cpp
     io.cpp
     jsonwriter.cpp
+    packer.cpp
     sorted_array.cpp
     storage.cpp
     str.cpp

--- a/src/engine/message.h
+++ b/src/engine/message.h
@@ -8,11 +8,42 @@
 class CMsgPacker : public CPacker
 {
 public:
-	CMsgPacker(int Type, bool System=false)
+	CMsgPacker(int Type, bool System = false)
 	{
 		Reset();
-		AddInt((Type<<1)|(System?1:0));
+		if(Type < 0 || Type > 0x3FFFFFFF)
+		{
+			m_Error = true;
+			return;
+		}
+		AddInt((Type << 1) | (System ? 1 : 0));
 	}
+};
+
+class CMsgUnpacker : public CUnpacker
+{
+	int m_Type;
+	bool m_System;
+
+public:
+	CMsgUnpacker(const void *pData, int Size)
+	{
+		Reset(pData, Size);
+		const int Msg = GetInt();
+		if(Msg < 0)
+			m_Error = true;
+		if(m_Error)
+		{
+			m_System = false;
+			m_Type = 0;
+			return;
+		}
+		m_System = Msg & 1;
+		m_Type = Msg >> 1;
+	}
+
+	int Type() const { return m_Type; }
+	bool System() const { return m_System; }
 };
 
 #endif

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -812,22 +812,15 @@ void CServer::UpdateClientMapListEntries()
 
 void CServer::ProcessClientPacket(CNetChunk *pPacket)
 {
-	int ClientID = pPacket->m_ClientID;
-	CUnpacker Unpacker;
-	Unpacker.Reset(pPacket->m_pData, pPacket->m_DataSize);
-
-	// unpack msgid and system flag
-	int Msg = Unpacker.GetInt();
-	int Sys = Msg&1;
-	Msg >>= 1;
-
+	CMsgUnpacker Unpacker(pPacket->m_pData, pPacket->m_DataSize);
 	if(Unpacker.Error())
 		return;
 
-	if(Sys)
+	const int ClientID = pPacket->m_ClientID;
+	if(Unpacker.System())
 	{
 		// system message
-		if(Msg == NETMSG_INFO)
+		if(Unpacker.Type() == NETMSG_INFO)
 		{
 			if((pPacket->m_Flags&NET_CHUNKFLAG_VITAL) != 0 && m_aClients[ClientID].m_State == CClient::STATE_AUTH)
 			{
@@ -855,7 +848,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				SendMap(ClientID);
 			}
 		}
-		else if(Msg == NETMSG_REQUEST_MAP_DATA)
+		else if(Unpacker.Type() == NETMSG_REQUEST_MAP_DATA)
 		{
 			if((pPacket->m_Flags&NET_CHUNKFLAG_VITAL) != 0 && (m_aClients[ClientID].m_State == CClient::STATE_CONNECTING || m_aClients[ClientID].m_State == CClient::STATE_CONNECTING_AS_SPEC))
 			{
@@ -889,7 +882,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				}
 			}
 		}
-		else if(Msg == NETMSG_READY)
+		else if(Unpacker.Type() == NETMSG_READY)
 		{
 			if((pPacket->m_Flags&NET_CHUNKFLAG_VITAL) != 0 && (m_aClients[ClientID].m_State == CClient::STATE_CONNECTING || m_aClients[ClientID].m_State == CClient::STATE_CONNECTING_AS_SPEC))
 			{
@@ -906,7 +899,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				SendConnectionReady(ClientID);
 			}
 		}
-		else if(Msg == NETMSG_ENTERGAME)
+		else if(Unpacker.Type() == NETMSG_ENTERGAME)
 		{
 			if((pPacket->m_Flags&NET_CHUNKFLAG_VITAL) != 0 && m_aClients[ClientID].m_State == CClient::STATE_READY && GameServer()->IsClientReady(ClientID))
 			{
@@ -921,7 +914,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				GameServer()->OnClientEnter(ClientID);
 			}
 		}
-		else if(Msg == NETMSG_INPUT)
+		else if(Unpacker.Type() == NETMSG_INPUT)
 		{
 			CClient::CInput *pInput;
 			int64 TagTime;
@@ -978,7 +971,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 			if(m_aClients[ClientID].m_State == CClient::STATE_INGAME)
 				GameServer()->OnClientDirectInput(ClientID, m_aClients[ClientID].m_LatestInput.m_aData);
 		}
-		else if(Msg == NETMSG_RCON_CMD)
+		else if(Unpacker.Type() == NETMSG_RCON_CMD)
 		{
 			const char *pCmd = Unpacker.GetString();
 
@@ -996,7 +989,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				m_RconAuthLevel = AUTHED_ADMIN;
 			}
 		}
-		else if(Msg == NETMSG_RCON_AUTH)
+		else if(Unpacker.Type() == NETMSG_RCON_AUTH)
 		{
 			const char *pPw = Unpacker.GetString(CUnpacker::SANITIZE_CC);
 
@@ -1063,7 +1056,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				}
 			}
 		}
-		else if(Msg == NETMSG_PING)
+		else if(Unpacker.Type() == NETMSG_PING)
 		{
 			CMsgPacker Msg(NETMSG_PING_REPLY, true);
 			SendMsg(&Msg, 0, ClientID);
@@ -1073,7 +1066,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 			if(Config()->m_Debug)
 			{
 				char aBuf[256];
-				str_format(aBuf, sizeof(aBuf), "strange message ClientID=%d msg=%d data_size=%d", ClientID, Msg, pPacket->m_DataSize);
+				str_format(aBuf, sizeof(aBuf), "strange message ClientID=%d msg=%d data_size=%d", ClientID, Unpacker.Type(), pPacket->m_DataSize);
 				Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "server", aBuf);
 				str_hex(aBuf, sizeof(aBuf), pPacket->m_pData, minimum(pPacket->m_DataSize, 32));
 				Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "server", aBuf);
@@ -1084,7 +1077,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 	{
 		// game message
 		if((pPacket->m_Flags&NET_CHUNKFLAG_VITAL) != 0 && m_aClients[ClientID].m_State >= CClient::STATE_READY)
-			GameServer()->OnMessage(Msg, &Unpacker, ClientID);
+			GameServer()->OnMessage(Unpacker.Type(), &Unpacker, ClientID);
 	}
 }
 

--- a/src/engine/shared/compression.cpp
+++ b/src/engine/shared/compression.cpp
@@ -5,8 +5,12 @@
 #include "compression.h"
 
 // Format: ESDDDDDD EDDDDDDD EDD... Extended, Data, Sign
-unsigned char *CVariableInt::Pack(unsigned char *pDst, int i)
+unsigned char *CVariableInt::Pack(unsigned char *pDst, int i, int DstSize)
 {
+	if(DstSize <= 0)
+		return 0;
+
+	DstSize--;
 	*pDst = 0;
 	if(i < 0)
 	{
@@ -18,7 +22,10 @@ unsigned char *CVariableInt::Pack(unsigned char *pDst, int i)
 	i >>= 6; // discard 6 bits
 	while(i)
 	{
+		if(DstSize <= 0)
+			return 0;
 		*pDst |= 0x80; // set extend bit
+		DstSize--;
 		pDst++;
 		*pDst = i & 0x7F; // pack 7bit
 		i >>= 7; // discard 7 bits
@@ -28,33 +35,28 @@ unsigned char *CVariableInt::Pack(unsigned char *pDst, int i)
 	return pDst;
 }
 
-const unsigned char *CVariableInt::Unpack(const unsigned char *pSrc, int *pInOut)
+const unsigned char *CVariableInt::Unpack(const unsigned char *pSrc, int *pInOut, int SrcSize)
 {
+	if(SrcSize <= 0)
+		return 0;
+
 	const int Sign = (*pSrc >> 6) & 1;
 	*pInOut = *pSrc & 0x3F;
+	SrcSize--;
 
-	do
+	const static int s_aMasks[] = {0x7F, 0x7F, 0x7F, 0x0F};
+	const static int s_aShifts[] = {6, 6 + 7, 6 + 7 + 7, 6 + 7 + 7 + 7};
+
+	for(unsigned i = 0; i < sizeof(s_aMasks) / sizeof(int); i++)
 	{
 		if(!(*pSrc & 0x80))
 			break;
+		if(SrcSize <= 0)
+			return 0;
+		SrcSize--;
 		pSrc++;
-		*pInOut |= (*pSrc & 0x7F) << 6;
-
-		if(!(*pSrc & 0x80))
-			break;
-		pSrc++;
-		*pInOut |= (*pSrc & 0x7F) << (6 + 7);
-
-		if(!(*pSrc & 0x80))
-			break;
-		pSrc++;
-		*pInOut |= (*pSrc & 0x7F) << (6 + 7 + 7);
-
-		if(!(*pSrc & 0x80))
-			break;
-		pSrc++;
-		*pInOut |= (*pSrc & 0x0F) << (6 + 7 + 7 + 7);
-	} while(false);
+		*pInOut |= (*pSrc & s_aMasks[i]) << s_aShifts[i];
+	}
 
 	pSrc++;
 	*pInOut ^= -Sign; // if(sign) *i = ~(*i)
@@ -66,14 +68,16 @@ long CVariableInt::Decompress(const void *pSrc_, int SrcSize, void *pDst_, int D
 	dbg_assert(DstSize % sizeof(int) == 0, "invalid bounds");
 
 	const unsigned char *pSrc = (unsigned char *)pSrc_;
-	const unsigned char *pEnd = pSrc + SrcSize;
+	const unsigned char *pSrcEnd = pSrc + SrcSize;
 	int *pDst = (int *)pDst_;
 	const int *pDstEnd = pDst + DstSize / sizeof(int);
-	while(pSrc < pEnd)
+	while(pSrc < pSrcEnd)
 	{
 		if(pDst >= pDstEnd)
 			return -1;
-		pSrc = CVariableInt::Unpack(pSrc, pDst);
+		pSrc = CVariableInt::Unpack(pSrc, pDst, pSrcEnd - pSrc);
+		if(!pSrc)
+			return -1;
 		pDst++;
 	}
 	return (long)((unsigned char *)pDst - (unsigned char *)pDst_);
@@ -89,9 +93,9 @@ long CVariableInt::Compress(const void *pSrc_, int SrcSize, void *pDst_, int Dst
 	SrcSize /= sizeof(int);
 	while(SrcSize)
 	{
-		if(pDstEnd - pDst <= MAX_BYTES_PACKED)
+		pDst = CVariableInt::Pack(pDst, *pSrc, pDstEnd - pDst);
+		if(!pDst)
 			return -1;
-		pDst = CVariableInt::Pack(pDst, *pSrc);
 		SrcSize--;
 		pSrc++;
 	}

--- a/src/engine/shared/compression.h
+++ b/src/engine/shared/compression.h
@@ -12,8 +12,8 @@ public:
 		MAX_BYTES_PACKED = 5, // maximum number of bytes in a packed int
 	};
 
-	static unsigned char *Pack(unsigned char *pDst, int i);
-	static const unsigned char *Unpack(const unsigned char *pSrc, int *pInOut);
+	static unsigned char *Pack(unsigned char *pDst, int i, int DstSize);
+	static const unsigned char *Unpack(const unsigned char *pSrc, int *pInOut, int SrcSize);
 
 	static long Compress(const void *pSrc, int SrcSize, void *pDst, int DstSize);
 	static long Decompress(const void *pSrc, int SrcSize, void *pDst, int DstSize);

--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -18,14 +18,13 @@ void CPacker::AddInt(int i)
 	if(m_Error)
 		return;
 
-	// make sure that we have space enough
-	if(m_pEnd - m_pCurrent <= CVariableInt::MAX_BYTES_PACKED)
+	unsigned char *pNext = CVariableInt::Pack(m_pCurrent, i, m_pEnd - m_pCurrent);
+	if(!pNext)
 	{
-		dbg_break();
 		m_Error = 1;
+		return;
 	}
-	else
-		m_pCurrent = CVariableInt::Pack(m_pCurrent, i);
+	m_pCurrent = pNext;
 }
 
 void CPacker::AddString(const char *pStr, int Limit)
@@ -103,12 +102,13 @@ int CUnpacker::GetInt()
 	}
 
 	int i;
-	m_pCurrent = CVariableInt::Unpack(m_pCurrent, &i);
-	if(m_pCurrent > m_pEnd)
+	const unsigned char *pNext = CVariableInt::Unpack(m_pCurrent, &i, m_pEnd - m_pCurrent);
+	if(!pNext)
 	{
 		m_Error = 1;
 		return 0;
 	}
+	m_pCurrent = pNext;
 	return i;
 }
 

--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -2,26 +2,25 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <base/system.h>
 
-#include "packer.h"
 #include "compression.h"
-#include "config.h"
+#include "packer.h"
 
 void CPacker::Reset()
 {
-	m_Error = 0;
+	m_Error = false;
 	m_pCurrent = m_aBuffer;
 	m_pEnd = m_pCurrent + PACKER_BUFFER_SIZE;
 }
 
-void CPacker::AddInt(int i)
+void CPacker::AddInt(int Integer)
 {
 	if(m_Error)
 		return;
 
-	unsigned char *pNext = CVariableInt::Pack(m_pCurrent, i, m_pEnd - m_pCurrent);
+	unsigned char *pNext = CVariableInt::Pack(m_pCurrent, Integer, RemainingSize());
 	if(!pNext)
 	{
-		m_Error = 1;
+		m_Error = true;
 		return;
 	}
 	m_pCurrent = pNext;
@@ -33,29 +32,26 @@ void CPacker::AddString(const char *pStr, int Limit)
 		return;
 
 	if(Limit <= 0)
-	{
 		Limit = PACKER_BUFFER_SIZE;
-	}
+
 	while(*pStr && Limit != 0)
 	{
 		int Codepoint = str_utf8_decode(&pStr);
 		if(Codepoint == -1)
-		{
 			Codepoint = 0xfffd; // Unicode replacement character.
-		}
-		char aGarbage[4];
-		int Length = str_utf8_encode(aGarbage, Codepoint);
+
+		char aEncoded[4];
+		const int Length = str_utf8_encode(aEncoded, Codepoint);
 		if(Limit < Length)
-		{
 			break;
-		}
+
 		// Ensure space for the null termination.
-		if(m_pEnd - m_pCurrent < Length + 1)
+		if(RemainingSize() < Length + 1)
 		{
-			m_Error = 1;
+			m_Error = true;
 			break;
 		}
-		Length = str_utf8_encode((char *)m_pCurrent, Codepoint);
+		mem_copy(m_pCurrent, aEncoded, Length);
 		m_pCurrent += Length;
 		Limit -= Length;
 	}
@@ -67,24 +63,20 @@ void CPacker::AddRaw(const void *pData, int Size)
 	if(m_Error)
 		return;
 
-	if(m_pCurrent+Size >= m_pEnd)
+	if(Size <= 0 || Size >= RemainingSize())
 	{
-		m_Error = 1;
+		m_Error = true;
 		return;
 	}
 
-	const unsigned char *pSrc = (const unsigned char *)pData;
-	while(Size)
-	{
-		*m_pCurrent++ = *pSrc++;
-		Size--;
-	}
+	mem_copy(m_pCurrent, pData, Size);
+	m_pCurrent += Size;
 }
 
 
 void CUnpacker::Reset(const void *pData, int Size)
 {
-	m_Error = 0;
+	m_Error = false;
 	m_pStart = (const unsigned char *)pData;
 	m_pEnd = m_pStart + Size;
 	m_pCurrent = m_pStart;
@@ -95,75 +87,84 @@ int CUnpacker::GetInt()
 	if(m_Error)
 		return 0;
 
-	if(m_pCurrent >= m_pEnd)
+	if(RemainingSize() <= 0)
 	{
-		m_Error = 1;
+		m_Error = true;
 		return 0;
 	}
 
-	int i;
-	const unsigned char *pNext = CVariableInt::Unpack(m_pCurrent, &i, m_pEnd - m_pCurrent);
+	int Integer;
+	const unsigned char *pNext = CVariableInt::Unpack(m_pCurrent, &Integer, RemainingSize());
 	if(!pNext)
 	{
-		m_Error = 1;
+		m_Error = true;
 		return 0;
 	}
 	m_pCurrent = pNext;
-	return i;
+	return Integer;
 }
 
 int CUnpacker::GetIntOrDefault(int Default)
 {
 	if(m_Error)
-	{
 		return 0;
-	}
-	if(m_pCurrent == m_pEnd)
-	{
+
+	if(RemainingSize() == 0)
 		return Default;
-	}
+
 	return GetInt();
 }
 
 const char *CUnpacker::GetString(int SanitizeType)
 {
-	if(m_Error || m_pCurrent >= m_pEnd)
+	if(m_Error)
 		return "";
 
-	char *pPtr = (char *)m_pCurrent;
-	while(*m_pCurrent) // skip the string
+	if(RemainingSize() <= 0)
+	{
+		m_Error = true;
+		return "";
+	}
+
+	// Ensure string is null terminated.
+	char *pStr = (char *)m_pCurrent;
+	while(*m_pCurrent)
 	{
 		m_pCurrent++;
 		if(m_pCurrent == m_pEnd)
 		{
-			m_Error = 1;;
+			m_Error = true;
 			return "";
 		}
 	}
 	m_pCurrent++;
 
 	// sanitize all strings
-	if(SanitizeType&SANITIZE)
-		str_sanitize(pPtr);
-	else if(SanitizeType&SANITIZE_CC)
-		str_sanitize_cc(pPtr);
-	return SanitizeType&SKIP_START_WHITESPACES ? str_utf8_skip_whitespaces(pPtr) : pPtr;
+	if(SanitizeType & SANITIZE)
+		str_sanitize(pStr);
+	else if(SanitizeType & SANITIZE_CC)
+		str_sanitize_cc(pStr);
+
+	if(SanitizeType & SKIP_START_WHITESPACES)
+		return str_utf8_skip_whitespaces(pStr);
+
+	return pStr;
 }
 
 const unsigned char *CUnpacker::GetRaw(int Size)
 {
-	const unsigned char *pPtr = m_pCurrent;
 	if(m_Error)
 		return 0;
 
 	// check for nasty sizes
-	if(Size < 0 || m_pCurrent+Size > m_pEnd)
+	if(Size <= 0 || Size > RemainingSize())
 	{
-		m_Error = 1;
+		m_Error = true;
 		return 0;
 	}
 
 	// "unpack" the data
+	const unsigned char *pPtr = m_pCurrent;
 	m_pCurrent += Size;
 	return pPtr;
 }

--- a/src/engine/shared/packer.h
+++ b/src/engine/shared/packer.h
@@ -7,11 +7,12 @@
 
 class CPacker
 {
+public:
 	enum
 	{
 		PACKER_BUFFER_SIZE=1024*2
 	};
-
+private:
 	unsigned char m_aBuffer[PACKER_BUFFER_SIZE];
 	unsigned char *m_pCurrent;
 	unsigned char *m_pEnd;

--- a/src/engine/shared/packer.h
+++ b/src/engine/shared/packer.h
@@ -3,27 +3,30 @@
 #ifndef ENGINE_SHARED_PACKER_H
 #define ENGINE_SHARED_PACKER_H
 
-
-
 class CPacker
 {
 public:
 	enum
 	{
-		PACKER_BUFFER_SIZE=1024*2
+		PACKER_BUFFER_SIZE = 1024 * 2
 	};
+
 private:
 	unsigned char m_aBuffer[PACKER_BUFFER_SIZE];
 	unsigned char *m_pCurrent;
 	unsigned char *m_pEnd;
-	int m_Error;
+
+protected:
+	bool m_Error;
+
 public:
 	void Reset();
-	void AddInt(int i);
-	void AddString(const char *pStr, int Limit);
+	void AddInt(int Integer);
+	void AddString(const char *pStr, int Limit = 0);
 	void AddRaw(const void *pData, int Size);
 
-	int Size() const { return (int)(m_pCurrent-m_aBuffer); }
+	int Size() const { return (int)(m_pCurrent - m_aBuffer); }
+	int RemainingSize() const { return (int)(m_pEnd - m_pCurrent); }
 	const unsigned char *Data() const { return m_aBuffer; }
 	bool Error() const { return m_Error; }
 };
@@ -33,13 +36,16 @@ class CUnpacker
 	const unsigned char *m_pStart;
 	const unsigned char *m_pCurrent;
 	const unsigned char *m_pEnd;
-	int m_Error;
+
+protected:
+	bool m_Error;
+
 public:
 	enum
 	{
-		SANITIZE=1,
-		SANITIZE_CC=2,
-		SKIP_START_WHITESPACES=4
+		SANITIZE = 1,
+		SANITIZE_CC = 2,
+		SKIP_START_WHITESPACES = 4
 	};
 
 	void Reset(const void *pData, int Size);
@@ -47,6 +53,11 @@ public:
 	int GetIntOrDefault(int Default);
 	const char *GetString(int SanitizeType = SANITIZE);
 	const unsigned char *GetRaw(int Size);
+
+	int Size() const { return m_pCurrent - m_pStart; }
+	int RemainingSize() const { return m_pEnd - m_pCurrent; }
+	int CompleteSize() const { return m_pEnd - m_pStart; }
+	const unsigned char *Data() const { return m_pStart; }
 	bool Error() const { return m_Error; }
 };
 

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -153,7 +153,7 @@ static void UndiffItem(const int *pPast, const int *pDiff, int *pOut, int Size, 
 		else
 		{
 			unsigned char aBuf[CVariableInt::MAX_BYTES_PACKED];
-			unsigned char *pEnd = CVariableInt::Pack(aBuf, *pDiff);
+			unsigned char *pEnd = CVariableInt::Pack(aBuf, *pDiff, sizeof(aBuf));
 			*pDataRate += (int)(pEnd - (unsigned char*)aBuf) * 8;
 		}
 

--- a/src/test/compression.cpp
+++ b/src/test/compression.cpp
@@ -12,8 +12,8 @@ TEST(CVariableInt, RoundtripPackUnpack)
 	{
 		unsigned char aPacked[CVariableInt::MAX_BYTES_PACKED];
 		int Result;
-		EXPECT_EQ(int(CVariableInt::Pack(aPacked, DATA[i]) - aPacked), SIZES[i]);
-		EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result) - aPacked), SIZES[i]);
+		EXPECT_EQ(int(CVariableInt::Pack(aPacked, DATA[i], sizeof(aPacked)) - aPacked), SIZES[i]);
+		EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result, sizeof(aPacked)) - aPacked), SIZES[i]);
 		EXPECT_EQ(Result, DATA[i]);
 	}
 }
@@ -21,17 +21,33 @@ TEST(CVariableInt, RoundtripPackUnpack)
 TEST(CVariableInt, UnpackInvalid)
 {
 	unsigned char aPacked[CVariableInt::MAX_BYTES_PACKED];
-	for(int i = 0; i < CVariableInt::MAX_BYTES_PACKED; i++)
+	for(unsigned i = 0; i < sizeof(aPacked); i++)
 		aPacked[i] = 0xFF;
 
 	int Result;
-	EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result) - aPacked), int(CVariableInt::MAX_BYTES_PACKED));
+	EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result, sizeof(aPacked)) - aPacked), int(CVariableInt::MAX_BYTES_PACKED));
 	EXPECT_EQ(Result, (-2147483647 - 1));
 
 	aPacked[0] &= ~0x40; // unset sign bit
 
-	EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result) - aPacked), int(CVariableInt::MAX_BYTES_PACKED));
+	EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result, sizeof(aPacked)) - aPacked), int(CVariableInt::MAX_BYTES_PACKED));
 	EXPECT_EQ(Result, 2147483647);
+}
+
+TEST(CVariableInt, PackBufferTooSmall)
+{
+	unsigned char aPacked[CVariableInt::MAX_BYTES_PACKED / 2]; // too small
+	EXPECT_EQ(CVariableInt::Pack(aPacked, 2147483647, sizeof(aPacked)), (const unsigned char *)0x0);
+}
+
+TEST(CVariableInt, UnpackBufferTooSmall)
+{
+	unsigned char aPacked[CVariableInt::MAX_BYTES_PACKED / 2];
+	for(unsigned i = 0; i < sizeof(aPacked); i++)
+		aPacked[i] = 0xFF; // extended bits are set, but buffer ends too early
+
+	int UnusedResult;
+	EXPECT_EQ(CVariableInt::Unpack(aPacked, &UnusedResult, sizeof(aPacked)), (const unsigned char *)0x0);
 }
 
 TEST(CVariableInt, RoundtripCompressDecompress)

--- a/src/test/packer.cpp
+++ b/src/test/packer.cpp
@@ -1,0 +1,64 @@
+#include "test.h"
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+#include <engine/shared/packer.h>
+
+// pExpected is NULL if an error is expected
+static void ExpectAddString5(const char *pString, int Limit, const char *pExpected)
+{
+	static char ZEROS[CPacker::PACKER_BUFFER_SIZE] = {0};
+	static const int OFFSET = CPacker::PACKER_BUFFER_SIZE - 5;
+	CPacker Packer;
+	Packer.Reset();
+	Packer.AddRaw(ZEROS, OFFSET);
+	Packer.AddString(pString, Limit);
+
+	EXPECT_EQ(pExpected == 0, Packer.Error());
+	if(pExpected)
+	{
+		// Include null termination.
+		int ExpectedLength = str_length(pExpected) + 1;
+		EXPECT_EQ(ExpectedLength, Packer.Size() - OFFSET);
+		if(ExpectedLength == Packer.Size() - OFFSET)
+		{
+			EXPECT_STREQ(pExpected, (const char *)Packer.Data() + OFFSET);
+		}
+	}
+}
+
+TEST(Packer, AddString)
+{
+	ExpectAddString5("", 0, "");
+	ExpectAddString5("a", 0, "a");
+	ExpectAddString5("abcd", 0, "abcd");
+	ExpectAddString5("abcde", 0, 0);
+}
+
+TEST(Packer, AddStringLimit)
+{
+	ExpectAddString5("", 1, "");
+	ExpectAddString5("a", 1, "a");
+	ExpectAddString5("aa", 1, "a");
+	ExpectAddString5("ä", 1, "");
+
+	ExpectAddString5("", 10, "");
+	ExpectAddString5("a", 10, "a");
+	ExpectAddString5("abcd", 10, "abcd");
+	ExpectAddString5("abcde", 10, 0);
+
+	ExpectAddString5("äöü", 5, "äö");
+	ExpectAddString5("äöü", 6, 0);
+}
+
+TEST(Packer, AddStringBroken)
+{
+	ExpectAddString5("\x80", 0, "�");
+	ExpectAddString5("\x80\x80", 0, 0);
+	ExpectAddString5("a\x80", 0, "a�");
+	ExpectAddString5("\x80""a", 0, "�a");
+	ExpectAddString5("\x80", 1, "");
+	ExpectAddString5("\x80\x80", 3, "�");
+	ExpectAddString5("\x80\x80", 5, "�");
+	ExpectAddString5("\x80\x80", 6, 0);
+}


### PR DESCRIPTION
- Replace invalid unicode with Unicode replacement character when packing string with `CPacker` to ensure only valid UTF-8 is send over the network.
- Add more size checks to `CVariableInt::Pack` and `::Unpack`. Adjust tests and add tests with too small buffer sizes.
- Add validation to `CMsgPacker`. Add `CMsgUnpacker` with validation to encapsulate the message packing.
- Add tests for `CPacker`, `CUnpacker`, `CMsgPacker` and `CMsgUnpacker`.
- Refactor `CPacker` and `CUnpacker`.
  - Minor change to behavior: `Unpacker.GetRaw(0)` will now put the unpacker in the error-state and return a null pointer, as size 0 would be a pointer that can't be accessed.
- Use `CMsgUnpacker` in server and client. Some refactoring of variable declarations.