### PR TITLE
Refactor editor file browser dialog using CListBox, fix selection and filter not being synced

### DIFF
--- a/src/game/client/ui_listbox.h
+++ b/src/game/client/ui_listbox.h
@@ -23,7 +23,7 @@ private:
 	int m_ListBoxSelectedIndex;
 	int m_ListBoxNewSelected;
 	int m_ListBoxNewSelOffset;
-	int m_ListBoxUpdateScroll;
+	bool m_ListBoxUpdateScroll;
 	bool m_ListBoxDoneEvents;
 	int m_ListBoxNumItems;
 	int m_ListBoxItemsPerRow;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2684,7 +2684,7 @@ static int EditorListdirCallback(const char *pName, int IsDir, int StorageType, 
 	Item.m_IsDir = IsDir != 0;
 	Item.m_IsLink = false;
 	Item.m_StorageType = StorageType;
-	pEditor->m_FileList.add(Item);
+	pEditor->m_CompleteFileList.add(Item);
 
 	return 0;
 }
@@ -2725,24 +2725,41 @@ void CEditor::RenderFileDialog()
 	// pathbox
 	char aPath[128], aBuf[128];
 	if(m_FilesSelectedIndex != -1)
-		Storage()->GetCompletePath(m_FileList[m_FilesSelectedIndex].m_StorageType, m_pFileDialogPath, aPath, sizeof(aPath));
+		Storage()->GetCompletePath(m_FilteredFileList[m_FilesSelectedIndex]->m_StorageType, m_pFileDialogPath, aPath, sizeof(aPath));
 	else
 		aPath[0] = 0;
 	str_format(aBuf, sizeof(aBuf), "Current path: %s", aPath);
 	UI()->DoLabel(&PathBox, aBuf, 10.0f, TEXTALIGN_LEFT);
 
 	// filebox
+	static CListBox s_ListBox;
+
 	if(m_FileDialogStorageType == IStorage::TYPE_SAVE)
 	{
 		UI()->DoLabel(&FileBoxLabel, "Filename:", 10.0f, TEXTALIGN_LEFT);
-		static CLineInput s_FileNameInput(m_aFileDialogFileName, sizeof(m_aFileDialogFileName));
-		if(DoEditBox(&s_FileNameInput, &FileBox, 10.0f))
+		if(DoEditBox(&m_FileDialogFileNameInput, &FileBox, 10.0f))
 		{
 			// remove '/' and '\'
-			for(int i = 0; m_aFileDialogFileName[i]; ++i)
-				if(m_aFileDialogFileName[i] == '/' || m_aFileDialogFileName[i] == '\\')
-					str_copy(&m_aFileDialogFileName[i], &m_aFileDialogFileName[i+1], (int)(sizeof(m_aFileDialogFileName))-i);
+			char aTempFileName[sizeof(m_aFileDialogFileName)];
+			str_copy(aTempFileName, m_aFileDialogFileName, sizeof(aTempFileName));
+			for(int i = 0; aTempFileName[i]; ++i)
+				if(aTempFileName[i] == '/' || aTempFileName[i] == '\\')
+					str_copy(&aTempFileName[i], &aTempFileName[i+1], (int)(sizeof(aTempFileName))-i);
+			m_FileDialogFileNameInput.Set(aTempFileName);
 			m_FilesSelectedIndex = -1;
+			m_aFilesSelectedName[0] = '\0';
+			// find first valid entry, if it exists
+			for(int i = 0; i < m_FilteredFileList.size(); i++)
+			{
+				if(str_comp_nocase(m_FilteredFileList[i]->m_aName, m_aFileDialogFileName) == 0)
+				{
+					m_FilesSelectedIndex = i;
+					str_copy(m_aFilesSelectedName, m_FilteredFileList[i]->m_aName, sizeof(m_aFilesSelectedName));
+					break;
+				}
+			}
+			if(m_FilesSelectedIndex >= 0)
+				s_ListBox.ScrollToSelected();
 		}
 	}
 	else
@@ -2751,34 +2768,47 @@ void CEditor::RenderFileDialog()
 		UI()->DoLabel(&FileBoxLabel, "Search:", 10.0f, TEXTALIGN_LEFT);
 		if(DoEditBox(&m_FileDialogFilterInput, &FileBox, 10.0f))
 		{
-			// reset scrolling
-			m_FileDialogScrollValue = 0;
-			if(m_FilesSelectedIndex == -1 || (m_FilesSelectedIndex >= 0 && m_aFileDialogFilterString[0] && !str_find_nocase(m_FileList[m_FilesSelectedIndex].m_aName, m_aFileDialogFilterString)))
+			RefreshFilteredFileList();
+			if(m_FilteredFileList.size() == 0)
+			{
+				m_FilesSelectedIndex = -1;
+			}
+			else if(m_FilesSelectedIndex == -1 || (m_aFileDialogFilterString[0] && !str_find_nocase(m_FilteredFileList[m_FilesSelectedIndex]->m_aName, m_aFileDialogFilterString)))
 			{
 				// we need to refresh selection
 				m_FilesSelectedIndex = -1;
-				// find first valid entry, if it exists
-				for(int i = 0; i < m_FileList.size(); i++)
-					if(str_find_nocase(m_FileList[i].m_aName, m_aFileDialogFilterString))
+				for(int i = 0; i < m_FilteredFileList.size(); i++)
+				{
+					if(str_find_nocase(m_FilteredFileList[i]->m_aName, m_aFileDialogFilterString))
 					{
 						m_FilesSelectedIndex = i;
 						break;
 					}
+				}
+				if(m_FilesSelectedIndex == -1)
+				{
+					// select first item
+					m_FilesSelectedIndex = 0;
+				}
 			}
+			if(m_FilesSelectedIndex >= 0)
+				str_copy(m_aFilesSelectedName, m_FilteredFileList[m_FilesSelectedIndex]->m_aName, sizeof(m_aFilesSelectedName));
+			else
+				m_aFilesSelectedName[0] = '\0';
+			s_ListBox.ScrollToSelected();
 		}
 	}
 
-	if(m_FilesSelectedIndex > -1)
+	if(m_FilesSelectedIndex >= 0 && m_FilesSelectedIndex < m_FilteredFileList.size())
 	{
-		if (m_FileDialogFileType == CEditor::FILETYPE_IMG && !m_PreviewImageIsLoaded && m_FilesSelectedIndex > -1)
+		if(m_FileDialogFileType == CEditor::FILETYPE_IMG && !m_PreviewImageIsLoaded)
 		{
-			int Length = str_length(m_FileList[m_FilesSelectedIndex].m_aFilename);
-			if (Length >= 4 && str_endswith_nocase(m_FileList[m_FilesSelectedIndex].m_aFilename, ".png"))
+			int Length = str_length(m_FilteredFileList[m_FilesSelectedIndex]->m_aFilename);
+			if(Length >= str_length(".png") && str_endswith_nocase(m_FilteredFileList[m_FilesSelectedIndex]->m_aFilename, ".png"))
 			{
-				char aBuffer[1024];
-				str_format(aBuffer, sizeof(aBuffer), "%s/%s", m_pFileDialogPath, m_FileList[m_FilesSelectedIndex].m_aFilename);
-
-				if(Graphics()->LoadPNG(&m_FilePreviewImageInfo, aBuffer, m_FileList[m_FilesSelectedIndex].m_StorageType))
+				char aBuffer[IO_MAX_PATH_LENGTH];
+				str_format(aBuffer, sizeof(aBuffer), "%s/%s", m_pFileDialogPath, m_FilteredFileList[m_FilesSelectedIndex]->m_aFilename);
+				if(Graphics()->LoadPNG(&m_FilePreviewImageInfo, aBuffer, m_FilteredFileList[m_FilesSelectedIndex]->m_StorageType))
 				{
 					Graphics()->UnloadTexture(&m_FilePreviewImage);
 					m_FilePreviewImage = Graphics()->LoadTextureRaw(m_FilePreviewImageInfo.m_Width, m_FilePreviewImageInfo.m_Height, m_FilePreviewImageInfo.m_Format, m_FilePreviewImageInfo.m_pData, m_FilePreviewImageInfo.m_Format, IGraphics::TEXLOAD_NORESAMPLE);
@@ -2787,16 +2817,16 @@ void CEditor::RenderFileDialog()
 				}
 			}
 		}
-		if (m_PreviewImageIsLoaded)
+		if(m_PreviewImageIsLoaded)
 		{
 			int w = m_FilePreviewImageInfo.m_Width;
 			int h = m_FilePreviewImageInfo.m_Height;
-			if (m_FilePreviewImageInfo.m_Width > Preview.w)
+			if(m_FilePreviewImageInfo.m_Width > Preview.w)
 			{
 				h = m_FilePreviewImageInfo.m_Height * Preview.w / m_FilePreviewImageInfo.m_Width;
 				w = Preview.w;
 			}
-			if (h > Preview.h)
+			if(h > Preview.h)
 			{
 				w = w * Preview.h / h,
 				h = Preview.h;
@@ -2811,25 +2841,11 @@ void CEditor::RenderFileDialog()
 		}
 	}
 
-	for(int i = 0; i < Input()->NumEvents(); i++)
+	s_ListBox.DoStart(15.0f, m_FilteredFileList.size(), 1, 5, m_FilesSelectedIndex, &View);
+
+	for(int i = 0; i < m_FilteredFileList.size(); i++)
 	{
-		IInput::CEvent Event = Input()->GetEvent(i);
-		if(Event.m_Flags&IInput::FLAG_PRESS)
-		{
-			if(Event.m_Key == KEY_RETURN || Event.m_Key == KEY_KP_ENTER)
-				m_aFileDialogActivate = true;
-		}
-	}
-
-	static CListBox s_ListBox;
-	s_ListBox.DoStart(15.0f, m_FileList.size(), 1, 5, m_FilesSelectedIndex, &View);
-
-	for(int i = 0; i < m_FileList.size(); i++)
-	{
-		if(m_aFileDialogFilterString[0] && !str_find_nocase(m_FileList[i].m_aName, m_aFileDialogFilterString))
-			continue;
-
-		CListboxItem Item = s_ListBox.DoNextItem(&m_FileList[i], m_FilesSelectedIndex == i);
+		CListboxItem Item = s_ListBox.DoNextItem(&m_FilteredFileList[i], m_FilesSelectedIndex == i);
 		if(!Item.m_Visible)
 			continue;
 
@@ -2840,66 +2856,60 @@ void CEditor::RenderFileDialog()
 
 		Graphics()->TextureSet(g_pData->m_aImages[IMAGE_FILEICONS].m_Id);
 		Graphics()->QuadsBegin();
-		RenderTools()->SelectSprite(m_FileList[i].m_IsDir ? SPRITE_FILE_FOLDER : SPRITE_FILE_MAP2);
+		RenderTools()->SelectSprite(m_FilteredFileList[i]->m_IsDir ? SPRITE_FILE_FOLDER : SPRITE_FILE_MAP2);
 		IGraphics::CQuadItem QuadItem(FileIcon.x, FileIcon.y, FileIcon.w, FileIcon.h);
 		Graphics()->QuadsDrawTL(&QuadItem, 1);
 		Graphics()->QuadsEnd();
 
-		UI()->DoLabelSelected(&Label, m_FileList[i].m_aName, Item.m_Selected, 10.0f, TEXTALIGN_ML);
+		UI()->DoLabelSelected(&Label, m_FilteredFileList[i]->m_aName, Item.m_Selected, 10.0f, TEXTALIGN_ML);
 	}
 
 	int NewSelection = s_ListBox.DoEnd();
 	if(NewSelection != m_FilesSelectedIndex)
 	{
 		m_FilesSelectedIndex = NewSelection;
-		if(!m_FileList[m_FilesSelectedIndex].m_IsDir)
-			str_copy(m_aFileDialogFileName, m_FileList[m_FilesSelectedIndex].m_aFilename, sizeof(m_aFileDialogFileName));
+		str_copy(m_aFilesSelectedName, m_FilteredFileList[m_FilesSelectedIndex]->m_aName, sizeof(m_aFilesSelectedName));
+		if(!m_FilteredFileList[m_FilesSelectedIndex]->m_IsDir)
+			m_FileDialogFileNameInput.Set(m_FilteredFileList[m_FilesSelectedIndex]->m_aFilename);
 		else
-			m_aFileDialogFileName[0] = 0;
+			m_FileDialogFileNameInput.Clear();
 		m_PreviewImageIsLoaded = false;
 	}
-	if(s_ListBox.WasItemActivated())
-		m_aFileDialogActivate = true;
 
 	// the buttons
-	static int s_OkButton = 0;
-	static int s_CancelButton = 0;
-	static int s_NewFolderButton = 0;
-	static int s_MapInfoButton = 0;
-
 	CUIRect Button;
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
-	bool IsDir = m_FilesSelectedIndex >= 0 && m_FileList[m_FilesSelectedIndex].m_IsDir;
-	if(DoButton_Editor(&s_OkButton, IsDir ? "Open" : m_pFileDialogButtonText, 0, &Button, 0, 0) || m_aFileDialogActivate)
+	bool IsDir = m_FilesSelectedIndex >= 0 && m_FilteredFileList[m_FilesSelectedIndex]->m_IsDir;
+	static int s_OkButton = 0;
+	if(DoButton_Editor(&s_OkButton, IsDir ? "Open" : m_pFileDialogButtonText, 0, &Button, 0, 0) || s_ListBox.WasItemActivated())
 	{
-		m_aFileDialogActivate = false;
 		if(IsDir)	// folder
 		{
-			if(str_comp(m_FileList[m_FilesSelectedIndex].m_aFilename, "..") == 0)	// parent folder
+			if(str_comp(m_FilteredFileList[m_FilesSelectedIndex]->m_aFilename, "..") == 0)	// parent folder
 			{
 				if(fs_parent_dir(m_pFileDialogPath))
 					m_pFileDialogPath = m_aFileDialogCurrentFolder;	// leave the link
 			}
 			else	// sub folder
 			{
-				if(m_FileList[m_FilesSelectedIndex].m_IsLink)
+				if(m_FilteredFileList[m_FilesSelectedIndex]->m_IsLink)
 				{
 					m_pFileDialogPath = m_aFileDialogCurrentLink;	// follow the link
-					str_copy(m_aFileDialogCurrentLink, m_FileList[m_FilesSelectedIndex].m_aFilename, sizeof(m_aFileDialogCurrentLink));
+					str_copy(m_aFileDialogCurrentLink, m_FilteredFileList[m_FilesSelectedIndex]->m_aFilename, sizeof(m_aFileDialogCurrentLink));
 				}
 				else
 				{
 					char aTemp[IO_MAX_PATH_LENGTH];
 					str_copy(aTemp, m_pFileDialogPath, sizeof(aTemp));
-					str_format(m_pFileDialogPath, IO_MAX_PATH_LENGTH, "%s/%s", aTemp, m_FileList[m_FilesSelectedIndex].m_aFilename);
+					str_format(m_pFileDialogPath, IO_MAX_PATH_LENGTH, "%s/%s", aTemp, m_FilteredFileList[m_FilesSelectedIndex]->m_aFilename);
 				}
 			}
 			FilelistPopulate(!str_comp(m_pFileDialogPath, "maps") || !str_comp(m_pFileDialogPath, "mapres") ? m_FileDialogStorageType :
-				m_FileList[m_FilesSelectedIndex].m_StorageType);
-			if(m_FilesSelectedIndex >= 0 && !m_FileList[m_FilesSelectedIndex].m_IsDir)
-				str_copy(m_aFileDialogFileName, m_FileList[m_FilesSelectedIndex].m_aFilename, sizeof(m_aFileDialogFileName));
+				m_FilteredFileList[m_FilesSelectedIndex]->m_StorageType);
+			if(m_FilesSelectedIndex >= 0 && !m_FilteredFileList[m_FilesSelectedIndex]->m_IsDir)
+				m_FileDialogFileNameInput.Set(m_FilteredFileList[m_FilesSelectedIndex]->m_aFilename);
 			else
-				m_aFileDialogFileName[0] = 0;
+				m_FileDialogFileNameInput.Clear();
 		}
 		else // file
 		{
@@ -2913,25 +2923,26 @@ void CEditor::RenderFileDialog()
 					m_PopupEventType = POPEVENT_SAVE;
 					m_PopupEventActivated = true;
 				}
-				else
-					if(m_pfnFileDialogFunc)
-						m_pfnFileDialogFunc(m_aFileSaveName, m_FilesSelectedIndex >= 0 ? m_FileList[m_FilesSelectedIndex].m_StorageType : m_FileDialogStorageType, m_pFileDialogUser);
+				else if(m_pfnFileDialogFunc)
+					m_pfnFileDialogFunc(m_aFileSaveName, m_FilesSelectedIndex >= 0 ? m_FilteredFileList[m_FilesSelectedIndex]->m_StorageType : m_FileDialogStorageType, m_pFileDialogUser);
 			}
-			else
-				if(m_pfnFileDialogFunc)
-					m_pfnFileDialogFunc(m_aFileSaveName, m_FilesSelectedIndex >= 0 ? m_FileList[m_FilesSelectedIndex].m_StorageType : m_FileDialogStorageType, m_pFileDialogUser);
+			else if(m_pfnFileDialogFunc)
+				m_pfnFileDialogFunc(m_aFileSaveName, m_FilesSelectedIndex >= 0 ? m_FilteredFileList[m_FilesSelectedIndex]->m_StorageType : m_FileDialogStorageType, m_pFileDialogUser);
 		}
+		s_ListBox.ScrollToSelected();
 	}
 
 	ButtonBar.VSplitRight(40.0f, &ButtonBar, &Button);
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
-	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, 0) || Input()->KeyPress(KEY_ESCAPE))
+	static int s_CancelButton = 0;
+	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, 0) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 		m_Dialog = DIALOG_NONE;
 
 	if(m_FileDialogStorageType == IStorage::TYPE_SAVE)
 	{
 		ButtonBar.VSplitLeft(40.0f, 0, &ButtonBar);
 		ButtonBar.VSplitLeft(70.0f, &Button, &ButtonBar);
+		static int s_NewFolderButton = 0;
 		if(DoButton_Editor(&s_NewFolderButton, "New folder", 0, &Button, 0, 0))
 		{
 			m_aFileDialogNewFolderName[0] = 0;
@@ -2939,12 +2950,10 @@ void CEditor::RenderFileDialog()
 			UI()->DoPopupMenu(Width/2.0f-200.0f, Height/2.0f-100.0f, 400.0f, 200.0f, this, PopupNewFolder);
 			UI()->SetActiveItem(0);
 		}
-	}
 
-	if(m_FileDialogStorageType == IStorage::TYPE_SAVE)
-	{
 		ButtonBar.VSplitLeft(40.0f, 0, &ButtonBar);
 		ButtonBar.VSplitLeft(70.0f, &Button, &ButtonBar);
+		static int s_MapInfoButton = 0;
 		if(DoButton_Editor(&s_MapInfoButton, "Map details", 0, &Button, 0, 0))
 		{
 			str_copy(m_Map.m_MapInfoTmp.m_aAuthor, m_Map.m_MapInfo.m_aAuthor, sizeof(m_Map.m_MapInfoTmp.m_aAuthor));
@@ -2957,9 +2966,42 @@ void CEditor::RenderFileDialog()
 	}
 }
 
+void CEditor::RefreshFilteredFileList()
+{
+	m_FilteredFileList.clear();
+	for(int i = 0; i < m_CompleteFileList.size(); i++)
+	{
+		if(!m_aFileDialogFilterString[0] || str_find_nocase(m_CompleteFileList[i].m_aName, m_aFileDialogFilterString))
+		{
+			m_FilteredFileList.add(&m_CompleteFileList[i]);
+		}
+	}
+	if(m_FilteredFileList.size() > 0)
+	{
+		if(m_aFilesSelectedName[0])
+		{
+			for(int i = 0; i < m_FilteredFileList.size(); i++)
+			{
+				if(m_aFilesSelectedName[0] && str_comp(m_FilteredFileList[i]->m_aName, m_aFilesSelectedName) == 0)
+				{
+					m_FilesSelectedIndex = i;
+					break;
+				}
+			}
+		}
+		m_FilesSelectedIndex = clamp(m_FilesSelectedIndex, 0, m_FilteredFileList.size() - 1);
+		str_copy(m_aFilesSelectedName, m_FilteredFileList[m_FilesSelectedIndex]->m_aName, sizeof(m_aFilesSelectedName));
+	}
+	else
+	{
+		m_FilesSelectedIndex = -1;
+		m_aFilesSelectedName[0] = '\0';
+	}
+}
+
 void CEditor::FilelistPopulate(int StorageType)
 {
-	m_FileList.clear();
+	m_CompleteFileList.clear();
 	if(m_FileDialogStorageType != IStorage::TYPE_SAVE && !str_comp(m_pFileDialogPath, "maps"))
 	{
 		CFilelistItem Item;
@@ -2968,12 +3010,16 @@ void CEditor::FilelistPopulate(int StorageType)
 		Item.m_IsDir = true;
 		Item.m_IsLink = true;
 		Item.m_StorageType = IStorage::TYPE_SAVE;
-		m_FileList.add(Item);
+		m_CompleteFileList.add(Item);
 	}
 	Storage()->ListDirectory(StorageType, m_pFileDialogPath, EditorListdirCallback, this);
-	m_FilesSelectedIndex = m_FileList.size() ? 0 : -1;
+	RefreshFilteredFileList();
+	m_FilesSelectedIndex = m_FilteredFileList.size() ? 0 : -1;
+	if(m_FilesSelectedIndex >= 0)
+		str_copy(m_aFilesSelectedName, m_FilteredFileList[m_FilesSelectedIndex]->m_aName, sizeof(m_aFilesSelectedName));
+	else
+		m_aFilesSelectedName[0] = '\0';
 	m_PreviewImageIsLoaded = false;
-	m_aFileDialogActivate = false;
 }
 
 void CEditor::InvokeFileDialog(int StorageType, int FileType, const char *pTitle, const char *pButtonText,
@@ -2985,18 +3031,17 @@ void CEditor::InvokeFileDialog(int StorageType, int FileType, const char *pTitle
 	m_pFileDialogButtonText = pButtonText;
 	m_pfnFileDialogFunc = pfnFunc;
 	m_pFileDialogUser = pUser;
-	m_aFileDialogFileName[0] = 0;
+	m_FileDialogFileNameInput.Clear();
 	m_aFileDialogCurrentFolder[0] = 0;
 	m_aFileDialogCurrentLink[0] = 0;
-	m_aFileDialogFilterString[0] = 0;
+	m_FileDialogFilterInput.Clear();
 	m_pFileDialogPath = m_aFileDialogCurrentFolder;
 	m_FileDialogFileType = FileType;
-	m_FileDialogScrollValue = 0.0f;
 	UI()->SetActiveItem(&m_FileDialogFilterInput);
 	m_PreviewImageIsLoaded = false;
 
 	if(pDefaultName)
-		str_copy(m_aFileDialogFileName, pDefaultName, sizeof(m_aFileDialogFileName));
+		m_FileDialogFileNameInput.Set(pDefaultName);
 	if(pBasePath)
 		str_copy(m_aFileDialogCurrentFolder, pBasePath, sizeof(m_aFileDialogCurrentFolder));
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -341,19 +341,6 @@ int CEditor::DoButton_Image(const void *pID, const char *pText, int Checked, con
 	return DoButton_Editor_Common(pID, pText, Checked, pRect, Flags, pToolTip);
 }
 
-int CEditor::DoButton_File(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip)
-{
-	if(Checked)
-		pRect->Draw(GetButtonColor(pID, Checked), 3.0f);
-	else if(UI()->HotItem() == pID)
-		pRect->Draw(vec4(1,1,1,0.33f), 3.0f);
-
-	CUIRect Label = *pRect;
-	Label.VMargin(5.0f, &Label);
-	UI()->DoLabel(&Label, pText, 10.0f, TEXTALIGN_ML);
-	return DoButton_Editor_Common(pID, pText, Checked, pRect, Flags, pToolTip);
-}
-
 int CEditor::DoButton_Menu(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip)
 {
 	pRect->Draw(vec4(0.5f, 0.5f, 0.5f, 1.0f), 3.0f, CUIRect::CORNER_T);
@@ -2702,41 +2689,6 @@ static int EditorListdirCallback(const char *pName, int IsDir, int StorageType, 
 	return 0;
 }
 
-void CEditor::AddFileDialogEntry(int Index, CUIRect *pView)
-{
-	if(m_aFileDialogFilterString[0] && !str_find_nocase(m_FileList[Index].m_aName, m_aFileDialogFilterString))
-		return;
-	m_FilesCur++;
-	if(m_FilesCur-1 < m_FilesStartAt || m_FilesCur >= m_FilesStopAt)
-		return;
-
-	CUIRect Button, FileIcon;
-	pView->HSplitTop(15.0f, &Button, pView);
-	pView->HSplitTop(2.0f, 0, pView);
-	Button.VSplitLeft(Button.h, &FileIcon, &Button);
-	Button.VSplitLeft(5.0f, 0, &Button);
-
-	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_FILEICONS].m_Id);
-	Graphics()->QuadsBegin();
-	RenderTools()->SelectSprite(m_FileList[Index].m_IsDir?SPRITE_FILE_FOLDER:SPRITE_FILE_MAP2);
-	IGraphics::CQuadItem QuadItem(FileIcon.x, FileIcon.y, FileIcon.w, FileIcon.h);
-	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	Graphics()->QuadsEnd();
-
-	if(DoButton_File(&m_FileList[Index], m_FileList[Index].m_aName, m_FilesSelectedIndex == Index, &Button, 0, 0))
-	{
-		if(!m_FileList[Index].m_IsDir)
-			str_copy(m_aFileDialogFileName, m_FileList[Index].m_aFilename, sizeof(m_aFileDialogFileName));
-		else
-			m_aFileDialogFileName[0] = 0;
-		m_FilesSelectedIndex = Index;
-		m_PreviewImageIsLoaded = false;
-
-		if(Input()->MouseDoubleClick())
-			m_aFileDialogActivate = true;
-	}
-}
-
 void CEditor::RenderFileDialog()
 {
 	// GUI coordsys
@@ -2816,53 +2768,8 @@ void CEditor::RenderFileDialog()
 		}
 	}
 
-	int Num = (int)(View.h/17.0f)+1;
-	m_FileDialogScrollValue = UI()->DoScrollbarV(&m_FileDialogScrollValue, &Scroll, m_FileDialogScrollValue);
-
-	int ScrollNum = m_FileList.size()-Num+1;
-	if(ScrollNum > 0)
-	{
-		if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP))
-			m_FileDialogScrollValue -= 3.0f/ScrollNum;
-		if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
-			m_FileDialogScrollValue += 3.0f/ScrollNum;
-	}
-	else
-		ScrollNum = 0;
-
 	if(m_FilesSelectedIndex > -1)
 	{
-		for(int i = 0; i < Input()->NumEvents(); i++)
-		{
-			IInput::CEvent Event = Input()->GetEvent(i);
-			int NewIndex = -1;
-			if(Event.m_Flags&IInput::FLAG_PRESS)
-			{
-				if(Event.m_Key == KEY_DOWN) NewIndex = m_FilesSelectedIndex + 1;
-				if(Event.m_Key == KEY_UP) NewIndex = m_FilesSelectedIndex - 1;
-			}
-			if(NewIndex > -1 && NewIndex < m_FileList.size())
-			{
-				//scroll
-				float IndexY = View.y - m_FileDialogScrollValue*ScrollNum*17.0f + NewIndex*17.0f;
-				int Scroll = View.y > IndexY ? -1 : View.y+View.h < IndexY+17.0f ? 1 : 0;
-				if(Scroll)
-				{
-					if(Scroll < 0)
-						m_FileDialogScrollValue = ((float)(NewIndex)+0.5f)/ScrollNum;
-					else
-						m_FileDialogScrollValue = ((float)(NewIndex-Num)+2.5f)/ScrollNum;
-				}
-
-				if(!m_FileList[NewIndex].m_IsDir)
-					str_copy(m_aFileDialogFileName, m_FileList[NewIndex].m_aFilename, sizeof(m_aFileDialogFileName));
-				else
-					m_aFileDialogFileName[0] = 0;
-				m_FilesSelectedIndex = NewIndex;
-				m_PreviewImageIsLoaded = false;
-			}
-		}
-
 		if (m_FileDialogFileType == CEditor::FILETYPE_IMG && !m_PreviewImageIsLoaded && m_FilesSelectedIndex > -1)
 		{
 			int Length = str_length(m_FileList[m_FilesSelectedIndex].m_aFilename);
@@ -2914,25 +2821,45 @@ void CEditor::RenderFileDialog()
 		}
 	}
 
-	if(m_FileDialogScrollValue < 0) m_FileDialogScrollValue = 0;
-	if(m_FileDialogScrollValue > 1) m_FileDialogScrollValue = 1;
-
-	m_FilesStartAt = (int)(ScrollNum*m_FileDialogScrollValue);
-	if(m_FilesStartAt < 0)
-		m_FilesStartAt = 0;
-
-	m_FilesStopAt = m_FilesStartAt+Num;
-
-	m_FilesCur = 0;
-
-	// set clipping
-	UI()->ClipEnable(&View);
+	static CListBox s_ListBox;
+	s_ListBox.DoStart(15.0f, m_FileList.size(), 1, 5, m_FilesSelectedIndex, &View);
 
 	for(int i = 0; i < m_FileList.size(); i++)
-		AddFileDialogEntry(i, &View);
+	{
+		if(m_aFileDialogFilterString[0] && !str_find_nocase(m_FileList[i].m_aName, m_aFileDialogFilterString))
+			continue;
 
-	// disable clipping again
-	UI()->ClipDisable();
+		CListboxItem Item = s_ListBox.DoNextItem(&m_FileList[i], m_FilesSelectedIndex == i);
+		if(!Item.m_Visible)
+			continue;
+
+		CUIRect Label, FileIcon;
+		Item.m_Rect.VSplitLeft(Item.m_Rect.h, &FileIcon, &Label);
+		FileIcon.Margin(2.0f, &FileIcon);
+		Label.VSplitLeft(5.0f, 0, &Label);
+
+		Graphics()->TextureSet(g_pData->m_aImages[IMAGE_FILEICONS].m_Id);
+		Graphics()->QuadsBegin();
+		RenderTools()->SelectSprite(m_FileList[i].m_IsDir ? SPRITE_FILE_FOLDER : SPRITE_FILE_MAP2);
+		IGraphics::CQuadItem QuadItem(FileIcon.x, FileIcon.y, FileIcon.w, FileIcon.h);
+		Graphics()->QuadsDrawTL(&QuadItem, 1);
+		Graphics()->QuadsEnd();
+
+		UI()->DoLabelSelected(&Label, m_FileList[i].m_aName, Item.m_Selected, 10.0f, TEXTALIGN_ML);
+	}
+
+	int NewSelection = s_ListBox.DoEnd();
+	if(NewSelection != m_FilesSelectedIndex)
+	{
+		m_FilesSelectedIndex = NewSelection;
+		if(!m_FileList[m_FilesSelectedIndex].m_IsDir)
+			str_copy(m_aFileDialogFileName, m_FileList[m_FilesSelectedIndex].m_aFilename, sizeof(m_aFileDialogFileName));
+		else
+			m_aFileDialogFileName[0] = 0;
+		m_PreviewImageIsLoaded = false;
+	}
+	if(s_ListBox.WasItemActivated())
+		m_aFileDialogActivate = true;
 
 	// the buttons
 	static int s_OkButton = 0;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -771,7 +771,6 @@ public:
 	int DoButton_ButtonDec(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
 	int DoButton_ButtonInc(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
 
-	int DoButton_File(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
 	int DoButton_Image(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip, bool Used);
 
 	int DoButton_Menu(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
@@ -836,7 +835,6 @@ public:
 	void RenderMenubar(CUIRect Menubar);
 	void RenderFileDialog();
 
-	void AddFileDialogEntry(int Index, CUIRect *pView);
 	void SortImages();
 	static void ExtractName(const char *pFileName, char *pName, int BufferSize)
 	{

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -545,21 +545,18 @@ public:
 		m_PopupEventWasActivated = false;
 
 		m_FileDialogStorageType = 0;
+		m_aFileDialogFileName[0] = '\0';
+		m_FileDialogFileNameInput.SetBuffer(m_aFileDialogFileName, sizeof(m_aFileDialogFileName));
 		m_aFileDialogFilterString[0] = '\0';
 		m_FileDialogFilterInput.SetBuffer(m_aFileDialogFilterString, sizeof(m_aFileDialogFilterString));
 		m_pFileDialogTitle = 0;
 		m_pFileDialogButtonText = 0;
 		m_pFileDialogUser = 0;
-		m_aFileDialogFileName[0] = 0;
 		m_aFileDialogCurrentFolder[0] = 0;
 		m_aFileDialogCurrentLink[0] = 0;
 		m_pFileDialogPath = m_aFileDialogCurrentFolder;
-		m_aFileDialogActivate = false;
-		m_FileDialogScrollValue = 0.0f;
 		m_FilesSelectedIndex = -1;
-		m_FilesStartAt = 0;
-		m_FilesCur = 0;
-		m_FilesStopAt = 999;
+		m_aFilesSelectedName[0] = '\0';
 
 		m_WorldOffsetX = 0;
 		m_WorldOffsetY = 0;
@@ -602,6 +599,7 @@ public:
 	virtual void UpdateAndRender();
 	virtual bool HasUnsavedData() const { return m_Map.m_Modified; }
 
+	void RefreshFilteredFileList();
 	void FilelistPopulate(int StorageType);
 	void InvokeFileDialog(int StorageType, int FileType, const char *pTitle, const char *pButtonText,
 		const char *pBasepath, const char *pDefaultName,
@@ -665,14 +663,14 @@ public:
 	const char *m_pFileDialogButtonText;
 	void (*m_pfnFileDialogFunc)(const char *pFileName, int StorageType, void *pUser);
 	void *m_pFileDialogUser;
+	CLineInput m_FileDialogFileNameInput;
 	char m_aFileDialogFileName[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogCurrentFolder[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogCurrentLink[IO_MAX_PATH_LENGTH];
 	char *m_pFileDialogPath;
-	bool m_aFileDialogActivate;
 	int m_FileDialogFileType;
-	float m_FileDialogScrollValue;
 	int m_FilesSelectedIndex;
+	char m_aFilesSelectedName[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogFilterString[64];
 	CLineInput m_FileDialogFilterInput;
 	char m_aFileDialogNewFolderName[64];
@@ -694,10 +692,8 @@ public:
 														m_IsDir && !Other.m_IsDir ? true : !m_IsDir && Other.m_IsDir ? false :
 														str_comp_filenames(m_aFilename, Other.m_aFilename) < 0; }
 	};
-	sorted_array<CFilelistItem> m_FileList;
-	int m_FilesStartAt;
-	int m_FilesCur;
-	int m_FilesStopAt;
+	sorted_array<CFilelistItem> m_CompleteFileList;
+	sorted_array<CFilelistItem *> m_FilteredFileList;
 
 	float m_WorldOffsetX;
 	float m_WorldOffsetY;


### PR DESCRIPTION
![screenshot_2022-03-10_18-22-57](https://user-images.githubusercontent.com/23437060/157720183-19996cde-9b51-40e6-a895-acb0ddb7109a.png)

![screenshot_2022-03-10_18-24-29](https://user-images.githubusercontent.com/23437060/157720269-cd6b75c0-471e-4469-9e88-adc01bc2aeb3.png)

Fix editor file browser selection and filter not being synced. Typing a filter text will restore the previous selection if possible and always scroll to make it visible. Closes #2290.