### PR TITLE
Add chat mode names for server and client messages, only print client ID and name to console if present

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1582,8 +1582,8 @@ void CChat::Com_Mute(IConsole::IResult *pResult, void *pContext)
 	int TargetID = pChatData->m_pClient->GetClientID(pResult->GetString(0));
 	if(TargetID != -1)
 	{
-		bool isMuted = pChatData->m_pClient->m_aClients[TargetID].m_ChatIgnore;
-		if(isMuted)
+		bool IsMuted = pChatData->m_pClient->m_aClients[TargetID].m_ChatIgnore;
+		if(IsMuted)
 			pChatData->m_pClient->Blacklist()->RemoveIgnoredPlayer(pChatData->m_pClient->m_aClients[TargetID].m_aName, pChatData->m_pClient->m_aClients[TargetID].m_aClan);
 		else
 			pChatData->m_pClient->Blacklist()->AddIgnoredPlayer(pChatData->m_pClient->m_aClients[TargetID].m_aName, pChatData->m_pClient->m_aClients[TargetID].m_aClan);
@@ -1592,7 +1592,7 @@ void CChat::Com_Mute(IConsole::IResult *pResult, void *pContext)
 		pChatData->ClearInput();
 
 		char aMsg[128];
-		str_format(aMsg, sizeof(aMsg), !isMuted ? Localize("'%s' was muted") : Localize("'%s' was unmuted"), pChatData->m_pClient->m_aClients[TargetID].m_aName);
+		str_format(aMsg, sizeof(aMsg), !IsMuted ? Localize("'%s' was muted") : Localize("'%s' was unmuted"), pChatData->m_pClient->m_aClients[TargetID].m_aName);
 		pChatData->AddLine(aMsg, CLIENT_MSG, CHAT_ALL);
 	}
 	pChatData->Disable();

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -701,7 +701,10 @@ void CChat::AddLine(const char *pLine, int ClientID, int Mode, int TargetID)
 
 		char aBuf[1024];
 		str_format(aBuf, sizeof(aBuf), "%2d: %s: %s", NameCID, pCurLine->m_aName, pCurLine->m_aText);
-		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, GetModeName(Mode), aBuf, Highlighted || Mode == CHAT_WHISPER);
+		char aMode[16];
+		str_copy(aMode, "chat/", sizeof(aMode));
+		str_append(aMode, GetModeName(Mode, ClientID), sizeof(aMode));
+		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, aMode, aBuf, Highlighted || Mode == CHAT_WHISPER);
 	}
 
 	if(Mode == CHAT_WHISPER && m_pClient->m_LocalClientID != ClientID)
@@ -738,10 +741,16 @@ int CChat::GetChatSound(int ChatType)
 	}
 }
 
-const char *CChat::GetModeName(int Mode) const
+const char *CChat::GetModeName(int Mode, int ClientID) const
 {
+	switch(ClientID)
+	{
+		case CLIENT_MSG: return "client";
+		case SERVER_MSG: return "server";
+	}
 	switch(Mode)
 	{
+		case CHAT_NONE:
 		case CHAT_ALL: return "all";
 		case CHAT_WHISPER: return "whisper";
 		case CHAT_TEAM: return "team";

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -700,7 +700,17 @@ void CChat::AddLine(const char *pLine, int ClientID, int Mode, int TargetID)
 		}
 
 		char aBuf[1024];
-		str_format(aBuf, sizeof(aBuf), "%2d: %s: %s", NameCID, pCurLine->m_aName, pCurLine->m_aText);
+		if(NameCID >= 0)
+			str_format(aBuf, sizeof(aBuf), "%d: ", NameCID);
+		else
+			aBuf[0] = '\0';
+		if(pCurLine->m_aName[0])
+		{
+			str_append(aBuf, pCurLine->m_aName, sizeof(aBuf));
+			str_append(aBuf, ": ", sizeof(aBuf));
+		}
+		str_append(aBuf, pCurLine->m_aText, sizeof(aBuf));
+
 		char aMode[16];
 		str_copy(aMode, "chat/", sizeof(aMode));
 		str_append(aMode, GetModeName(Mode, ClientID), sizeof(aMode));

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -695,8 +695,8 @@ void CChat::AddLine(const char *pLine, int ClientID, int Mode, int TargetID)
 					pCurLine->m_NameColor = TEAM_BLUE;
 			}
 
-			str_format(pCurLine->m_aName, sizeof(pCurLine->m_aName), "%s", m_pClient->m_aClients[NameCID].m_aName);
-			str_format(pCurLine->m_aText, sizeof(pCurLine->m_aText), "%s", pLine);
+			str_copy(pCurLine->m_aName, m_pClient->m_aClients[NameCID].m_aName, sizeof(pCurLine->m_aName));
+			str_copy(pCurLine->m_aText, pLine, sizeof(pCurLine->m_aText));
 		}
 
 		char aBuf[1024];

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -98,7 +98,7 @@ class CChat : public CComponent
 	void HandleCommands(float x, float y, float w);
 	bool ExecuteCommand();
 	bool CompleteCommand();
-	const char *GetModeName(int Mode) const;
+	const char *GetModeName(int Mode, int ClientID = 0) const;
 
 	static void Com_All(IConsole::IResult *pResult, void *pContext);
 	static void Com_Team(IConsole::IResult *pResult, void *pContext);


### PR DESCRIPTION
Server and client chat messages previously had no mode name when printed in the console, so they appeared as `[]` or `[all]`. The names `server` and `client` are added for server and client messages. The prefix `chat/` is added for all console messages of chat messages, to avoid confusion with other client messages.

The client ID is no longer printed in the console messages for server and client messages, as the mode name makes it redundant. The name and colon are also skipped if the name is empty.

Before:

```
[team]:  0: Robyt3: test
[all]:  0: Robyt3: test
[]: -2: : — test
[all]: -1: : *** test
```

After:

```
[chat/team]: 0: Robyt3: test
[chat/all]: 0: Robyt3: test
[chat/client]: — test
[chat/server]: *** test
```