### PR TITLE
Delete the tmp file at the end of storage test

### DIFF
--- a/src/test/storage.cpp
+++ b/src/test/storage.cpp
@@ -38,4 +38,6 @@ TEST(Storage, FindFile)
 
 	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), &WrongSha256, 0x3bb935c6, 5));
 	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), &SHA256_ZEROED, 0x3bb935c6, 5));
+
+	EXPECT_TRUE(pStorage->RemoveFile(Info.m_aFilename, IStorage::TYPE_SAVE));
 }


### PR DESCRIPTION
Otherwise `Storage.FindFile-PID.tmp` files keep accumulating in the build folder when running the tests locally.