### PR TITLE
Refactoring: Add CLineInputBuffered, a CLineInput owning a statically sized buffer

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -21,12 +21,6 @@
 #include "chat.h"
 #include "binds.h"
 
-CChat::CChat()
-{
-	m_aInputBuf[0] = '\0';
-	m_Input.SetBuffer(m_aInputBuf, sizeof(m_aInputBuf));
-}
-
 void CChat::OnReset()
 {
 	if(Client()->State() == IClient::STATE_OFFLINE || Client()->State() == IClient::STATE_DEMOPLAYBACK)

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -18,8 +18,7 @@ class CChat : public CComponent
 		MAX_LINE_LENGTH = 512,
 	};
 
-	char m_aInputBuf[MAX_LINE_LENGTH];
-	CLineInput m_Input;
+	CLineInputBuffered<static_cast<int>(MAX_LINE_LENGTH)> m_Input;
 
 	struct CLine
 	{
@@ -131,7 +130,6 @@ public:
 	void EnableMode(int Mode, const char *pText = 0x0);
 	void Say(int Mode, const char *pLine);
 
-	CChat();
 	virtual void OnInit();
 	virtual void OnReset();
 	virtual void OnMapLoad();

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -75,8 +75,6 @@ CGameConsole::CInstance::CInstance(int Type)
 	Reset();
 
 	m_IsCommand = false;
-	m_aInputBuf[0] = '\0';
-	m_Input.SetBuffer(m_aInputBuf, sizeof(m_aInputBuf));
 }
 
 void CGameConsole::CInstance::Init(CGameConsole *pGameConsole)

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -21,8 +21,7 @@ class CGameConsole : public CComponent
 		TStaticRingBuffer<char, 64*1024, CRingBufferBase::FLAG_RECYCLE> m_History;
 		char *m_pHistoryEntry;
 
-		char m_aInputBuf[256];
-		CLineInput m_Input;
+		CLineInputBuffered<256> m_Input;
 		const char *m_pName;
 		int m_Type;
 		int m_BacklogActPage;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -74,7 +74,6 @@ CMenus::CMenus()
 
 	str_copy(m_aCurrentDemoFolder, "demos", sizeof(m_aCurrentDemoFolder));
 	m_aCallvoteReason[0] = 0;
-	m_aFilterString[0] = 0;
 
 	m_ActiveListBox = ACTLB_NONE;
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -73,7 +73,6 @@ CMenus::CMenus()
 	m_LastInput = time_get();
 
 	str_copy(m_aCurrentDemoFolder, "demos", sizeof(m_aCurrentDemoFolder));
-	m_aCallvoteReason[0] = 0;
 
 	m_ActiveListBox = ACTLB_NONE;
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -54,8 +54,6 @@ CMenus::CMenus()
 	m_NeedRestartSound = false;
 	m_NeedRestartPlayer = false;
 	m_TeePartSelected = SKINPART_BODY;
-	m_aSaveSkinName[0] = '\0';
-	m_SkinNameInput.SetBuffer(m_aSaveSkinName, sizeof(m_aSaveSkinName), MAX_SKIN_LENGTH);
 	m_RefreshSkinSelector = true;
 	m_pSelectedSkin = 0;
 	m_MenuActive = true;
@@ -1519,13 +1517,13 @@ void CMenus::RenderMenu(CUIRect Screen)
 				m_Popup = POPUP_NONE;
 
 			static CButtonContainer s_ButtonYes;
-			if(DoButton_Menu(&s_ButtonYes, Localize("Yes"), !m_aSaveSkinName[0], &Yes) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+			if(DoButton_Menu(&s_ButtonYes, Localize("Yes"), !m_SkinNameInput.GetLength(), &Yes) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 			{
-				if(m_aSaveSkinName[0])
+				if(m_SkinNameInput.GetLength())
 				{
-					if(m_aSaveSkinName[0] != 'x' && m_aSaveSkinName[1] != '_')
+					if(m_SkinNameInput.GetString()[0] != 'x' && m_SkinNameInput.GetString()[1] != '_')
 					{
-						if(m_pClient->m_pSkins->SaveSkinfile(m_aSaveSkinName))
+						if(m_pClient->m_pSkins->SaveSkinfile(m_SkinNameInput.GetString()))
 						{
 							m_Popup = POPUP_NONE;
 							m_RefreshSkinSelector = true;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -73,8 +73,6 @@ CMenus::CMenus()
 	m_LastInput = time_get();
 
 	str_copy(m_aCurrentDemoFolder, "demos", sizeof(m_aCurrentDemoFolder));
-	m_aCurrentDemoFile[0] = '\0';
-	m_DemoNameInput.SetBuffer(m_aCurrentDemoFile, sizeof(m_aCurrentDemoFile));
 	m_aCallvoteReason[0] = 0;
 	m_aFilterString[0] = 0;
 
@@ -1467,9 +1465,9 @@ void CMenus::RenderMenu(CUIRect Screen)
 				m_Popup = POPUP_NONE;
 
 			static CButtonContainer s_ButtonYes;
-			if(DoButton_Menu(&s_ButtonYes, Localize("Yes"), !m_aCurrentDemoFile[0], &Yes) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+			if(DoButton_Menu(&s_ButtonYes, Localize("Yes"), !m_DemoNameInput.GetLength(), &Yes) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 			{
-				if(m_aCurrentDemoFile[0])
+				if(m_DemoNameInput.GetLength())
 				{
 					m_Popup = POPUP_NONE;
 					// rename demo
@@ -1479,14 +1477,13 @@ void CMenus::RenderMenu(CUIRect Screen)
 						const int ExtLength = str_length(pExt);
 						char aBufOld[IO_MAX_PATH_LENGTH];
 						str_format(aBufOld, sizeof(aBufOld), "%s/%s", m_aCurrentDemoFolder, m_lDemos[m_DemolistSelectedIndex].m_aFilename);
-						int Length = str_length(m_aCurrentDemoFile);
-						if(Length < ExtLength || str_comp(m_aCurrentDemoFile + Length - ExtLength, pExt))
-							str_append(m_aCurrentDemoFile, pExt, sizeof(m_aCurrentDemoFile));
+						if(m_DemoNameInput.GetLength() < ExtLength || str_comp(m_DemoNameInput.GetString() + m_DemoNameInput.GetLength() - ExtLength, pExt))
+							m_DemoNameInput.Append(pExt);
 						char aPathNew[IO_MAX_PATH_LENGTH];
-						str_format(aPathNew, sizeof(aPathNew), "%s/%s", m_aCurrentDemoFolder, m_aCurrentDemoFile);
+						str_format(aPathNew, sizeof(aPathNew), "%s/%s", m_aCurrentDemoFolder, m_DemoNameInput.GetString());
 						if(Storage()->RenameFile(aBufOld, aPathNew, m_lDemos[m_DemolistSelectedIndex].m_StorageType))
 						{
-							str_copy(m_aDemolistPreviousSelection, m_aCurrentDemoFile, sizeof(m_aDemolistPreviousSelection));
+							str_copy(m_aDemolistPreviousSelection, m_DemoNameInput.GetString(), sizeof(m_aDemolistPreviousSelection));
 							DemolistPopulate();
 							DemolistOnUpdate(false);
 						}

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -197,8 +197,7 @@ private:
 	bool m_NeedRestartGraphics;
 	bool m_NeedRestartSound;
 	int m_TeePartSelected;
-	char m_aSaveSkinName[MAX_SKIN_ARRAY_SIZE];
-	CLineInput m_SkinNameInput;
+	CLineInputBuffered<static_cast<int>(MAX_SKIN_ARRAY_SIZE), static_cast<int>(MAX_SKIN_LENGTH)> m_SkinNameInput;
 
 	bool m_RefreshSkinSelector;
 	const CSkins::CSkin *m_pSelectedSkin;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -218,7 +218,7 @@ private:
 	// for call vote
 	int m_CallvoteSelectedOption;
 	int m_CallvoteSelectedPlayer;
-	char m_aFilterString[VOTE_REASON_LENGTH];
+	CLineInputBuffered<static_cast<int>(VOTE_REASON_LENGTH)> m_CallvoteFilterInput;
 	char m_aCallvoteReason[VOTE_REASON_LENGTH];
 
 	// demo

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -219,7 +219,7 @@ private:
 	int m_CallvoteSelectedOption;
 	int m_CallvoteSelectedPlayer;
 	CLineInputBuffered<static_cast<int>(VOTE_REASON_LENGTH)> m_CallvoteFilterInput;
-	char m_aCallvoteReason[VOTE_REASON_LENGTH];
+	CLineInputBuffered<static_cast<int>(VOTE_REASON_LENGTH)> m_CallvoteReasonInput;
 
 	// demo
 	enum

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -303,8 +303,7 @@ private:
 
 	sorted_array<CDemoItem> m_lDemos;
 	char m_aCurrentDemoFolder[IO_MAX_PATH_LENGTH];
-	char m_aCurrentDemoFile[IO_MAX_PATH_LENGTH];
-	CLineInput m_DemoNameInput;
+	CLineInputBuffered<static_cast<int>(IO_MAX_PATH_LENGTH)> m_DemoNameInput;
 	int m_DemolistSelectedIndex;
 	bool m_DemolistSelectedIsDir;
 	int m_DemolistStorageType;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1734,21 +1734,20 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 		ButtonLine.VSplitRight(ButtonLine.h, &ButtonLine, &AddExlButton);
 		ButtonLine.VSplitRight(ButtonLine.h, &EditBox, &AddIncButton);
 
-		static char s_aGametype[16] = { 0 };
-		static CLineInput s_GametypeInput(s_aGametype, sizeof(s_aGametype));
+		static CLineInputBuffered<16> s_GametypeInput;
 		UI()->DoEditBox(&s_GametypeInput, &EditBox, FontSize, CUIRect::CORNER_L);
 
 		static CButtonContainer s_AddInclusiveGametype;
-		if(DoButton_Menu(&s_AddInclusiveGametype, "+", 0, &AddIncButton, 0, 0) && s_aGametype[0])
+		if(DoButton_Menu(&s_AddInclusiveGametype, "+", 0, &AddIncButton, 0, 0) && s_GametypeInput.GetLength())
 		{
 			for(int i = 0; i < CServerFilterInfo::MAX_GAMETYPES; ++i)
 			{
 				if(!FilterInfo.m_aGametype[i][0])
 				{
-					str_copy(FilterInfo.m_aGametype[i], s_aGametype, sizeof(FilterInfo.m_aGametype[i]));
+					str_copy(FilterInfo.m_aGametype[i], s_GametypeInput.GetString(), sizeof(FilterInfo.m_aGametype[i]));
 					FilterInfo.m_aGametypeExclusive[i] = false;
 					UpdateFilter = true;
-					s_aGametype[0] = 0;
+					s_GametypeInput.Clear();
 					break;
 				}
 			}
@@ -1756,16 +1755,16 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 		UI()->DoTooltip(&s_AddInclusiveGametype, &AddIncButton, Localize("Include servers with this gametype."));
 
 		static CButtonContainer s_AddExclusiveGametype;
-		if(DoButton_Menu(&s_AddExclusiveGametype, "-", 0, &AddExlButton, 0, CUIRect::CORNER_R) && s_aGametype[0])
+		if(DoButton_Menu(&s_AddExclusiveGametype, "-", 0, &AddExlButton, 0, CUIRect::CORNER_R) && s_GametypeInput.GetLength())
 		{
 			for(int i = 0; i < CServerFilterInfo::MAX_GAMETYPES; ++i)
 			{
 				if(!FilterInfo.m_aGametype[i][0])
 				{
-					str_copy(FilterInfo.m_aGametype[i], s_aGametype, sizeof(FilterInfo.m_aGametype[i]));
+					str_copy(FilterInfo.m_aGametype[i], s_GametypeInput.GetString(), sizeof(FilterInfo.m_aGametype[i]));
 					FilterInfo.m_aGametypeExclusive[i] = true;
 					UpdateFilter = true;
-					s_aGametype[0] = 0;
+					s_GametypeInput.Clear();
 					break;
 				}
 			}

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1569,13 +1569,12 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 	// new filter
 	ServerFilter.HSplitBottom(LineSize, &ServerFilter, &Button);
 	Button.VSplitLeft(60.0f, &Icon, &Button);
-	static char s_aFilterName[32] = { 0 };
-	static CLineInput s_FilterInput(s_aFilterName, sizeof(s_aFilterName));
+	static CLineInputBuffered<32> s_FilterInput;
 	UI()->DoEditBox(&s_FilterInput, &Icon, FontSize, CUIRect::CORNER_L);
 	Button.Draw(vec4(1.0f, 1.0f, 1.0f, 0.25f), 5.0f, CUIRect::CORNER_R);
 	Button.VSplitLeft(Button.h, &Icon, &Label);
 	UI()->DoLabel(&Label, Localize("New filter"), FontSize, TEXTALIGN_ML);
-	if(s_aFilterName[0])
+	if(s_FilterInput.GetLength())
 	{
 		DoIcon(IMAGE_FRIENDICONS, UI()->MouseHovered(&Button) ? SPRITE_FRIEND_PLUS_A : SPRITE_FRIEND_PLUS_B, &Icon);
 		static CButtonContainer s_AddFilter;
@@ -1584,9 +1583,9 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 			CBrowserFilter *pSelectedFilter = GetSelectedBrowserFilter();
 			if(pSelectedFilter)
 				pSelectedFilter->Switch();
-			m_lFilters.add(CBrowserFilter(CBrowserFilter::FILTER_CUSTOM, s_aFilterName, ServerBrowser()));
+			m_lFilters.add(CBrowserFilter(CBrowserFilter::FILTER_CUSTOM, s_FilterInput.GetString(), ServerBrowser()));
 			m_lFilters[m_lFilters.size()-1].Switch();
-			s_aFilterName[0] = 0;
+			s_FilterInput.Clear();
 			Client()->ServerBrowserUpdate();
 		}
 	}

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1507,37 +1507,35 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 	BottomArea.HSplitTop(SpacingH, 0, &BottomArea);
 	Button.VSplitLeft(50.0f, &Label, &Button);
 	UI()->DoLabel(&Label, Localize("Name"), FontSize, TEXTALIGN_ML);
-	static char s_aName[MAX_NAME_ARRAY_SIZE] = { 0 };
-	static CLineInput s_NameInput(s_aName, sizeof(s_aName), MAX_NAME_LENGTH);
+	static CLineInputBuffered<static_cast<int>(MAX_NAME_ARRAY_SIZE), static_cast<int>(MAX_NAME_LENGTH)> s_NameInput;
 	UI()->DoEditBox(&s_NameInput, &Button, Button.h*CUI::ms_FontmodHeight*0.8f);
 
 	BottomArea.HSplitTop(HeaderHeight, &Button, &BottomArea);
 	BottomArea.HSplitTop(SpacingH, 0, &BottomArea);
 	Button.VSplitLeft(50.0f, &Label, &Button);
 	UI()->DoLabel(&Label, Localize("Clan"), FontSize, TEXTALIGN_ML);
-	static char s_aClan[MAX_CLAN_ARRAY_SIZE] = { 0 };
-	static CLineInput s_ClanInput(s_aClan, sizeof(s_aClan), MAX_CLAN_LENGTH);
+	static CLineInputBuffered<static_cast<int>(MAX_CLAN_ARRAY_SIZE), static_cast<int>(MAX_CLAN_LENGTH)> s_ClanInput;
 	UI()->DoEditBox(&s_ClanInput, &Button, Button.h*CUI::ms_FontmodHeight*0.8f);
 
 	BottomArea.HSplitTop(HeaderHeight, &Button, &BottomArea);
 	Button.Draw(vec4(1.0f, 1.0f, 1.0f, 0.25f));
-	if(s_aName[0] || s_aClan[0])
+	if(s_NameInput.GetLength() || s_ClanInput.GetLength())
 		Button.VSplitLeft(Button.h, &Icon, &Label);
 	else
 		Label = Button;
 
-	const char *pButtonText = (!s_aName[0] && !s_aClan[0]) ? Localize("Add friend/clan") : s_aName[0] ? Localize("Add friend") : Localize("Add clan");
+	const char *pButtonText = (!s_NameInput.GetLength() && !s_ClanInput.GetLength()) ? Localize("Add friend/clan") : s_NameInput.GetLength() ? Localize("Add friend") : Localize("Add clan");
 	UI()->DoLabel(&Label, pButtonText, FontSize, TEXTALIGN_MC);
-	if(s_aName[0] || s_aClan[0])
+	if(s_NameInput.GetLength() || s_ClanInput.GetLength())
 		DoIcon(IMAGE_FRIENDICONS, UI()->MouseHovered(&Button) ? SPRITE_FRIEND_PLUS_A : SPRITE_FRIEND_PLUS_B, &Icon);
 	static CButtonContainer s_AddFriend;
-	if((s_aName[0] || s_aClan[0]) && UI()->DoButtonLogic(&s_AddFriend, &Button))
+	if((s_NameInput.GetLength() || s_ClanInput.GetLength()) && UI()->DoButtonLogic(&s_AddFriend, &Button))
 	{
-		m_pClient->Friends()->AddFriend(s_aName, s_aClan);
+		m_pClient->Friends()->AddFriend(s_NameInput.GetString(), s_ClanInput.GetString());
 		FriendlistOnUpdate();
 		Client()->ServerBrowserUpdate();
-		s_aName[0] = 0;
-		s_aClan[0] = 0;
+		s_NameInput.Clear();
+		s_ClanInput.Clear();
 	}
 
 	// delete friend

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1816,11 +1816,10 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 	ServerFilter.HSplitTop(LineSize, &Button, &ServerFilter);
 	UI()->DoLabel(&Button, Localize("Server address:"), FontSize, TEXTALIGN_LEFT);
 	Button.VSplitRight(60.0f, 0, &Button);
-	static char s_aAddressFilter[sizeof(FilterInfo.m_aAddress)];
-	static CLineInput s_AddressInput(s_aAddressFilter, sizeof(s_aAddressFilter));
+	static CLineInputBuffered<static_cast<int>(sizeof(FilterInfo.m_aAddress))> s_AddressInput;
 	if(UI()->DoEditBox(&s_AddressInput, &Button, FontSize))
 	{
-		str_copy(FilterInfo.m_aAddress, s_aAddressFilter, sizeof(FilterInfo.m_aAddress));
+		str_copy(FilterInfo.m_aAddress, s_AddressInput.GetString(), sizeof(FilterInfo.m_aAddress));
 		UpdateFilter = true;
 	}
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -518,7 +518,7 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 
 	for(const CVoteOptionClient *pOption = m_pClient->m_pVoting->FirstVoteOption(); pOption; pOption = pOption->m_pNext)
 	{
-		if(m_aFilterString[0] && !pOption->m_IsSubheader && !str_find_nocase(pOption->m_aDescription, m_aFilterString))
+		if(m_CallvoteFilterInput.GetLength() && !pOption->m_IsSubheader && !str_find_nocase(pOption->m_aDescription, m_CallvoteFilterInput.GetString()))
 			continue; // no match found
 
 		if(!pOption->m_aDescription[0])
@@ -619,7 +619,7 @@ void CMenus::HandleCallvote(int Page, bool Force)
 		int RealIndex = 0, FilteredIndex = 0;
 		for(const CVoteOptionClient *pOption = m_pClient->m_pVoting->FirstVoteOption(); pOption; pOption = pOption->m_pNext, RealIndex++)
 		{
-			if(m_aFilterString[0] && !pOption->m_IsSubheader && !str_find_nocase(pOption->m_aDescription, m_aFilterString))
+			if(m_CallvoteFilterInput.GetLength() && !pOption->m_IsSubheader && !str_find_nocase(pOption->m_aDescription, m_CallvoteFilterInput.GetString()))
 				continue; // no match found
 
 			if(!pOption->m_aDescription[0])
@@ -765,8 +765,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 				Search.VSplitLeft(TextRender()->TextWidth(FontSize, pSearchLabel, -1) + 10.0f, &Label, &Search);
 				Label.y += 2.0f;
 				UI()->DoLabel(&Label, pSearchLabel, FontSize, TEXTALIGN_LEFT);
-				static CLineInput s_FilterInput(m_aFilterString, sizeof(m_aFilterString));
-				if(UI()->DoEditBox(&s_FilterInput, &Search, FontSize))
+				if(UI()->DoEditBox(&m_CallvoteFilterInput, &Search, FontSize))
 					m_CallvoteSelectedOption = 0;
 			}
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -840,21 +840,20 @@ void CMenus::RenderServerControl(CUIRect MainView)
 				Bottom.VSplitLeft(2*Spacing, 0, &Button);
 				UI()->DoLabel(&Button, Localize("Vote command:"), FontSize, TEXTALIGN_LEFT);
 
-				static char s_aVoteDescription[VOTE_DESC_LENGTH] = {0};
-				static char s_aVoteCommand[VOTE_CMD_LENGTH] = {0};
+				static CLineInputBuffered<static_cast<int>(VOTE_DESC_LENGTH)> s_DescriptionInput;
+				static CLineInputBuffered<static_cast<int>(VOTE_CMD_LENGTH)> s_CommandInput;
+
 				Extended.HSplitTop(LineHeight, &Bottom, &Extended);
 				Bottom.VSplitRight(ColumnWidth, &Bottom, &Button);
 				static CButtonContainer s_AddVoteButton;
 				if(DoButton_Menu(&s_AddVoteButton, Localize("Add"), 0, &Button))
-					if(s_aVoteDescription[0] != 0 && s_aVoteCommand[0] != 0)
-						m_pClient->m_pVoting->RconAddVoteOption(s_aVoteDescription, s_aVoteCommand);
+					if(s_DescriptionInput.GetLength() && s_CommandInput.GetLength())
+						m_pClient->m_pVoting->RconAddVoteOption(s_DescriptionInput.GetString(), s_CommandInput.GetString());
 
 				Bottom.VSplitLeft(2*ColumnWidth+Spacing, &Button, &Bottom);
-				static CLineInput s_DescriptionInput(s_aVoteDescription, sizeof(s_aVoteDescription));
 				UI()->DoEditBox(&s_DescriptionInput, &Button, FontSize);
 
 				Bottom.VMargin(2*Spacing, &Button);
-				static CLineInput s_CommandInput(s_aVoteCommand, sizeof(s_aVoteCommand));
 				UI()->DoEditBox(&s_CommandInput, &Button, FontSize);
 			}
 		}

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -630,14 +630,14 @@ void CMenus::HandleCallvote(int Page, bool Force)
 
 			FilteredIndex++;
 		}
-		m_pClient->m_pVoting->CallvoteOption(RealIndex, m_aCallvoteReason, Force);
+		m_pClient->m_pVoting->CallvoteOption(RealIndex, m_CallvoteReasonInput.GetString(), Force);
 	}
 	else if(Page == 1)
 	{
 		if(m_CallvoteSelectedPlayer >= 0 && m_CallvoteSelectedPlayer < MAX_CLIENTS &&
 			m_pClient->m_aClients[m_CallvoteSelectedPlayer].m_Active)
 		{
-			m_pClient->m_pVoting->CallvoteKick(m_CallvoteSelectedPlayer, m_aCallvoteReason, Force);
+			m_pClient->m_pVoting->CallvoteKick(m_CallvoteSelectedPlayer, m_CallvoteReasonInput.GetString(), Force);
 			SetActive(false);
 		}
 	}
@@ -646,7 +646,7 @@ void CMenus::HandleCallvote(int Page, bool Force)
 		if(m_CallvoteSelectedPlayer >= 0 && m_CallvoteSelectedPlayer < MAX_CLIENTS &&
 			m_pClient->m_aClients[m_CallvoteSelectedPlayer].m_Active)
 		{
-			m_pClient->m_pVoting->CallvoteSpectate(m_CallvoteSelectedPlayer, m_aCallvoteReason, Force);
+			m_pClient->m_pVoting->CallvoteSpectate(m_CallvoteSelectedPlayer, m_CallvoteReasonInput.GetString(), Force);
 			SetActive(false);
 		}
 	}
@@ -788,20 +788,19 @@ void CMenus::RenderServerControl(CUIRect MainView)
 				Reason.VSplitLeft(TextRender()->TextWidth(FontSize, pReasonLabel, -1) + 10.0f, &Label, &Reason);
 				Label.y += 2.0f;
 				UI()->DoLabel(&Label, pReasonLabel, FontSize, TEXTALIGN_LEFT);
-				static CLineInput s_ReasonInput(m_aCallvoteReason, sizeof(m_aCallvoteReason));
-				UI()->DoEditBox(&s_ReasonInput, &Reason, FontSize, CUIRect::CORNER_L);
+				UI()->DoEditBox(&m_CallvoteReasonInput, &Reason, FontSize, CUIRect::CORNER_L);
 
 				// clear button
 				static CButtonContainer s_ClearButton;
 				if(DoButton_SpriteID(&s_ClearButton, IMAGE_TOOLICONS, SPRITE_TOOL_X_A, false, &ClearButton, CUIRect::CORNER_R, 5.0f, true))
-					m_aCallvoteReason[0] = 0;
+					m_CallvoteReasonInput.Clear();
 
 				// call vote button
 				static CButtonContainer s_CallVoteButton;
 				if(DoButton_Menu(&s_CallVoteButton, Localize("Call vote"), 0, &CallVoteButton) || DoCallVote)
 				{
 					HandleCallvote(s_ControlPage, false);
-					m_aCallvoteReason[0] = 0;
+					m_CallvoteReasonInput.Clear();
 				}
 			}
 		}
@@ -820,7 +819,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 			if(DoButton_Menu(&s_ForceVoteButton, Localize("Force vote"), 0, &Button))
 			{
 				HandleCallvote(s_ControlPage, true);
-				m_aCallvoteReason[0] = 0;
+				m_CallvoteReasonInput.Clear();
 			}
 
 			if(s_ControlPage == 0)

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -118,4 +118,17 @@ public:
 	void Deactivate();
 };
 
+template<int MaxSize, int MaxChars = MaxSize>
+class CLineInputBuffered : public CLineInput
+{
+	char m_aBuffer[MaxSize];
+
+public:
+	CLineInputBuffered() : CLineInput()
+	{
+		m_aBuffer[0] = 0;
+		SetBuffer(m_aBuffer, MaxSize, MaxChars);
+	}
+};
+
 #endif

--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -13,8 +13,6 @@ CListBox::CListBox()
 {
 	m_ScrollOffset = vec2(0,0);
 	m_ListBoxUpdateScroll = false;
-	m_aFilterString[0] = '\0';
-	m_FilterInput.SetBuffer(m_aFilterString, sizeof(m_aFilterString));
 }
 
 void CListBox::DoBegin(const CUIRect *pRect)
@@ -228,5 +226,5 @@ int CListBox::DoEnd()
 
 bool CListBox::FilterMatches(const char *pNeedle) const
 {
-	return !m_aFilterString[0] || str_find_nocase(pNeedle, m_aFilterString);
+	return !m_FilterInput.GetLength() || str_find_nocase(pNeedle, m_FilterInput.GetString());
 }

--- a/src/game/client/ui_listbox.h
+++ b/src/game/client/ui_listbox.h
@@ -32,8 +32,7 @@ private:
 	float m_FooterHeight;
 	CScrollRegion m_ScrollRegion;
 	vec2 m_ScrollOffset;
-	CLineInput m_FilterInput;
-	char m_aFilterString[128];
+	CLineInputBuffered<128> m_FilterInput;
 	int m_BackgroundCorners;
 
 protected:

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2740,18 +2740,15 @@ void CEditor::RenderFileDialog()
 		if(DoEditBox(&m_FileDialogFileNameInput, &FileBox, 10.0f))
 		{
 			// remove '/' and '\'
-			char aTempFileName[sizeof(m_aFileDialogFileName)];
-			str_copy(aTempFileName, m_aFileDialogFileName, sizeof(aTempFileName));
-			for(int i = 0; aTempFileName[i]; ++i)
-				if(aTempFileName[i] == '/' || aTempFileName[i] == '\\')
-					str_copy(&aTempFileName[i], &aTempFileName[i+1], (int)(sizeof(aTempFileName))-i);
-			m_FileDialogFileNameInput.Set(aTempFileName);
+			for(int i = 0; m_FileDialogFileNameInput.GetString()[i]; ++i)
+				if(m_FileDialogFileNameInput.GetString()[i] == '/' || m_FileDialogFileNameInput.GetString()[i] == '\\')
+					m_FileDialogFileNameInput.SetRange(m_FileDialogFileNameInput.GetString() + i + 1, i, m_FileDialogFileNameInput.GetLength());
 			m_FilesSelectedIndex = -1;
 			m_aFilesSelectedName[0] = '\0';
 			// find first valid entry, if it exists
 			for(int i = 0; i < m_FilteredFileList.size(); i++)
 			{
-				if(str_comp_nocase(m_FilteredFileList[i]->m_aName, m_aFileDialogFileName) == 0)
+				if(str_comp_nocase(m_FilteredFileList[i]->m_aName, m_FileDialogFileNameInput.GetString()) == 0)
 				{
 					m_FilesSelectedIndex = i;
 					str_copy(m_aFilesSelectedName, m_FilteredFileList[i]->m_aName, sizeof(m_aFilesSelectedName));
@@ -2913,7 +2910,7 @@ void CEditor::RenderFileDialog()
 		}
 		else // file
 		{
-			str_format(m_aFileSaveName, sizeof(m_aFileSaveName), "%s/%s", m_pFileDialogPath, m_aFileDialogFileName);
+			str_format(m_aFileSaveName, sizeof(m_aFileSaveName), "%s/%s", m_pFileDialogPath, m_FileDialogFileNameInput.GetString());
 			if(!str_comp(m_pFileDialogButtonText, "Save"))
 			{
 				IOHANDLE File = Storage()->OpenFile(m_aFileSaveName, IOFLAG_READ, IStorage::TYPE_SAVE);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2773,13 +2773,13 @@ void CEditor::RenderFileDialog()
 			{
 				m_FilesSelectedIndex = -1;
 			}
-			else if(m_FilesSelectedIndex == -1 || (m_aFileDialogFilterString[0] && !str_find_nocase(m_FilteredFileList[m_FilesSelectedIndex]->m_aName, m_aFileDialogFilterString)))
+			else if(m_FilesSelectedIndex == -1 || (m_FileDialogFilterInput.GetLength() && !str_find_nocase(m_FilteredFileList[m_FilesSelectedIndex]->m_aName, m_FileDialogFilterInput.GetString())))
 			{
 				// we need to refresh selection
 				m_FilesSelectedIndex = -1;
 				for(int i = 0; i < m_FilteredFileList.size(); i++)
 				{
-					if(str_find_nocase(m_FilteredFileList[i]->m_aName, m_aFileDialogFilterString))
+					if(str_find_nocase(m_FilteredFileList[i]->m_aName, m_FileDialogFilterInput.GetString()))
 					{
 						m_FilesSelectedIndex = i;
 						break;
@@ -2971,7 +2971,7 @@ void CEditor::RefreshFilteredFileList()
 	m_FilteredFileList.clear();
 	for(int i = 0; i < m_CompleteFileList.size(); i++)
 	{
-		if(!m_aFileDialogFilterString[0] || str_find_nocase(m_CompleteFileList[i].m_aName, m_aFileDialogFilterString))
+		if(!m_FileDialogFilterInput.GetLength() || str_find_nocase(m_CompleteFileList[i].m_aName, m_FileDialogFilterInput.GetString()))
 		{
 			m_FilteredFileList.add(&m_CompleteFileList[i]);
 		}

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2948,7 +2948,7 @@ void CEditor::RenderFileDialog()
 			m_FileDialogNewFolderNameInput.Clear();
 			m_aFileDialogErrString[0] = 0;
 			UI()->DoPopupMenu(Width/2.0f-200.0f, Height/2.0f-100.0f, 400.0f, 200.0f, this, PopupNewFolder);
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(&m_FileDialogNewFolderNameInput);
 		}
 
 		ButtonBar.VSplitLeft(40.0f, 0, &ButtonBar);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2945,7 +2945,7 @@ void CEditor::RenderFileDialog()
 		static int s_NewFolderButton = 0;
 		if(DoButton_Editor(&s_NewFolderButton, "New folder", 0, &Button, 0, 0))
 		{
-			m_aFileDialogNewFolderName[0] = 0;
+			m_FileDialogNewFolderNameInput.Clear();
 			m_aFileDialogErrString[0] = 0;
 			UI()->DoPopupMenu(Width/2.0f-200.0f, Height/2.0f-100.0f, 400.0f, 200.0f, this, PopupNewFolder);
 			UI()->SetActiveItem(0);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2741,8 +2741,13 @@ void CEditor::RenderFileDialog()
 		{
 			// remove '/' and '\'
 			for(int i = 0; m_FileDialogFileNameInput.GetString()[i]; ++i)
+			{
 				if(m_FileDialogFileNameInput.GetString()[i] == '/' || m_FileDialogFileNameInput.GetString()[i] == '\\')
+				{
 					m_FileDialogFileNameInput.SetRange(m_FileDialogFileNameInput.GetString() + i + 1, i, m_FileDialogFileNameInput.GetLength());
+					--i;
+				}
+			}
 			m_FilesSelectedIndex = -1;
 			m_aFilesSelectedName[0] = '\0';
 			// find first valid entry, if it exists

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -547,8 +547,6 @@ public:
 		m_FileDialogStorageType = 0;
 		m_aFileDialogFileName[0] = '\0';
 		m_FileDialogFileNameInput.SetBuffer(m_aFileDialogFileName, sizeof(m_aFileDialogFileName));
-		m_aFileDialogFilterString[0] = '\0';
-		m_FileDialogFilterInput.SetBuffer(m_aFileDialogFilterString, sizeof(m_aFileDialogFilterString));
 		m_pFileDialogTitle = 0;
 		m_pFileDialogButtonText = 0;
 		m_pFileDialogUser = 0;
@@ -671,8 +669,7 @@ public:
 	int m_FileDialogFileType;
 	int m_FilesSelectedIndex;
 	char m_aFilesSelectedName[IO_MAX_PATH_LENGTH];
-	char m_aFileDialogFilterString[64];
-	CLineInput m_FileDialogFilterInput;
+	CLineInputBuffered<64> m_FileDialogFilterInput;
 	CLineInputBuffered<64> m_FileDialogNewFolderNameInput;
 	char m_aFileDialogErrString[64];
 	IGraphics::CTextureHandle m_FilePreviewImage;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -673,7 +673,7 @@ public:
 	char m_aFilesSelectedName[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogFilterString[64];
 	CLineInput m_FileDialogFilterInput;
-	char m_aFileDialogNewFolderName[64];
+	CLineInputBuffered<64> m_FileDialogNewFolderNameInput;
 	char m_aFileDialogErrString[64];
 	IGraphics::CTextureHandle m_FilePreviewImage;
 	bool m_PreviewImageIsLoaded;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -545,8 +545,6 @@ public:
 		m_PopupEventWasActivated = false;
 
 		m_FileDialogStorageType = 0;
-		m_aFileDialogFileName[0] = '\0';
-		m_FileDialogFileNameInput.SetBuffer(m_aFileDialogFileName, sizeof(m_aFileDialogFileName));
 		m_pFileDialogTitle = 0;
 		m_pFileDialogButtonText = 0;
 		m_pFileDialogUser = 0;
@@ -661,8 +659,7 @@ public:
 	const char *m_pFileDialogButtonText;
 	void (*m_pfnFileDialogFunc)(const char *pFileName, int StorageType, void *pUser);
 	void *m_pFileDialogUser;
-	CLineInput m_FileDialogFileNameInput;
-	char m_aFileDialogFileName[IO_MAX_PATH_LENGTH];
+	CLineInputBuffered<static_cast<int>(IO_MAX_PATH_LENGTH)> m_FileDialogFileNameInput;
 	char m_aFileDialogCurrentFolder[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogCurrentLink[IO_MAX_PATH_LENGTH];
 	char *m_pFileDialogPath;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -564,8 +564,7 @@ bool CEditor::PopupNewFolder(void *pContext, CUIRect View)
 		View.HSplitBottom(40.0f, &View, 0);
 		View.VMargin(40.0f, &View);
 		View.HSplitBottom(20.0f, &View, &Label);
-		static CLineInput s_FolderInput(pEditor->m_aFileDialogNewFolderName, sizeof(pEditor->m_aFileDialogNewFolderName));
-		pEditor->DoEditBox(&s_FolderInput, &Label, 15.0f);
+		pEditor->DoEditBox(&pEditor->m_FileDialogNewFolderNameInput, &Label, 15.0f);
 		View.HSplitBottom(20.0f, &View, &Label);
 		pEditor->UI()->DoLabel(&Label, "Name:", 10.0f, TEXTALIGN_LEFT);
 
@@ -576,10 +575,10 @@ bool CEditor::PopupNewFolder(void *pContext, CUIRect View)
 		if(pEditor->DoButton_Editor(&s_CreateButton, "Create", 0, &Label, 0, 0))
 		{
 			// create the folder
-			if(pEditor->m_aFileDialogNewFolderName[0])
+			if(pEditor->m_FileDialogNewFolderNameInput.GetLength())
 			{
 				char aBuf[IO_MAX_PATH_LENGTH];
-				str_format(aBuf, sizeof(aBuf), "%s/%s", pEditor->m_pFileDialogPath, pEditor->m_aFileDialogNewFolderName);
+				str_format(aBuf, sizeof(aBuf), "%s/%s", pEditor->m_pFileDialogPath, pEditor->m_FileDialogNewFolderNameInput.GetString());
 				if(pEditor->Storage()->CreateFolder(aBuf, IStorage::TYPE_SAVE))
 				{
 					pEditor->FilelistPopulate(IStorage::TYPE_SAVE);


### PR DESCRIPTION
The `CLineInputBuffered` is a `CLineInput` that owns its own `char` array with the size of the array being configured by a template parameter, so there is no dynamic memory allocation. The char array is encapsulated, so any string access/manipulation must go through the `CLineInput` functions when using this class. The `CLineInputBuffered` is now used in every case where a static buffer was previously used.

Other changes:
- Minor usability improvement: Activate the editor new folder input when opening the new folder popup.
- Fix slash removal for editor save filename when a string with multiple consecutive slashes is pasted in.
- Fix selection and cursor offset of editor save filename being reset by every keyboard input (by not calling `Set` and instead calling `SetRange` when necessary, though this will still reset the selection when slashes are entered).