### PR TITLE
Store localized strings in a CHeap instead of using tl/string.h

### DIFF
--- a/src/engine/shared/memheap.cpp
+++ b/src/engine/shared/memheap.cpp
@@ -85,3 +85,11 @@ void *CHeap::Allocate(unsigned int Size)
 
 	return pMem;
 }
+
+const char *CHeap::StoreString(const char *pSrc)
+{
+	const int Size = str_length(pSrc) + 1;
+	char *pMem = static_cast<char *>(Allocate(Size));
+	str_copy(pMem, pSrc, Size);
+	return pMem;
+}

--- a/src/engine/shared/memheap.h
+++ b/src/engine/shared/memheap.h
@@ -30,5 +30,6 @@ public:
 	~CHeap();
 	void Reset();
 	void *Allocate(unsigned int Size);
+	const char *StoreString(const char *pSrc);
 };
 #endif

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -5,6 +5,7 @@
 
 #include <base/vmath.h>
 #include <base/tl/sorted_array.h>
+#include <base/tl/string.h>
 
 #include <engine/graphics.h>
 #include <engine/demo.h>

--- a/src/game/client/localization.cpp
+++ b/src/game/client/localization.cpp
@@ -44,7 +44,7 @@ void CLocalizationDatabase::AddString(const char *pOrgStr, const char *pNewStr, 
 	CString s;
 	s.m_Hash = str_quickhash(pOrgStr);
 	s.m_ContextHash = str_quickhash(pContext);
-	s.m_Replacement = *pNewStr ? pNewStr : pOrgStr;
+	s.m_pReplacement = m_StringsHeap.StoreString(*pNewStr ? pNewStr : pOrgStr);
 	m_Strings.add(s);
 }
 
@@ -54,6 +54,7 @@ bool CLocalizationDatabase::Load(const char *pFilename, IStorage *pStorage, ICon
 	if(pFilename[0] == 0)
 	{
 		m_Strings.clear();
+		m_StringsHeap.Reset();
 		m_CurrentVersion = 0;
 		return true;
 	}
@@ -72,6 +73,7 @@ bool CLocalizationDatabase::Load(const char *pFilename, IStorage *pStorage, ICon
 	str_format(aBuf, sizeof(aBuf), "loaded '%s'", pFilename);
 	pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "localization", aBuf);
 	m_Strings.clear();
+	m_StringsHeap.Reset();
 
 	// parse json data
 	json_settings JsonSettings;
@@ -129,6 +131,7 @@ const char *CLocalizationDatabase::FindString(unsigned Hash, unsigned ContextHas
 	CString String;
 	String.m_Hash = Hash;
 	String.m_ContextHash = ContextHash;
+	String.m_pReplacement = 0x0;
 	sorted_array<CString>::range r = ::find_binary(m_Strings.all(), String);
 	if(r.empty())
 		return 0;
@@ -139,12 +142,12 @@ const char *CLocalizationDatabase::FindString(unsigned Hash, unsigned ContextHas
 	{
 		const CString &rStr = r.index(i);
 		if(rStr.m_ContextHash == ContextHash)
-			return rStr.m_Replacement;
+			return rStr.m_pReplacement;
 		else if(rStr.m_ContextHash == DefaultHash)
 			DefaultIndex = i;
 	}
 	
-    return r.index(DefaultIndex).m_Replacement;
+    return r.index(DefaultIndex).m_pReplacement;
 }
 
 CLocalizationDatabase g_Localization;

--- a/src/game/client/localization.h
+++ b/src/game/client/localization.h
@@ -2,8 +2,10 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_LOCALIZATION_H
 #define GAME_LOCALIZATION_H
-#include <base/tl/string.h>
+
 #include <base/tl/sorted_array.h>
+
+#include <engine/shared/memheap.h>
 
 class CLocalizationDatabase
 {
@@ -12,9 +14,7 @@ class CLocalizationDatabase
 	public:
 		unsigned m_Hash;
 		unsigned m_ContextHash;
-
-		// TODO: do this as an const char * and put everything on a incremental heap
-		string m_Replacement;
+		const char *m_pReplacement;
 
 		bool operator <(const CString &Other) const { return m_Hash < Other.m_Hash || (m_Hash == Other.m_Hash && m_ContextHash < Other.m_ContextHash); }
 		bool operator <=(const CString &Other) const { return m_Hash < Other.m_Hash || (m_Hash == Other.m_Hash && m_ContextHash <= Other.m_ContextHash); }
@@ -22,6 +22,7 @@ class CLocalizationDatabase
 	};
 
 	sorted_array<CString> m_Strings;
+	CHeap m_StringsHeap;
 	int m_VersionCounter;
 	int m_CurrentVersion;
 


### PR DESCRIPTION
Reduces the total number of memory allocations when loading the localizated strings.