### PR TITLE
Keep selected demo in view when sorting and renaming

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -59,6 +59,7 @@ CMenus::CMenus()
 	m_RefreshSkinSelector = true;
 	m_pSelectedSkin = 0;
 	m_MenuActive = true;
+	m_aDemolistPreviousSelection[0] = '\0';
 	m_SeekBarActivatedTime = 0;
 	m_SeekBarActive = true;
 	m_SkinModified = false;
@@ -1476,16 +1477,18 @@ void CMenus::RenderMenu(CUIRect Screen)
 					// rename demo
 					if(m_DemolistSelectedIndex >= 0 && !m_DemolistSelectedIsDir)
 					{
+						const char *pExt = ".demo";
+						const int ExtLength = str_length(pExt);
 						char aBufOld[IO_MAX_PATH_LENGTH];
 						str_format(aBufOld, sizeof(aBufOld), "%s/%s", m_aCurrentDemoFolder, m_lDemos[m_DemolistSelectedIndex].m_aFilename);
 						int Length = str_length(m_aCurrentDemoFile);
-						char aBufNew[IO_MAX_PATH_LENGTH];
-						if(Length <= 4 || m_aCurrentDemoFile[Length-5] != '.' || str_comp_nocase(m_aCurrentDemoFile+Length-4, "demo"))
-							str_format(aBufNew, sizeof(aBufNew), "%s/%s.demo", m_aCurrentDemoFolder, m_aCurrentDemoFile);
-						else
-							str_format(aBufNew, sizeof(aBufNew), "%s/%s", m_aCurrentDemoFolder, m_aCurrentDemoFile);
-						if(Storage()->RenameFile(aBufOld, aBufNew, m_lDemos[m_DemolistSelectedIndex].m_StorageType))
+						if(Length < ExtLength || str_comp(m_aCurrentDemoFile + Length - ExtLength, pExt))
+							str_append(m_aCurrentDemoFile, pExt, sizeof(m_aCurrentDemoFile));
+						char aPathNew[IO_MAX_PATH_LENGTH];
+						str_format(aPathNew, sizeof(aPathNew), "%s/%s", m_aCurrentDemoFolder, m_aCurrentDemoFile);
+						if(Storage()->RenameFile(aBufOld, aPathNew, m_lDemos[m_DemolistSelectedIndex].m_StorageType))
 						{
+							str_copy(m_aDemolistPreviousSelection, m_aCurrentDemoFile, sizeof(m_aDemolistPreviousSelection));
 							DemolistPopulate();
 							DemolistOnUpdate(false);
 						}

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -309,6 +309,7 @@ private:
 	int m_DemolistSelectedIndex;
 	bool m_DemolistSelectedIsDir;
 	int m_DemolistStorageType;
+	char m_aDemolistPreviousSelection[IO_MAX_PATH_LENGTH];
 	int64 m_SeekBarActivatedTime;
 	bool m_SeekBarActive;
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -534,11 +534,28 @@ void CMenus::RenderDemoList(CUIRect MainView)
 			}
 
 			// Don't rescan in order to keep fetched headers, just resort
+			if(m_DemolistSelectedIndex >= 0)
+				str_copy(m_aDemolistPreviousSelection, m_lDemos[m_DemolistSelectedIndex].m_aFilename, sizeof(m_aDemolistPreviousSelection));
 			m_lDemos.sort_range_by(CDemoComparator(
 				Config()->m_BrDemoSort, Config()->m_BrDemoSortOrder
 			));
 			DemolistOnUpdate(false);
 		}
+	}
+
+	// Restore previous selection based on name
+	if(m_aDemolistPreviousSelection[0])
+	{
+		for(sorted_array<CDemoItem>::range r = m_lDemos.all(); !r.empty(); r.pop_front())
+		{
+			if(str_comp(r.front().m_aFilename, m_aDemolistPreviousSelection) == 0)
+			{
+				m_DemolistSelectedIndex = &r.front() - m_lDemos.base_ptr();
+				break;
+			}
+		}
+		m_aDemolistPreviousSelection[0] = '\0';
+		s_ListBox.ScrollToSelected();
 	}
 
 	s_ListBox.DoSpacing(UI()->GetListHeaderHeight());
@@ -547,6 +564,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	for(sorted_array<CDemoItem>::range r = m_lDemos.all(); !r.empty(); r.pop_front())
 	{
 		CListboxItem Item = s_ListBox.DoNextItem(&r.front(), (&r.front() - m_lDemos.base_ptr()) == m_DemolistSelectedIndex);
+
 		// marker count
 		const CDemoItem& DemoItem = r.front();
 		const int DemoMarkerCount = DemoItem.GetMarkerCount();
@@ -671,6 +689,8 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	static CButtonContainer s_RefreshButton;
 	if(DoButton_Menu(&s_RefreshButton, Localize("Refresh"), 0, &Button) || (UI()->KeyPress(KEY_R) && (Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL))))
 	{
+		if(m_DemolistSelectedIndex >= 0)
+			str_copy(m_aDemolistPreviousSelection, m_lDemos[m_DemolistSelectedIndex].m_aFilename, sizeof(m_aDemolistPreviousSelection));
 		DemolistPopulate();
 		DemolistOnUpdate(false);
 	}
@@ -680,6 +700,8 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	static CButtonContainer s_FetchButton;
 	if(DoButton_Menu(&s_FetchButton, Localize("Fetch Info"), 0, &Button))
 	{
+		if(m_DemolistSelectedIndex >= 0)
+			str_copy(m_aDemolistPreviousSelection, m_lDemos[m_DemolistSelectedIndex].m_aFilename, sizeof(m_aDemolistPreviousSelection));
 		for(sorted_array<CDemoItem>::range r = m_lDemos.all(); !r.empty(); r.pop_front())
 		{
 			if(str_comp(r.front().m_aFilename, ".."))


### PR DESCRIPTION
Keep same demo selected when renaming.

Scroll to reveal selected demo when sorting the demo list (or refreshing / fetching info, which influences the order) and when renaming a demo.

This also changes the rename dialog so it will enforce the `.demo` extension in lower case only. Previously it was possible to rename a demo to use an extension like `.Demo`, which prevents the demo from being listed.