### PR TITLE
Update copyright.py script, add missing copyright notices to file headers

### DIFF
--- a/scripts/copyright.py
+++ b/scripts/copyright.py
@@ -1,7 +1,7 @@
 import os, sys
 os.chdir(os.path.dirname(os.path.realpath(sys.argv[0])) + "/..")
 
-notice = [b"/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */\n", b"/* If you are missing that file, acquire a complete release at teeworlds.com.                */\n"]
+notice = [("/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */" + os.linesep).encode('utf-8'), ("/* If you are missing that file, acquire a complete release at teeworlds.com.                */" + os.linesep).encode('utf-8')]
 exclude = ["src%sengine%sexternal" % (os.sep, os.sep), "src%sosxlaunch" % os.sep]
 updated_files = 0
 

--- a/scripts/copyright.py
+++ b/scripts/copyright.py
@@ -2,7 +2,7 @@ import os, sys
 os.chdir(os.path.dirname(os.path.realpath(sys.argv[0])) + "/..")
 
 notice = [("/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */" + os.linesep).encode('utf-8'), ("/* If you are missing that file, acquire a complete release at teeworlds.com.                */" + os.linesep).encode('utf-8')]
-exclude = ["src%sengine%sexternal" % (os.sep, os.sep), "src%sosxlaunch" % os.sep]
+exclude = ["src%sengine%sexternal" % (os.sep, os.sep), "src%sosxlaunch" % os.sep, "src%sbase%shash_libtomcrypt.c" % (os.sep, os.sep)]
 updated_files = 0
 
 def fix_copyright_notice(filename):
@@ -50,7 +50,8 @@ for root, dirs, files in os.walk("src"):
 		continue
 	for name in files:
 		filename = os.path.join(root, name)
-
+		if filename in exclude:
+			continue
 		if filename[-2:] != ".c" and filename[-4:] != ".cpp" and filename[-2:] != ".h":
 			continue
 

--- a/src/base/hash.c
+++ b/src/base/hash.c
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "hash.h"
 #include "hash_ctxt.h"
 

--- a/src/base/hash.h
+++ b/src/base/hash.h
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef BASE_HASH_H
 #define BASE_HASH_H
 

--- a/src/base/hash_bundled.c
+++ b/src/base/hash_bundled.c
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #if !defined(CONF_OPENSSL)
 
 #include "hash_ctxt.h"

--- a/src/base/hash_ctxt.h
+++ b/src/base/hash_ctxt.h
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef BASE_HASH_CTXT_H
 #define BASE_HASH_CTXT_H
 

--- a/src/base/hash_openssl.c
+++ b/src/base/hash_openssl.c
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #if defined(CONF_OPENSSL)
 #include "hash_ctxt.h"
 

--- a/src/base/tl/threading.h
+++ b/src/base/tl/threading.h
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef BASE_TL_THREADING_H
 #define BASE_TL_THREADING_H
 

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <base/detect.h>
 #include "SDL.h"
 #include "SDL_opengl.h"

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef ENGINE_CLIENT_BACKEND_SDL_H
 #define ENGINE_CLIENT_BACKEND_SDL_H
 

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef ENGINE_CLIENT_GRAPHICS_THREADED_H
 #define ENGINE_CLIENT_GRAPHICS_THREADED_H
 

--- a/src/engine/client/graphics_threaded_null.h
+++ b/src/engine/client/graphics_threaded_null.h
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef ENGINE_CLIENT_GRAPHICS_THREADED_NULL_H
 #define ENGINE_CLIENT_GRAPHICS_THREADED_NULL_H
 

--- a/src/engine/shared/econ.cpp
+++ b/src/engine/shared/econ.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/console.h>
 #include <engine/shared/config.h>
 

--- a/src/engine/shared/econ.h
+++ b/src/engine/shared/econ.h
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef ENGINE_SHARED_ECON_H
 #define ENGINE_SHARED_ECON_H
 

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <base/math.h>
 
 #include <engine/console.h>

--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef ENGINE_SHARED_NETBAN_H
 #define ENGINE_SHARED_NETBAN_H
 

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -1,4 +1,3 @@
-
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_SCOREBOARD_H

--- a/src/game/client/components/stats.cpp
+++ b/src/game/client/components/stats.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 #include <engine/graphics.h>

--- a/src/game/client/components/stats.h
+++ b/src/game/client/components/stats.h
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_STATS_H
 #define GAME_CLIENT_COMPONENTS_STATS_H
 

--- a/src/game/commands.h
+++ b/src/game/commands.h
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_COMMANDS_H
 #define GAME_COMMANDS_H
 

--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/console.h>
 #include <engine/storage.h>
 

--- a/src/game/editor/auto_map.h
+++ b/src/game/editor/auto_map.h
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_EDITOR_AUTO_MAP_H
 #define GAME_EDITOR_AUTO_MAP_H
 

--- a/src/test/bytes_be.cpp
+++ b/src/test/bytes_be.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "test.h"
 
 #include <gtest/gtest.h>

--- a/src/test/compression.cpp
+++ b/src/test/compression.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <gtest/gtest.h>
 
 #include <engine/shared/compression.h>

--- a/src/test/datafile.cpp
+++ b/src/test/datafile.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "test.h"
 
 #include <gtest/gtest.h>

--- a/src/test/fs.cpp
+++ b/src/test/fs.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "test.h"
 #include <gtest/gtest.h>
 

--- a/src/test/git_revision.cpp
+++ b/src/test/git_revision.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <gtest/gtest.h>
 
 #include <base/system.h>

--- a/src/test/hash.cpp
+++ b/src/test/hash.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <gtest/gtest.h>
 
 #include <base/hash_ctxt.h>

--- a/src/test/io.cpp
+++ b/src/test/io.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "test.h"
 #include <gtest/gtest.h>
 

--- a/src/test/jsonwriter.cpp
+++ b/src/test/jsonwriter.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "test.h"
 #include <gtest/gtest.h>
 

--- a/src/test/sorted_array.cpp
+++ b/src/test/sorted_array.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <gtest/gtest.h>
 
 #include <base/tl/sorted_array.h>

--- a/src/test/storage.cpp
+++ b/src/test/storage.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "test.h"
 
 #include <gtest/gtest.h>

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <gtest/gtest.h>
 
 #include <base/system.h>

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "test.h"
 #include <gtest/gtest.h>
 

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef TEST_TEST_H
 #define TEST_TEST_H
 class CTestInfo

--- a/src/test/thread.cpp
+++ b/src/test/thread.cpp
@@ -1,3 +1,5 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <gtest/gtest.h>
 
 #include <base/system.h>


### PR DESCRIPTION
- Use the current OS line endings in the copyright notice fixing script. Otherwise the script incorrectly adds the file headers to every file again, if the files are checked out with windows file endings.
- Exclude [base/hash_libtomcrypt.c](https://github.com/teeworlds/teeworlds/blob/master/src/base/hash_libtomcrypt.c) from the copyright script, as this file is in the public domain according to its file header.
- Add missing copyright notice to all files using the script.
  - `scoreboard.h` was adjusted manually, as the first line was empty and the header was therefore not detected.