### PR TITLE
Fix CLineInput::m_Hidden being uninitialized

### DIFF
--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -34,6 +34,7 @@ void CLineInput::SetBuffer(char *pStr, int MaxSize, int MaxChars)
 	{
 		m_ScrollOffset = 0;
 		m_CaretPosition = vec2(0, 0);
+		m_Hidden = false;
 	}
 	if(m_pStr && m_pStr != pLastStr)
 		UpdateStrData();


### PR DESCRIPTION
Fixes 

```
src/game/client/lineinput.h:108:33: runtime error: load of value 190, which is not a valid value for type 'bool'
    #0 0x56458d19835b in CLineInput::IsHidden() const src/game/client/lineinput.h:108
    #1 0x56458d18872b in CLineInput::GetDisplayedString() src/game/client/lineinput.cpp:110
    #2 0x56458d179bdb in CUI::DoEditBox(CLineInput*, CUIRect const*, float, int, IButtonColorFunction const*) src/game/client/ui.cpp:385
    #3 0x56458d705a3d in CEditor::DoEditBox(CLineInput*, CUIRect const*, float) src/game/editor/editor.h:775
    #4 0x56458d69edfd in CEditor::RenderFileDialog() src/game/editor/editor.cpp:2740
    #5 0x56458d6dfb2b in CEditor::Render() src/game/editor/editor.cpp:3898
    #6 0x56458d6f9ac6 in CEditor::UpdateAndRender() src/game/editor/editor.cpp:4344
    #7 0x56458cfc4b87 in CClient::Render() src/engine/client/client.cpp:793
    #8 0x56458d004583 in CClient::Run() src/engine/client/client.cpp:2133
    #9 0x56458d01db6a in main src/engine/client/client.cpp:2710
```