### PR TITLE
Statboard: Sort players by team with local client first, add red and blue team headers

### DIFF
--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -14,8 +14,6 @@ class CScoreboard : public CComponent
 
 	static void ConKeyScoreboard(IConsole::IResult *pResult, void *pUserData);
 
-	const char *GetClanName(int Team);
-
 	bool m_Active;
 	bool m_Activate;
  	class CUIRect m_TotalRect;
@@ -26,10 +24,11 @@ public:
 	virtual void OnConsoleInit();
 	virtual void OnRender();
 	virtual void OnRelease();
-	
+
  	bool IsActive() const;
 	void ResetPlayerStats(int ClientID);
  	class CUIRect GetScoreboardRect() const { return m_TotalRect; }
+	const char *GetClanName(int Team);
 };
 
 #endif


### PR DESCRIPTION
Previously the players in the statboard were sorted by client ID. They are now sorted by team and then client ID. The local / spectated player is always shown in the first position. The team of the local / spectated player will be shown first.

Red and blue team headers similar to those in the scoreboard are added. I think left-aligning the title text looks better than centering it. This would also allow to show summary statistics for each team in the free space (e.g. K:D of the entire team). I also prefer all corners to be round here, instead of making some of the rectangles corner-less.

![screenshot_2022-03-24_21-44-32](https://user-images.githubusercontent.com/23437060/160007338-147cf6f7-a22a-4d6f-b063-e7af0bd7f255.png)

![screenshot_2022-03-24_21-45-14](https://user-images.githubusercontent.com/23437060/160007332-243b571c-92c2-4ce0-b00f-0649f5ecb5b9.png)

Closes #2355.
