### PR TITLE
[0.8] Use correct tuning for ReckoningCore/EvolveCharacter

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -558,6 +558,7 @@ void CGameClient::UpdatePositions()
 void CGameClient::EvolveCharacter(CNetObj_Character *pCharacter, int Tick)
 {
 	CWorldCore TempWorld;
+	TempWorld.m_Tuning = m_Tuning;
 	CCharacterCore TempCore;
 	mem_zero(&TempCore, sizeof(TempCore));
 	TempCore.Init(&TempWorld, Collision());

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -543,6 +543,7 @@ void CCharacter::TickDefered()
 	// advance the dummy
 	{
 		CWorldCore TempWorld;
+		TempWorld.m_Tuning = *GameServer()->Tuning();
 		m_ReckoningCore.Init(&TempWorld, GameServer()->Collision());
 		m_ReckoningCore.Tick(false);
 		m_ReckoningCore.Move();


### PR DESCRIPTION
**This requires a major version bump (0.8)**, as the game would otherwise be broken for old clients on servers with non-default tuning.

See https://github.com/teeworlds/teeworlds/issues/1120#issuecomment-612869798.