### PR TITLE
Improve map search for client and demo recorder/player

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -912,9 +912,9 @@ const char *CClient::LoadMapSearch(const char *pMapName, const SHA256_DIGEST *pW
 	}
 
 	// search for the map within subfolders
-	char aFilename[128];
+	char aFilename[IO_MAX_PATH_LENGTH];
 	str_format(aFilename, sizeof(aFilename), "%s.map", pMapName);
-	if(Storage()->FindFile(aFilename, "maps", IStorage::TYPE_ALL, aBuf, sizeof(aBuf)))
+	if(Storage()->FindFile(aFilename, "maps", IStorage::TYPE_ALL, aBuf, sizeof(aBuf), pWantedSha256, WantedCrc))
 		pError = LoadMap(pMapName, aBuf, pWantedSha256, WantedCrc);
 
 	return pError;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2339,18 +2339,7 @@ void CClient::DemoRecorder_Start(const char *pFilename, bool WithTimestamp)
 	if(State() != IClient::STATE_ONLINE)
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "demorec/record", "client is not online");
 	else
-	{
-		char aFilename[128];
-		if(WithTimestamp)
-		{
-			char aDate[20];
-			str_timestamp(aDate, sizeof(aDate));
-			str_format(aFilename, sizeof(aFilename), "demos/%s_%s.demo", pFilename, aDate);
-		}
-		else
-			str_format(aFilename, sizeof(aFilename), "demos/%s.demo", pFilename);
-		m_DemoRecorder.Start(aFilename, GameClient()->NetVersion(), m_aCurrentMap, m_CurrentMapSha256, m_CurrentMapCrc, "client");
-	}
+		m_DemoRecorder.Start(pFilename, WithTimestamp, GameClient()->NetVersion(), m_aCurrentMap, m_CurrentMapSha256, m_CurrentMapCrc, "client");
 }
 
 void CClient::DemoRecorder_HandleAutoStart()

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -68,6 +68,7 @@ public:
 
 	virtual void DemoRecorder_Start(const char *pFilename, bool WithTimestamp) = 0;
 	virtual void DemoRecorder_HandleAutoStart() = 0;
+	virtual void DemoRecorder_Stop(bool ErrorIfNotRecording = false) = 0;
 	virtual bool DemoRecorder_IsRecording() = 0;
 };
 

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -66,6 +66,7 @@ public:
 	virtual void Kick(int ClientID, const char *pReason) = 0;
 	virtual void ChangeMap(const char *pMap) = 0;
 
+	virtual void DemoRecorder_Start(const char *pFilename, bool WithTimestamp) = 0;
 	virtual void DemoRecorder_HandleAutoStart() = 0;
 	virtual bool DemoRecorder_IsRecording() = 0;
 };

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1606,16 +1606,7 @@ void CServer::ConShutdown(IConsole::IResult *pResult, void *pUser)
 
 void CServer::DemoRecorder_Start(const char *pFilename, bool WithTimestamp)
 {
-	char aFilename[IO_MAX_PATH_LENGTH];
-	if(WithTimestamp)
-	{
-		char aDate[20];
-		str_timestamp(aDate, sizeof(aDate));
-		str_format(aFilename, sizeof(aFilename), "demos/%s_%s.demo", pFilename, aDate);
-	}
-	else
-		str_format(aFilename, sizeof(aFilename), "demos/%s.demo", pFilename);
-	m_DemoRecorder.Start(aFilename, GameServer()->NetVersion(), m_aCurrentMap, m_CurrentMapSha256, m_CurrentMapCrc, "server");
+	m_DemoRecorder.Start(pFilename, WithTimestamp, GameServer()->NetVersion(), m_aCurrentMap, m_CurrentMapSha256, m_CurrentMapCrc, "server");
 }
 
 void CServer::DemoRecorder_HandleAutoStart()

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1243,8 +1243,7 @@ int CServer::LoadMap(const char *pMapName)
 		return 0;
 
 	// stop recording when we change map
-	if(m_DemoRecorder.IsRecording())
-		m_DemoRecorder.Stop();
+	DemoRecorder_Stop();
 
 	// reinit snapshot ids
 	m_IDPool.TimeoutIDs();
@@ -1623,8 +1622,7 @@ void CServer::DemoRecorder_HandleAutoStart()
 {
 	if(Config()->m_SvAutoDemoRecord)
 	{
-		if(m_DemoRecorder.IsRecording())
-			m_DemoRecorder.Stop();
+		DemoRecorder_Stop();
 		DemoRecorder_Start("auto/autorecord", true);
 		if(Config()->m_SvAutoDemoMax)
 		{
@@ -1633,6 +1631,12 @@ void CServer::DemoRecorder_HandleAutoStart()
 			AutoDemos.Init(Storage(), "demos/server", "autorecord", ".demo", Config()->m_SvAutoDemoMax);
 		}
 	}
+}
+
+void CServer::DemoRecorder_Stop(bool ErrorIfNotRecording)
+{
+	if(ErrorIfNotRecording || m_DemoRecorder.IsRecording())
+		m_DemoRecorder.Stop();
 }
 
 bool CServer::DemoRecorder_IsRecording()
@@ -1652,7 +1656,7 @@ void CServer::ConRecord(IConsole::IResult *pResult, void *pUser)
 
 void CServer::ConStopRecord(IConsole::IResult *pResult, void *pUser)
 {
-	((CServer *)pUser)->m_DemoRecorder.Stop();
+	((CServer *)pUser)->DemoRecorder_Stop(true);
 }
 
 void CServer::ConMapReload(IConsole::IResult *pResult, void *pUser)

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -200,6 +200,7 @@ public:
 
 	void Kick(int ClientID, const char *pReason);
 
+	void DemoRecorder_Start(const char *pFilename, bool WithTimestamp);
 	void DemoRecorder_HandleAutoStart();
 	bool DemoRecorder_IsRecording();
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -202,6 +202,7 @@ public:
 
 	void DemoRecorder_Start(const char *pFilename, bool WithTimestamp);
 	void DemoRecorder_HandleAutoStart();
+	void DemoRecorder_Stop(bool ErrorIfNotRecording = false);
 	bool DemoRecorder_IsRecording();
 
 	int64 TickStartTime(int Tick);

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -481,12 +481,11 @@ unsigned CDataFileReader::Crc() const
 
 bool CDataFileReader::CheckSha256(IOHANDLE Handle, const void *pSha256)
 {
-	// read the hash of the file
 	SHA256_CTX Sha256Ctx;
 	sha256_init(&Sha256Ctx);
 	unsigned char aBuffer[64*1024];
-	
-	while(1)
+
+	while(true)
 	{
 		unsigned Bytes = io_read(Handle, aBuffer, sizeof(aBuffer));
 		if(Bytes == 0)
@@ -497,7 +496,25 @@ bool CDataFileReader::CheckSha256(IOHANDLE Handle, const void *pSha256)
 	io_seek(Handle, 0, IOSEEK_START);
 	SHA256_DIGEST Sha256 = sha256_finish(&Sha256Ctx);
 
-	return !sha256_comp(*(const SHA256_DIGEST *)pSha256, Sha256);
+	return *(const SHA256_DIGEST *)pSha256 == Sha256;
+}
+
+bool CDataFileReader::CheckCrc(IOHANDLE Handle, const void *pCrc)
+{
+	unsigned Crc = crc32(0L, 0x0, 0);
+	unsigned char aBuffer[64*1024];
+
+	while(true)
+	{
+		unsigned Bytes = io_read(Handle, aBuffer, sizeof(aBuffer));
+		if(Bytes == 0)
+			break;
+		Crc = crc32(Crc, aBuffer, Bytes);
+	}
+
+	io_seek(Handle, 0, IOSEEK_START);
+
+	return *(const unsigned *)pCrc == Crc;
 }
 
 

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -39,6 +39,7 @@ public:
 	unsigned Crc() const;
 
 	static bool CheckSha256(IOHANDLE Handle, const void *pSha256);
+	static bool CheckCrc(IOHANDLE Handle, const void *pCrc);
 };
 
 // write access

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -43,7 +43,7 @@ int CDemoRecorder::Start(const char *pFilename, const char *pNetVersion, const c
 	}
 
 	// open mapfile
-	char aMapFilename[128];
+	char aMapFilename[IO_MAX_PATH_LENGTH];
 	// try the normal maps folder
 	str_format(aMapFilename, sizeof(aMapFilename), "maps/%s.map", pMap);
 	IOHANDLE MapFile = m_pStorage->OpenFile(aMapFilename, IOFLAG_READ, IStorage::TYPE_ALL, 0, 0, CDataFileReader::CheckSha256, &Sha256);
@@ -66,8 +66,8 @@ int CDemoRecorder::Start(const char *pFilename, const char *pNetVersion, const c
 		// search for the map within subfolders
 		char aBuf[IO_MAX_PATH_LENGTH];
 		str_format(aMapFilename, sizeof(aMapFilename), "%s.map", pMap);
-		if(m_pStorage->FindFile(aMapFilename, "maps", IStorage::TYPE_ALL, aBuf, sizeof(aBuf)))
-			MapFile = m_pStorage->OpenFile(aBuf, IOFLAG_READ, IStorage::TYPE_ALL, 0, 0, CDataFileReader::CheckSha256, &Sha256);
+		if(m_pStorage->FindFile(aMapFilename, "maps", IStorage::TYPE_ALL, aBuf, sizeof(aBuf), &Sha256, Crc))
+			MapFile = m_pStorage->OpenFile(aBuf, IOFLAG_READ, IStorage::TYPE_ALL);
 	}
 	if(!MapFile)
 	{

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -29,7 +29,7 @@ public:
 	CDemoRecorder(class CSnapshotDelta *pSnapshotDelta);
 	void Init(class IConsole *pConsole, class IStorage *pStorage);
 
-	int Start(const char *pFilename, const char *pNetversion, const char *pMap, SHA256_DIGEST MapSha256, unsigned MapCrc, const char *pType);
+	int Start(const char *pFilename, bool WithTimestamp, const char *pNetversion, const char *pMap, SHA256_DIGEST MapSha256, unsigned MapCrc, const char *pType);
 	int Stop();
 	void AddDemoMarker();
 

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -28,6 +28,7 @@ public:
 	virtual bool ReadFile(const char *pFilename, int Type, void **ppResult, unsigned *pResultLen) = 0;
 	virtual char *ReadFileStr(const char *pFilename, int Type) = 0;
 	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize) = 0;
+	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize, const SHA256_DIGEST *pWantedSha256, unsigned WantedCrc) = 0;
 	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize, const SHA256_DIGEST *pWantedSha256, unsigned WantedCrc, unsigned WantedSize) = 0;
 	virtual bool RemoveFile(const char *pFilename, int Type) = 0;
 	virtual bool RenameFile(const char* pOldFilename, const char* pNewFilename, int Type) = 0;

--- a/src/test/storage.cpp
+++ b/src/test/storage.cpp
@@ -32,6 +32,12 @@ TEST(Storage, FindFile)
 	EXPECT_TRUE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), &Sha256, 0x3bb935c6, 5));
 	EXPECT_STREQ(aFound, aFilenameWithDot);
 
+	EXPECT_TRUE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), 0, 0x3bb935c6));
+	EXPECT_STREQ(aFound, aFilenameWithDot);
+
+	EXPECT_TRUE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), &Sha256, 0x3bb935c6));
+	EXPECT_STREQ(aFound, aFilenameWithDot);
+
 	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), 0, 0, 0));
 	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), 0, 0x3bb935c6, 0));
 	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), 0, 0, 5));
@@ -40,6 +46,12 @@ TEST(Storage, FindFile)
 
 	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), &WrongSha256, 0x3bb935c6, 5));
 	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), &SHA256_ZEROED, 0x3bb935c6, 5));
+
+	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), 0, 0));
+	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), 0, 0x3bb935c5));
+
+	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), &WrongSha256, 0x3bb935c6));
+	EXPECT_FALSE(pStorage->FindFile(Info.m_aFilename, ".", IStorage::TYPE_ALL, aFound, sizeof(aFound), &SHA256_ZEROED, 0x3bb935c6));
 
 	EXPECT_TRUE(pStorage->RemoveFile(Info.m_aFilename, IStorage::TYPE_SAVE));
 }


### PR DESCRIPTION
The map search for client and demo recorder now scans all subfolders for a map with correct name _and_ hash instead of stopping on the first map with the correct name, which may not have the correct hash.

The map search for demo player now scans the maps folder and its subfolders for a map with the name and CRC specified by the demo, instead of only looking in the downloadedmaps folder.

Some refactoring to reduce duplicate code.