### PR TITLE
Show completion options for tune params in console, make tuning commands more versatile

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -331,7 +331,7 @@ CGameConsole::CGameConsole()
 
 float CGameConsole::TimeNow()
 {
-	static long long s_TimeStart = time_get();
+	static int64 s_TimeStart = time_get();
 	return float(time_get()-s_TimeStart)/float(time_freq());
 }
 

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -26,11 +26,19 @@
 #include "console.h"
 
 static const char *s_apMapCommands[] = {"sv_map ", "change_map "};
-
 static bool IsMapCommandPrefix(const char *pStr)
 {
 	for(unsigned i = 0; i < sizeof(s_apMapCommands) / sizeof(char *); i++)
 		if(str_startswith_nocase(pStr, s_apMapCommands[i]))
+			return true;
+	return false;
+}
+
+static const char *s_apTuningCommands[] = {"tune ", "tune_reset "};
+static bool IsTuningCommandPrefix(const char *pStr)
+{
+	for(unsigned i = 0; i < sizeof(s_apTuningCommands) / sizeof(char *); i++)
+		if(str_startswith_nocase(pStr, s_apTuningCommands[i]))
 			return true;
 	return false;
 }
@@ -60,11 +68,10 @@ CGameConsole::CInstance::CInstance(int Type)
 		m_CompletionFlagmask = CFGFLAG_SERVER;
 	}
 
-	m_aCompletionMapBuffer[0] = 0;
-	m_CompletionMapChosen = -1;
-
 	m_aCompletionBuffer[0] = 0;
 	m_CompletionChosen = -1;
+	m_aCompletionBufferArgument[0] = 0;
+	m_CompletionChosenArgument = -1;
 	Reset();
 
 	m_IsCommand = false;
@@ -109,10 +116,10 @@ void CGameConsole::CInstance::PossibleCommandsCompleteCallback(int Index, const 
 		pInstance->m_Input.Set(pStr);
 }
 
-void CGameConsole::CInstance::PossibleMapsCompleteCallback(int Index, const char *pStr, void *pUser)
+void CGameConsole::CInstance::PossibleArgumentsCompleteCallback(int Index, const char *pStr, void *pUser)
 {
 	CGameConsole::CInstance *pInstance = (CGameConsole::CInstance *)pUser;
-	if(pInstance->m_CompletionMapChosen == Index)
+	if(pInstance->m_CompletionChosenArgument == Index)
 	{
 		// get command
 		char aBuf[512] = { 0 };
@@ -123,7 +130,7 @@ void CGameConsole::CInstance::PossibleMapsCompleteCallback(int Index, const char
 		aBuf[i++] = ' ';
 		aBuf[i] = 0;
 
-		// add mapname to current command
+		// append argument
 		str_append(aBuf, pStr, sizeof(aBuf));
 		pInstance->m_Input.Set(aBuf);
 	}
@@ -201,21 +208,34 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 				}
 			}
 
-			// maplist completion
-			if(m_Type == CGameConsole::CONSOLETYPE_REMOTE && m_pGameConsole->Client()->RconAuthed() && IsMapCommandPrefix(GetString()))
+			// argument completion (map, tuning, ...)
+			if(m_Type == CGameConsole::CONSOLETYPE_REMOTE && m_pGameConsole->Client()->RconAuthed())
 			{
-				const int CompletionMapEnumerationCount = m_pGameConsole->m_pConsole->PossibleMaps(m_aCompletionMapBuffer);
-				if(CompletionMapEnumerationCount)
+				const bool MapCompletion = IsMapCommandPrefix(GetString());
+				const bool TuningCompletion = IsTuningCommandPrefix(GetString());
+				if(MapCompletion || TuningCompletion)
 				{
-					if(m_CompletionMapChosen == -1 && Direction < 0)
-						m_CompletionMapChosen = 0;
-					m_CompletionMapChosen = (m_CompletionMapChosen + Direction + CompletionMapEnumerationCount) % CompletionMapEnumerationCount;
-					m_pGameConsole->m_pConsole->PossibleMaps(m_aCompletionMapBuffer, PossibleMapsCompleteCallback, this);
-				}
-				else if(m_CompletionMapChosen != -1)
-				{
-					m_CompletionMapChosen = -1;
-					Reset();
+					int CompletionEnumerationCount = 0;
+					if(MapCompletion)
+						CompletionEnumerationCount = m_pGameConsole->m_pConsole->PossibleMaps(m_aCompletionBufferArgument);
+					else if(TuningCompletion)
+						CompletionEnumerationCount = m_pGameConsole->m_pClient->m_Tuning.PossibleTunings(m_aCompletionBufferArgument);
+
+					if(CompletionEnumerationCount)
+					{
+						if(m_CompletionChosenArgument == -1 && Direction < 0)
+							m_CompletionChosenArgument = 0;
+						m_CompletionChosenArgument = (m_CompletionChosenArgument + Direction + CompletionEnumerationCount) % CompletionEnumerationCount;
+						if(MapCompletion)
+							m_pGameConsole->m_pConsole->PossibleMaps(m_aCompletionBufferArgument, PossibleArgumentsCompleteCallback, this);
+						else if(TuningCompletion)
+							m_pGameConsole->m_pClient->m_Tuning.PossibleTunings(m_aCompletionBufferArgument, PossibleArgumentsCompleteCallback, this);
+					}
+					else if(m_CompletionChosenArgument != -1)
+					{
+						m_CompletionChosenArgument = -1;
+						Reset();
+					}
 				}
 			}
 		}
@@ -243,13 +263,22 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 
 			for(unsigned i = 0; i < sizeof(s_apMapCommands) / sizeof(char *); i++)
 			{
-				if(str_startswith_nocase(GetString(), s_apMapCommands[i]))
+				if(str_startswith_nocase(m_Input.GetString(), s_apMapCommands[i]))
 				{
-					m_CompletionMapChosen = -1;
-					str_copy(m_aCompletionMapBuffer, &m_Input.GetString()[str_length(s_apMapCommands[i])], sizeof(m_aCompletionBuffer));
+					m_CompletionChosenArgument = -1;
+					str_copy(m_aCompletionBufferArgument, &m_Input.GetString()[str_length(s_apMapCommands[i])], sizeof(m_aCompletionBufferArgument));
 				}
 			}
-			
+
+			for(unsigned i = 0; i < sizeof(s_apTuningCommands) / sizeof(char *); i++)
+			{
+				if(str_startswith_nocase(m_Input.GetString(), s_apTuningCommands[i]))
+				{
+					m_CompletionChosenArgument = -1;
+					str_copy(m_aCompletionBufferArgument, &m_Input.GetString()[str_length(s_apTuningCommands[i])], sizeof(m_aCompletionBufferArgument));
+				}
+			}
+
 			Reset();
 		}
 
@@ -544,13 +573,18 @@ void CGameConsole::OnRender()
 
 			if(Info.m_EnumCount <= 0 && pConsole->m_IsCommand)
 			{
-				if(IsMapCommandPrefix(Info.m_pCurrentCmd))
+				const bool MapCompletion = IsMapCommandPrefix(Info.m_pCurrentCmd);
+				const bool TuningCompletion = IsTuningCommandPrefix(Info.m_pCurrentCmd);
+				if(MapCompletion || TuningCompletion)
 				{
-					Info.m_WantedCompletion = pConsole->m_CompletionMapChosen;
+					Info.m_WantedCompletion = pConsole->m_CompletionChosenArgument;
 					Info.m_EnumCount = 0;
 					Info.m_TotalWidth = 0.0f;
-					Info.m_pCurrentCmd = pConsole->m_aCompletionMapBuffer;
-					m_pConsole->PossibleMaps(Info.m_pCurrentCmd, PossibleCommandsRenderCallback, &Info);
+					Info.m_pCurrentCmd = pConsole->m_aCompletionBufferArgument;
+					if(MapCompletion)
+						m_pConsole->PossibleMaps(Info.m_pCurrentCmd, PossibleCommandsRenderCallback, &Info);
+					else if(TuningCompletion)
+						m_pClient->m_Tuning.PossibleTunings(Info.m_pCurrentCmd, PossibleCommandsRenderCallback, &Info);
 				}
 
 				if(Info.m_EnumCount <= 0 && pConsole->m_IsCommand)

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -29,11 +29,10 @@ class CGameConsole : public CComponent
 
 		CGameConsole *m_pGameConsole;
 
-		char m_aCompletionMapBuffer[128];
-		int m_CompletionMapChosen;
-
 		char m_aCompletionBuffer[128];
 		int m_CompletionChosen;
+		char m_aCompletionBufferArgument[128];
+		int m_CompletionChosenArgument;
 		int m_CompletionFlagmask;
 		float m_CompletionRenderOffset;
 		float m_CompletionRenderOffsetChange;
@@ -57,7 +56,7 @@ class CGameConsole : public CComponent
 
 		const char *GetString() const { return m_Input.GetString(); }
 		static void PossibleCommandsCompleteCallback(int Index, const char *pStr, void *pUser);
-		static void PossibleMapsCompleteCallback(int Index, const char *pStr, void *pUser);
+		static void PossibleArgumentsCompleteCallback(int Index, const char *pStr, void *pUser);
 	};
 
 	class IConsole *m_pConsole;

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -42,6 +42,20 @@ bool CTuningParams::Get(const char *pName, float *pValue) const
 	return false;
 }
 
+int CTuningParams::PossibleTunings(const char *pStr, IConsole::FPossibleCallback pfnCallback, void *pUser)
+{
+	int Index = 0;
+	for(int i = 0; i < Num(); i++)
+	{
+		if(str_find_nocase(GetName(i), pStr))
+		{
+			pfnCallback(Index, GetName(i), pUser);
+			Index++;
+		}
+	}
+	return Index;
+}
+
 
 float VelocityRamp(float Value, float Start, float Range, float Curvature)
 {

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -8,9 +8,9 @@
 
 #include <math.h>
 #include "collision.h"
+#include <engine/console.h>
 #include <engine/shared/protocol.h>
 #include <generated/protocol.h>
-
 
 class CTuneParam
 {
@@ -45,6 +45,7 @@ public:
 	bool Get(int Index, float *pValue) const;
 	bool Get(const char *pName, float *pValue) const;
 	const char *GetName(int Index) const { return s_apNames[Index]; }
+	int PossibleTunings(const char *pStr, IConsole::FPossibleCallback pfnCallback = IConsole::EmptyPossibleCommandCallback, void *pUser = 0);
 };
 
 inline void StrToInts(int *pInts, int Num, const char *pStr)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1164,20 +1164,34 @@ void CGameContext::ConTuneParam(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	const char *pParamName = pResult->GetString(0);
-	float NewValue = pResult->GetFloat(1);
 
 	char aBuf[256];
-	if(pSelf->Tuning()->Set(pParamName, NewValue) && pSelf->Tuning()->Get(pParamName, &NewValue))
+	if(pResult->NumArguments() == 2)
 	{
-		str_format(aBuf, sizeof(aBuf), "%s changed to %.2f", pParamName, NewValue);
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "tuning", aBuf);
-		pSelf->SendTuningParams(-1);
+		float NewValue = pResult->GetFloat(1);
+		if(pSelf->Tuning()->Set(pParamName, NewValue) && pSelf->Tuning()->Get(pParamName, &NewValue))
+		{
+			str_format(aBuf, sizeof(aBuf), "%s changed to %.2f", pParamName, NewValue);
+			pSelf->SendTuningParams(-1);
+		}
+		else
+		{
+			str_format(aBuf, sizeof(aBuf), "No such tuning parameter: %s", pParamName);
+		}
 	}
 	else
 	{
-		str_format(aBuf, sizeof(aBuf), "No such tuning parameter: %s", pParamName);
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "tuning", aBuf);
+		float Value;
+		if(pSelf->Tuning()->Get(pParamName, &Value))
+		{
+			str_format(aBuf, sizeof(aBuf), "%s %.2f", pParamName, Value);
+		}
+		else
+		{
+			str_format(aBuf, sizeof(aBuf), "No such tuning parameter: %s", pParamName);
+		}
 	}
+	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "tuning", aBuf);
 }
 
 void CGameContext::ConTuneReset(IConsole::IResult *pResult, void *pUserData)
@@ -1538,7 +1552,7 @@ void CGameContext::OnConsoleInit()
 	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 
-	Console()->Register("tune", "s[tuning] i[value]", CFGFLAG_SERVER, ConTuneParam, this, "Tune variable to value");
+	Console()->Register("tune", "s[tuning] ?i[value]", CFGFLAG_SERVER, ConTuneParam, this, "Tune variable to value or show current value");
 	Console()->Register("tune_reset", "?s[tuning]", CFGFLAG_SERVER, ConTuneReset, this, "Reset all or one tuning variable to default");
 	Console()->Register("tunes", "", CFGFLAG_SERVER, ConTunes, this, "List all tuning variables and their values");
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1167,7 +1167,7 @@ void CGameContext::ConTuneParam(IConsole::IResult *pResult, void *pUserData)
 	float NewValue = pResult->GetFloat(1);
 
 	char aBuf[256];
-	if(pSelf->Tuning()->Set(pParamName, NewValue))
+	if(pSelf->Tuning()->Set(pParamName, NewValue) && pSelf->Tuning()->Get(pParamName, &NewValue))
 	{
 		str_format(aBuf, sizeof(aBuf), "%s changed to %.2f", pParamName, NewValue);
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "tuning", aBuf);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1166,15 +1166,18 @@ void CGameContext::ConTuneParam(IConsole::IResult *pResult, void *pUserData)
 	const char *pParamName = pResult->GetString(0);
 	float NewValue = pResult->GetFloat(1);
 
+	char aBuf[256];
 	if(pSelf->Tuning()->Set(pParamName, NewValue))
 	{
-		char aBuf[256];
 		str_format(aBuf, sizeof(aBuf), "%s changed to %.2f", pParamName, NewValue);
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "tuning", aBuf);
 		pSelf->SendTuningParams(-1);
 	}
 	else
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "tuning", "No such tuning parameter");
+	{
+		str_format(aBuf, sizeof(aBuf), "No such tuning parameter: %s", pParamName);
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "tuning", aBuf);
+	}
 }
 
 void CGameContext::ConTuneReset(IConsole::IResult *pResult, void *pUserData)


### PR DESCRIPTION
- Print the incorrect tuning parameter name in the error message.
- Extend `tune_reset` so a single tuning value can be reset to default. For example `tune_reset player_collision` will reset just the `player_collision` tuning, whereas `tune_reset` will reset all to defaults like before.
- Get the actual tuning value after setting it, as the value that was applied may differ due to overflow or rounding errors.
- Extend `tune` so the current value of a given tuning variable is printed if no new value is given, so it works like commands in the console. For example `tune player_collision` will print the current value of the variable, whereas `tune player_collision 0` will change the value like before.
- Generalize the console map argument completion to also complete tuning variable names for the commands `tune` and `tune_reset`: 
![grafik](https://user-images.githubusercontent.com/23437060/157916789-109c60bd-2413-4e9f-b28f-361bd782473e.png)
