### PR TITLE
RFC: Embed non-standard skin parts in json skin files and load embedded parts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1268,6 +1268,8 @@ generate_source("src/generated/server_data.h" "server_content_header")
 
 # Sources
 set_src(BASE GLOB_RECURSE src/base
+  base64.c
+  base64.h
   color.h
   detect.h
   hash.c
@@ -1729,6 +1731,7 @@ add_custom_target(everything DEPENDS ${TARGETS_OWN})
 
 if(GTEST_FOUND OR DOWNLOAD_GTEST)
   set_src(TESTS GLOB src/test
+    base64.cpp
     bytes_be.cpp
     compression.cpp
     datafile.cpp

--- a/src/base/base64.c
+++ b/src/base/base64.c
@@ -1,0 +1,95 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "base64.h"
+#include "system.h"
+
+static const char base64_encode_table[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+char *base64_encode(const unsigned char *data, unsigned len)
+{
+	unsigned result_index = 0;
+	unsigned result_len = 4 * ((len + 2) / 3) + 1;
+	char *result = mem_alloc(result_len);
+
+	for(unsigned x = 0; x < len; x += 3) 
+	{
+		unsigned n = ((unsigned)data[x]) << 16;
+		if((x + 1) < len)
+			n += ((unsigned)data[x + 1]) << 8;
+		if((x + 2) < len)
+			n += data[x + 2];
+
+		result[result_index++] = base64_encode_table[(n >> 18) & 0x3F];
+		result[result_index++] = base64_encode_table[(n >> 12) & 0x3F];
+
+		if((x + 1) < len)
+			result[result_index++] = base64_encode_table[(n >> 6) & 0x3F];
+		if((x + 2) < len)
+			result[result_index++] = base64_encode_table[n & 0x3F];
+	}
+
+	for(int padding = len % 3; padding > 0 && padding < 3; padding++) 
+		result[result_index++] = '=';
+
+	dbg_assert(result_index < result_len, "too small base64 encode size");
+	result[result_index] = '\0';
+	return result;
+}
+
+static const unsigned char base64_decode_table[256] = {
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63, 52, 53,
+	54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64, 64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+	10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64, 64, 26, 27, 28,
+	29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+	64, 64, 64, 64, 64, 64
+};
+
+unsigned base64_decode(unsigned char **data, const char *str)
+{
+	unsigned char iter = 0;
+	unsigned buf = 0;
+	unsigned str_index = 0;
+	unsigned str_len = str_length(str);
+	const unsigned char *str_unsigned = (const unsigned char *)str; // so indices for the decoding table are positive
+	unsigned data_index = 0;
+	unsigned data_len = (str_len * 3) / 4 + 1;
+	*data = mem_alloc(data_len);
+
+	while(str_index < str_len)
+	{
+		const unsigned char chr_value = base64_decode_table[str_unsigned[str_index++]];
+		if(chr_value == 64) // skip whitespace, padding and invalid characters
+			continue;
+
+		buf = buf << 6 | chr_value;
+		iter++;
+		if(iter == 4)
+		{
+			(*data)[data_index++] = (buf >> 16) & 0xFF;
+			(*data)[data_index++] = (buf >> 8) & 0xFF;
+			(*data)[data_index++] = buf & 0xFF;
+			buf = 0;
+			iter = 0;
+		}
+	}
+
+	if(iter == 3)
+	{
+		(*data)[data_index++] = (buf >> 10) & 0xFF;
+		(*data)[data_index++] = (buf >> 2) & 0xFF;
+	}
+	else if(iter == 2)
+	{
+		(*data)[data_index++] = (buf >> 4) & 0xFF;
+	}
+
+	dbg_assert(data_index < data_len, "too small base64 decode size");
+	(*data)[data_index] = '\0'; // zero-terminate for more convenient usage with strings
+	return data_index; // the zero-terminator is not included in the total size
+}

--- a/src/base/base64.h
+++ b/src/base/base64.h
@@ -1,0 +1,52 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef BASE_BASE64_H
+#define BASE_BASE64_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+	Function: base64_encode
+		Encodes data as a base64 string (RFC 4648).
+
+	Parameters:
+		data - The data to be encoded.
+		len - Size of the data to be encoded.
+
+	Returns:
+		The base64 encoded data in a newly allocated string buffer.
+
+	Remarks:
+		- The string is zero-terminated.
+		- The result must be freed after it has been used.
+*/
+char *base64_encode(const unsigned char *data, unsigned len);
+
+/*
+	Function: base64_decode
+		Decodes data from a base64 string (RFC 4648).
+
+	Parameters:
+		data - Pointer that will receive the decoded data.
+		str - The base64 string to be decoded.
+
+	Returns:
+		The size of the decoded data.
+
+	Remarks:
+		- The string must be zero-terminated.
+		- The data is zero-terminated for convenience when decoding strings.
+		- The returned size does not include the size of the zero-terminator.
+		- Any non-base64-alphabet characters in the string are ignored,
+		  including whitespace and misplaced padding characters.
+		- The result must be freed after it has been used.
+*/
+unsigned base64_decode(unsigned char **data, const char *str);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -7,8 +7,6 @@
 
 #include <base/system.h>
 
-#include <pnglite.h>
-
 #include <engine/shared/config.h>
 #include <engine/graphics.h>
 #include <engine/storage.h>
@@ -395,46 +393,114 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadTexture(const char *pFilename,
 	return m_InvalidTexture;
 }
 
-int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType)
+bool CGraphics_Threaded::LoadPNGImpl(CImageInfo *pImg, png_read_callback_t pfnPngReadFunc, void *pPngReadUserData, const char *pFilename)
+{
+	png_init(0, 0);
+	png_t Png;
+	const int PngOpenError = png_open_read(&Png, pfnPngReadFunc, pPngReadUserData);
+	if(PngOpenError != PNG_NO_ERROR)
+	{
+		char aBuf[512];
+		str_format(aBuf, sizeof(aBuf), "failed to read header. filename='%s' error='%s'", pFilename, png_error_string(PngOpenError));
+		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game/png", aBuf);
+		return false;
+	}
+
+	if(Png.depth != 8 || (Png.color_type != PNG_TRUECOLOR && Png.color_type != PNG_TRUECOLOR_ALPHA))
+	{
+		char aBuf[512];
+		str_format(aBuf, sizeof(aBuf), "invalid format, must be 8 bits per pixel . filename='%s' depth='%d' color_type='%d'", pFilename, Png.depth, Png.color_type);
+		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game/png", aBuf);
+		return false;
+	}
+
+	const unsigned MaxPngDimension = 8192;
+	if(Png.width > MaxPngDimension || Png.height > MaxPngDimension)
+	{
+		char aBuf[512];
+		str_format(aBuf, sizeof(aBuf), "too large. filename='%s' width='%d' height='%d' max='%d'", pFilename, Png.width, Png.height, MaxPngDimension);
+		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game/png", aBuf);
+		return false;
+	}
+
+	unsigned char *pBuffer = static_cast<unsigned char *>(mem_alloc(Png.width * Png.height * Png.bpp));
+	const int PngDataError = png_get_data(&Png, pBuffer);
+	if(PngDataError != PNG_NO_ERROR)
+	{
+		mem_free(pBuffer);
+		char aBuf[512];
+		str_format(aBuf, sizeof(aBuf), "failed to read data. filename='%s' error='%s'", pFilename, png_error_string(PngDataError));
+		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game/png", aBuf);
+		return false;
+	}
+
+	pImg->m_Width = Png.width;
+	pImg->m_Height = Png.height;
+	if(Png.color_type == PNG_TRUECOLOR)
+		pImg->m_Format = CImageInfo::FORMAT_RGB;
+	else if(Png.color_type == PNG_TRUECOLOR_ALPHA)
+		pImg->m_Format = CImageInfo::FORMAT_RGBA;
+	pImg->m_pData = pBuffer;
+	return true;
+}
+
+bool CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType)
 {
 	// open file for reading
 	char aCompleteFilename[IO_MAX_PATH_LENGTH];
 	IOHANDLE File = m_pStorage->OpenFile(pFilename, IOFLAG_READ, StorageType, aCompleteFilename, sizeof(aCompleteFilename));
 	if(!File)
 	{
-		dbg_msg("game/png", "failed to open file. filename='%s'", pFilename);
-		return 0;
+		char aBuf[IO_MAX_PATH_LENGTH + 64];
+		str_format(aBuf, sizeof(aBuf), "failed to open file. filename='%s'", pFilename);
+		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game/png", aBuf);
+		return false;
 	}
 
-	png_init(0, 0); // ignore_convention
-	png_t Png; // ignore_convention
-	int Error = png_open_read(&Png, 0, File); // ignore_convention
-	if(Error != PNG_NO_ERROR)
-	{
-		dbg_msg("game/png", "failed to read file. filename='%s'", aCompleteFilename);
-		io_close(File);
-		return 0;
-	}
-
-	if(Png.depth != 8 || (Png.color_type != PNG_TRUECOLOR && Png.color_type != PNG_TRUECOLOR_ALPHA) || Png.width > (2<<12) || Png.height > (2<<12)) // ignore_convention
-	{
-		dbg_msg("game/png", "invalid format. filename='%s'", aCompleteFilename);
-		io_close(File);
-		return 0;
-	}
-
-	unsigned char *pBuffer = (unsigned char *)mem_alloc(Png.width * Png.height * Png.bpp); // ignore_convention
-	png_get_data(&Png, pBuffer); // ignore_convention
+	// Use default file-based read function
+	const bool Result = LoadPNGImpl(pImg, 0x0, File, aCompleteFilename);
 	io_close(File);
+	return Result;
+}
 
-	pImg->m_Width = Png.width; // ignore_convention
-	pImg->m_Height = Png.height; // ignore_convention
-	if(Png.color_type == PNG_TRUECOLOR) // ignore_convention
-		pImg->m_Format = CImageInfo::FORMAT_RGB;
-	else if(Png.color_type == PNG_TRUECOLOR_ALPHA) // ignore_convention
-		pImg->m_Format = CImageInfo::FORMAT_RGBA;
-	pImg->m_pData = pBuffer;
-	return 1;
+struct ReadPNGFromMemoryData
+{
+	const unsigned char *m_pData;
+	unsigned m_Size;
+	unsigned m_Position;
+};
+
+static unsigned ReadPNGFromMemory(void *pOut, unsigned long ElemSize, unsigned long ElemNum, void *pUserRaw)
+{
+	ReadPNGFromMemoryData *pUser = static_cast<ReadPNGFromMemoryData *>(pUserRaw);
+	unsigned long Size = ElemSize * ElemNum;
+	if(pOut)
+	{
+		if(pUser->m_Position >= pUser->m_Size)
+			return 0;
+		if(pUser->m_Position + Size > pUser->m_Size)
+			Size = pUser->m_Size - pUser->m_Position;
+		if(Size)
+		{
+			mem_copy(pOut, pUser->m_pData + pUser->m_Position, Size);
+			pUser->m_Position += Size;
+		}
+		return Size;
+	}
+	else
+	{
+		pUser->m_Position += Size;
+		return 0;
+	}
+}
+
+bool CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const unsigned char *pData, unsigned Size, const char *pContext)
+{
+	ReadPNGFromMemoryData UserData;
+	UserData.m_pData = pData;
+	UserData.m_Size = Size;
+	UserData.m_Position = 0;
+	return LoadPNGImpl(pImg, ReadPNGFromMemory, &UserData, pContext ? pContext : "memory");
 }
 
 void CGraphics_Threaded::KickCommandBuffer()

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -5,6 +5,8 @@
 
 #include <stdint.h>
 
+#include <pnglite.h>
+
 #include <engine/graphics.h>
 
 class CCommandBuffer
@@ -392,6 +394,8 @@ class CGraphics_Threaded : public IEngineGraphics
 
 	void KickCommandBuffer();
 
+	bool LoadPNGImpl(CImageInfo *pImg, png_read_callback_t pfnPngReadFunc, void *pPngReadUserData, const char *pFilename);
+
 	int IssueInit();
 	int InitWindow();
 public:
@@ -423,7 +427,8 @@ public:
 
 	// simple uncompressed RGBA loaders
 	virtual IGraphics::CTextureHandle LoadTexture(const char *pFilename, int StorageType, int StoreFormat, int Flags);
-	virtual int LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType);
+	virtual bool LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType);
+	virtual bool LoadPNG(CImageInfo *pImg, const unsigned char *pData, unsigned Size, const char *pContext);
 
 	void ScreenshotDirect(const char *pFilename);
 

--- a/src/engine/client/graphics_threaded_null.h
+++ b/src/engine/client/graphics_threaded_null.h
@@ -40,7 +40,8 @@ public:
 
 	// simple uncompressed RGBA loaders
 	virtual IGraphics::CTextureHandle LoadTexture(const char *pFilename, int StorageType, int StoreFormat, int Flags) { return CreateTextureHandle(0); };
-	virtual int LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) { return 0; };
+	virtual bool LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) { return false; };
+	virtual bool LoadPNG(CImageInfo *pImg, const unsigned char *pData, unsigned Size, const char *pContext) { return false; };
 
 	virtual void TextureSet(CTextureHandle TextureID) {};
 

--- a/src/engine/external/pnglite/pnglite.c
+++ b/src/engine/external/pnglite/pnglite.c
@@ -828,11 +828,8 @@ int png_get_data(png_t* png, unsigned char* data)
 
 	if(result != PNG_DONE)
 	{
-		if(!png->png_data)
-		{
-			png_free(png->png_data);
-			png->png_data = 0;
-		}
+		png_free(png->png_data);
+		png->png_data = 0;
 		return result;
 	}
 

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -136,7 +136,8 @@ public:
 	virtual void WrapMode(int WrapU, int WrapV) = 0;
 	virtual int MemoryUsage() const = 0;
 
-	virtual int LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) = 0;
+	virtual bool LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) = 0;
+	virtual bool LoadPNG(CImageInfo *pImg, const unsigned char *pData, unsigned Size, const char *pContext = 0x0) = 0;
 
 	virtual int UnloadTexture(CTextureHandle *pIndex) = 0;
 	virtual CTextureHandle LoadTextureRaw(int Width, int Height, int Format, const void *pData, int StoreFormat, int Flags) = 0;

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -24,17 +24,57 @@ int *CSkins::ms_apColorVariables[NUM_SKINPARTS] = {0};
 
 const float MIN_EYE_BODY_COLOR_DIST = 80.f; // between body and eyes (LAB color space)
 
+void CSkins::LoadSkinPartImpl(int PartIndex, CSkinPart *pPart, CImageInfo *pInfo)
+{
+	pPart->m_OrgTexture = Graphics()->LoadTextureRaw(pInfo->m_Width, pInfo->m_Height, pInfo->m_Format, pInfo->m_pData, pInfo->m_Format, 0);
+	pPart->m_BloodColor = vec3(1.0f, 1.0f, 1.0f);
+
+	const int Step = pInfo->GetPixelSize();
+	unsigned char *pData = static_cast<unsigned char *>(pInfo->m_pData);
+
+	// dig out blood color
+	if(PartIndex == SKINPART_BODY)
+	{
+		const int Pitch = pInfo->m_Width * Step;
+		const int PartX = pInfo->m_Width / 2;
+		const int PartY = 0;
+		const int PartWidth = pInfo->m_Width / 2;
+		const int PartHeight = pInfo->m_Height / 2;
+
+		int aColors[3] = {0};
+		for(int y = PartY; y < PartY + PartHeight; y++)
+			for(int x = PartX; x < PartX + PartWidth; x++)
+				if(pData[y * Pitch + x * Step + 3] > 128)
+					for(int c = 0; c < 3; c++)
+						aColors[c] += pData[y * Pitch + x * Step + c];
+
+		pPart->m_BloodColor = normalize(vec3(aColors[0], aColors[1], aColors[2]));
+	}
+
+	// create colorless version
+	for(int i = 0; i < pInfo->m_Width * pInfo->m_Height; i++)
+	{
+		const int Average = (pData[i * Step] + pData[i * Step + 1] + pData[i * Step + 2]) / 3;
+		pData[i * Step] = Average;
+		pData[i * Step + 1] = Average;
+		pData[i * Step + 2] = Average;
+	}
+
+	pPart->m_ColorTexture = Graphics()->LoadTextureRaw(pInfo->m_Width, pInfo->m_Height, pInfo->m_Format, pInfo->m_pData, pInfo->m_Format, 0);
+	mem_free(pInfo->m_pData);
+}
+
 int CSkins::SkinPartScan(const char *pName, int IsDir, int DirType, void *pUser)
 {
 	CSkins *pSelf = (CSkins *)pUser;
 	if(IsDir || !str_endswith(pName, ".png"))
 		return 0;
 
+	char aBuf[IO_MAX_PATH_LENGTH + 64];
 	int PartNameSize, PartNameCount;
 	str_utf8_stats(pName, str_length(pName) - str_length(".png") + 1, IO_MAX_PATH_LENGTH, &PartNameSize, &PartNameCount);
 	if(PartNameSize >= MAX_SKIN_ARRAY_SIZE || PartNameCount > MAX_SKIN_LENGTH)
 	{
-		char aBuf[IO_MAX_PATH_LENGTH + 64];
 		str_format(aBuf, sizeof(aBuf), "failed to load skin part '%s': name too long", pName);
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "skins", aBuf);
 		return 0;
@@ -45,7 +85,6 @@ int CSkins::SkinPartScan(const char *pName, int IsDir, int DirType, void *pUser)
 	if(pSelf->FindSkinPart(pSelf->m_ScanningPart, Part.m_aName, true) != -1)
 		return 0;
 
-	char aBuf[IO_MAX_PATH_LENGTH];
 	str_format(aBuf, sizeof(aBuf), "skins/%s/%s", CSkins::ms_apSkinPartNames[pSelf->m_ScanningPart], pName);
 	CImageInfo Info;
 	if(!pSelf->Graphics()->LoadPNG(&Info, aBuf, DirType))
@@ -61,57 +100,65 @@ int CSkins::SkinPartScan(const char *pName, int IsDir, int DirType, void *pUser)
 		return 0;
 	}
 
-	Part.m_OrgTexture = pSelf->Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
-	Part.m_BloodColor = vec3(1.0f, 1.0f, 1.0f);
-
-	const int Step = Info.GetPixelSize();
-	unsigned char *pData = (unsigned char *)Info.m_pData;
-
-	// dig out blood color
-	if(pSelf->m_ScanningPart == SKINPART_BODY)
-	{
-		int Pitch = Info.m_Width * Step;
-		int PartX = Info.m_Width/2;
-		int PartY = 0;
-		int PartWidth = Info.m_Width/2;
-		int PartHeight = Info.m_Height/2;
-
-		int aColors[3] = {0};
-		for(int y = PartY; y < PartY+PartHeight; y++)
-			for(int x = PartX; x < PartX+PartWidth; x++)
-				if(pData[y*Pitch+x*Step+3] > 128)
-					for(int c = 0; c < 3; c++)
-						aColors[c] += pData[y*Pitch+x*Step+c];
-
-		Part.m_BloodColor = normalize(vec3(aColors[0], aColors[1], aColors[2]));
-	}
-
-	// create colorless version
-	for(int i = 0; i < Info.m_Width*Info.m_Height; i++)
-	{
-		const int Average = (pData[i*Step]+pData[i*Step+1]+pData[i*Step+2])/3;
-		pData[i*Step] = Average;
-		pData[i*Step+1] = Average;
-		pData[i*Step+2] = Average;
-	}
-
-	Part.m_ColorTexture = pSelf->Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
-	mem_free(Info.m_pData);
+	pSelf->LoadSkinPartImpl(pSelf->m_ScanningPart, &Part, &Info);
 
 	// set skin part data
 	Part.m_Flags = 0;
-	if(pName[0] == 'x' && pName[1] == '_')
+	if(str_startswith(pName, "x_"))
 		Part.m_Flags |= SKINFLAG_SPECIAL;
 	if(DirType != IStorage::TYPE_SAVE)
 		Part.m_Flags |= SKINFLAG_STANDARD;
+
 	if(pSelf->Config()->m_Debug)
 	{
-		str_format(aBuf, sizeof(aBuf), "load skin part %s", Part.m_aName);
+		str_format(aBuf, sizeof(aBuf), "loaded skin part '%s'", pName);
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "skins", aBuf);
 	}
-	pSelf->m_aaSkinParts[pSelf->m_ScanningPart].add(Part);
 
+	pSelf->AddSkinPart(pSelf->m_ScanningPart, &Part);
 	return 0;
+}
+
+const CSkins::CSkinPart *CSkins::LoadEmbeddedSkinPart(int PartIndex, const char *pName, const unsigned char *pData, unsigned Size)
+{
+	char aBuf[IO_MAX_PATH_LENGTH + 64];
+	int PartNameSize, PartNameCount;
+	str_utf8_stats(pName, str_length(pName) + 1, IO_MAX_PATH_LENGTH, &PartNameSize, &PartNameCount);
+	if(PartNameSize >= MAX_SKIN_ARRAY_SIZE || PartNameCount > MAX_SKIN_LENGTH)
+	{
+		str_format(aBuf, sizeof(aBuf), "failed to load embedded skin part '%s': name too long", pName);
+		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "skins", aBuf);
+		return 0x0;
+	}
+
+	CImageInfo Info;
+	if(!Graphics()->LoadPNG(&Info, pData, Size, pName))
+	{
+		str_format(aBuf, sizeof(aBuf), "failed to load embedded skin part '%s'", pName);
+		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "skins", aBuf);
+		return 0x0;
+	}
+	if(Info.m_Format != CImageInfo::FORMAT_RGBA)
+	{
+		str_format(aBuf, sizeof(aBuf), "failed to load embedded skin part '%s': must be RGBA format", pName);
+		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "skins", aBuf);
+		return 0x0;
+	}
+
+	CSkinPart Part;
+	str_copy(Part.m_aName, pName, minimum<int>(PartNameSize + 1, sizeof(Part.m_aName)));
+
+	LoadSkinPartImpl(PartIndex, &Part, &Info);
+
+	Part.m_Flags = SKINFLAG_EMBEDDED;
+
+	if(Config()->m_Debug)
+	{
+		str_format(aBuf, sizeof(aBuf), "loaded embedded skin part '%s'", pName);
+		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "skins", aBuf);
+	}
+
+	return AddSkinPart(PartIndex, &Part);
 }
 
 int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
@@ -173,12 +220,28 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 				continue;
 
 			// filename
+			bool LoadedFromFile = false;
 			const json_value &rFilename = rPart["filename"];
 			if(rFilename.type == json_string)
 			{
 				int SkinPart = pSelf->FindSkinPart(PartIndex, (const char *)rFilename, SpecialSkin);
 				if(SkinPart > -1)
+				{
 					Skin.m_apParts[PartIndex] = pSelf->GetSkinPart(PartIndex, SkinPart);
+					LoadedFromFile = true;
+				}
+			}
+
+			// embedded data
+			const json_value &rData = rPart["data"];
+			if(!LoadedFromFile && rData.type == json_string)
+			{
+				unsigned char *pImageData;
+				unsigned ImageSize = base64_decode(&pImageData, rData.u.string.ptr);
+				const CSkinPart *pEmbeddedPart = pSelf->LoadEmbeddedSkinPart(PartIndex, rFilename.u.string.ptr, pImageData, ImageSize);
+				if(pEmbeddedPart)
+					Skin.m_apParts[PartIndex] = pEmbeddedPart;
+				mem_free(pImageData);
 			}
 
 			// use custom colors
@@ -257,9 +320,10 @@ void CSkins::OnInit()
 	ms_apColorVariables[SKINPART_FEET] = &Config()->m_PlayerColorFeet;
 	ms_apColorVariables[SKINPART_EYES] = &Config()->m_PlayerColorEyes;
 
+	m_SkinPartsHeap.Reset();
 	for(int p = 0; p < NUM_SKINPARTS; p++)
 	{
-		m_aaSkinParts[p].clear();
+		m_aapSkinParts[p].clear();
 
 		// add none part
 		if(p == SKINPART_MARKING || p == SKINPART_DECORATION)
@@ -268,7 +332,7 @@ void CSkins::OnInit()
 			NoneSkinPart.m_Flags = SKINFLAG_STANDARD;
 			str_copy(NoneSkinPart.m_aName, "", sizeof(NoneSkinPart.m_aName));
 			NoneSkinPart.m_BloodColor = vec3(1.0f, 1.0f, 1.0f);
-			m_aaSkinParts[p].add(NoneSkinPart);
+			AddSkinPart(p, &NoneSkinPart);
 		}
 
 		// load skin parts
@@ -278,13 +342,13 @@ void CSkins::OnInit()
 		Storage()->ListDirectory(IStorage::TYPE_ALL, aBuf, SkinPartScan, this);
 
 		// add dummy skin part
-		if(!m_aaSkinParts[p].size())
+		if(!m_aapSkinParts[p].size())
 		{
 			CSkinPart DummySkinPart;
 			DummySkinPart.m_Flags = SKINFLAG_STANDARD;
 			str_copy(DummySkinPart.m_aName, "dummy", sizeof(DummySkinPart.m_aName));
 			DummySkinPart.m_BloodColor = vec3(1.0f, 1.0f, 1.0f);
-			m_aaSkinParts[p].add(DummySkinPart);
+			AddSkinPart(p, &DummySkinPart);
 		}
 
 		m_pClient->m_pMenus->RenderLoading(5);
@@ -392,7 +456,7 @@ int CSkins::Num()
 
 int CSkins::NumSkinPart(int Part)
 {
-	return m_aaSkinParts[Part].size();
+	return m_aapSkinParts[Part].size();
 }
 
 const CSkins::CSkin *CSkins::Get(int Index)
@@ -412,17 +476,27 @@ int CSkins::Find(const char *pName, bool AllowSpecialSkin)
 
 const CSkins::CSkinPart *CSkins::GetSkinPart(int Part, int Index)
 {
-	return &m_aaSkinParts[Part][clamp(Index, 0, m_aaSkinParts[Part].size() - 1)];
+	return m_aapSkinParts[Part][clamp(Index, 0, m_aapSkinParts[Part].size() - 1)];
 }
 
 int CSkins::FindSkinPart(int Part, const char *pName, bool AllowSpecialPart)
 {
-	for(int i = 0; i < m_aaSkinParts[Part].size(); i++)
+	for(int i = 0; i < m_aapSkinParts[Part].size(); i++)
 	{
-		if(str_comp(m_aaSkinParts[Part][i].m_aName, pName) == 0 && ((m_aaSkinParts[Part][i].m_Flags&SKINFLAG_SPECIAL) == 0 || AllowSpecialPart))
+		if(str_comp(m_aapSkinParts[Part][i]->m_aName, pName) == 0 && ((m_aapSkinParts[Part][i]->m_Flags&SKINFLAG_SPECIAL) == 0 || AllowSpecialPart))
 			return i;
 	}
 	return -1;
+}
+
+CSkins::CSkinPart *CSkins::AddSkinPart(int PartIndex, const CSkinPart *pPart)
+{
+	// Store the skin parts in a heap so their locations in memory don't change
+	// when more parts are added to the sorted array.
+	CSkinPart *pStoredPart = static_cast<CSkinPart *>(m_SkinPartsHeap.Allocate(sizeof(CSkinPart)));
+	mem_copy(pStoredPart, pPart, sizeof(CSkinPart));
+	m_aapSkinParts[PartIndex].add(pStoredPart);
+	return pStoredPart;
 }
 
 void CSkins::RandomizeSkin()

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -397,7 +397,7 @@ int CSkins::NumSkinPart(int Part)
 
 const CSkins::CSkin *CSkins::Get(int Index)
 {
-	return &m_aSkins[maximum(0, Index%m_aSkins.size())];
+	return &m_aSkins[clamp(Index, 0, m_aSkins.size() - 1)];
 }
 
 int CSkins::Find(const char *pName, bool AllowSpecialSkin)
@@ -412,8 +412,7 @@ int CSkins::Find(const char *pName, bool AllowSpecialSkin)
 
 const CSkins::CSkinPart *CSkins::GetSkinPart(int Part, int Index)
 {
-	int Size = m_aaSkinParts[Part].size();
-	return &m_aaSkinParts[Part][maximum(0, Index%Size)];
+	return &m_aaSkinParts[Part][clamp(Index, 0, m_aaSkinParts[Part].size() - 1)];
 }
 
 int CSkins::FindSkinPart(int Part, const char *pName, bool AllowSpecialPart)

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -4,6 +4,7 @@
 #define GAME_CLIENT_COMPONENTS_SKINS_H
 #include <base/vmath.h>
 #include <base/tl/sorted_array.h>
+#include <engine/shared/memheap.h>
 #include <game/client/component.h>
 
 // todo: fix duplicate skins (different paths)
@@ -12,8 +13,9 @@ class CSkins : public CComponent
 public:
 	enum
 	{
-		SKINFLAG_SPECIAL=1<<0,
-		SKINFLAG_STANDARD=1<<1,
+		SKINFLAG_SPECIAL = 1 << 0,
+		SKINFLAG_STANDARD = 1 << 1,
+		SKINFLAG_EMBEDDED = 1 << 2,
 
 		DARKEST_COLOR_LGT=61,
 
@@ -67,6 +69,7 @@ public:
 	int Find(const char *pName, bool AllowSpecialSkin);
 	const CSkinPart *GetSkinPart(int Part, int Index);
 	int FindSkinPart(int Part, const char *pName, bool AllowSpecialPart);
+	CSkinPart *AddSkinPart(int PartIndex, const CSkinPart *pPart);
 	void RandomizeSkin();
 
 	vec3 GetColorV3(int v) const;
@@ -80,11 +83,14 @@ public:
 
 private:
 	int m_ScanningPart;
-	sorted_array<CSkinPart> m_aaSkinParts[NUM_SKINPARTS];
+	CHeap m_SkinPartsHeap;
+	sorted_array<CSkinPart *> m_aapSkinParts[NUM_SKINPARTS];
 	sorted_array<CSkin> m_aSkins;
 	CSkin m_DummySkin;
 
+	void LoadSkinPartImpl(int PartIndex, CSkinPart *pPart, CImageInfo *pInfo);
 	static int SkinPartScan(const char *pName, int IsDir, int DirType, void *pUser);
+	const CSkinPart *LoadEmbeddedSkinPart(int PartIndex, const char *pName, const unsigned char *pData, unsigned Size);
 	static int SkinScan(const char *pName, int IsDir, int DirType, void *pUser);
 };
 

--- a/src/test/base64.cpp
+++ b/src/test/base64.cpp
@@ -1,0 +1,48 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <gtest/gtest.h>
+
+#include <base/base64.h>
+#include <base/system.h>
+
+static const char *TESTDATA[] = {"", "a", "ab", "abc", "abcd", "abcde", "Heizölrückstoßabdämpfung", "поплавать", "愛愛"};
+static const char *TESTDATA_ENCODED[] = {"", "YQ==", "YWI=", "YWJj", "YWJjZA==", "YWJjZGU=", "SGVpesO2bHLDvGNrc3Rvw59hYmTDpG1wZnVuZw==", "0L/QvtC/0LvQsNCy0LDRgtGM", "5oSb5oSb"};
+static const int NUM_TESTDATA = sizeof(TESTDATA) / sizeof(TESTDATA[0]);
+
+static const char *TESTDATA_SPECIAL_ENCODED[] = {"YäQö==", "=====", "YW====Jj", "Yw", "Y+", "Y++", "Y+++", "Y  Q==", "Y\tQ==", "\nY\nW\n\n\nI\n=\n", "YWJ\r\njZGU="};
+static const char *TESTDATA_SPECIAL[] = {"a", "", "abc", "c", "c", "c\xEF", "c\xEF\xBE", "a", "a", "ab", "abcde"};
+static const int NUM_TESTDATA_SPECIAL = sizeof(TESTDATA_SPECIAL) / sizeof(TESTDATA_SPECIAL[0]);
+
+TEST(Base64, Encode)
+{
+	for(int i = 0; i < NUM_TESTDATA; i++)
+	{
+		char *pEncoded = base64_encode(reinterpret_cast<const unsigned char *>(TESTDATA[i]), str_length(TESTDATA[i]));
+		ASSERT_TRUE(pEncoded);
+		EXPECT_STREQ(TESTDATA_ENCODED[i], pEncoded);
+		mem_free(pEncoded);
+	}
+}
+
+TEST(Base64, Decode)
+{
+	for(int i = 0; i < NUM_TESTDATA; i++)
+	{
+		unsigned char *pData;
+		EXPECT_EQ(str_length(TESTDATA[i]), base64_decode(&pData, TESTDATA_ENCODED[i]));
+		EXPECT_STREQ(TESTDATA[i], reinterpret_cast<const char *>(pData));
+		mem_free(pData);
+	}
+}
+
+TEST(Base64, DecodeSpecial)
+{
+	for(int i = 0; i < NUM_TESTDATA_SPECIAL; i++)
+	{
+		unsigned char *pData;
+		EXPECT_EQ(str_length(TESTDATA_SPECIAL[i]), base64_decode(&pData, TESTDATA_SPECIAL_ENCODED[i]));
+		ASSERT_TRUE(pData);
+		EXPECT_STREQ(TESTDATA_SPECIAL[i], reinterpret_cast<const char *>(pData));
+		mem_free(pData);
+	}
+}


### PR DESCRIPTION
See #2271.

### Skin saving

Embed the png files of non-standard skin parts into the json skin files as base64 encoded strings when saving the skin.

Standard (`SKINFLAG_STANDARD`) means that the skin part was loaded from the save path (the first path listed in `storage.cfg`).

### Skin loading

Skin parts are first loaded based on the filename. If the filename search fails and embedded data is present, skin parts are decoded from the embedded data.

#### Base64 implementation

- Adapted from public domain code.
- The encode function should produce valid base64 according to section 4 of [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648).
- The decode function is not strictly accoding to RFC 4648, as it is most lenient and allows (silently skips) all non-base64-alphabet characters (including spaces, line breaks and misplaced padding characters), as this is the easiest and most performant to implement. It is also the most convenient for users of the function, as it requires no error handling at the call site.
- The decode function will also null-terminate the data, as this makes usage more convenient (for testing) with null-terminated strings.
- Using the full size 256 lookup table for decoding results in a 4.6x speedup compared to using a lookup function.
   - The second half of the lookup table is all 64, so it could be cut down by adding one if-statement instead, but that would reduce the speedup to 3.8x when compared to using a lookup function.
   - Performance was tested by decoding realistic inputs (i.e. encoded skin parts).

#### PNG loading

- Add `LoadPNG` method to load a png file from memory using pnglite, by implementing a pnglite read callback that operates on a memory buffer.
- Fix a memory leak in pnglite when png data cannot be loaded.
- Improve error messages.

## Open issues / Questions

- Should embedded skin parts be extracted into the skin parts folder as png files?
  - Extracted skin parts should go in a different folder than the user's skin parts.
  - A skin part md5 hash should be added to the json file when embedding skin parts.
- Saving skins with embedded parts will get rid of the embedded part, as embedding currently requires the skin part png file to be available. I can imagine the following solutions, ordered by how easy they would be to realise in my opinion:
  - Solution 1: Do not allow changing/saving skins that contain any embedded parts. Original authors can still save the skin, as the have the skin part files locally and the embedded parts are therefore not loaded.
  - Solution 2: Keep embedded skin parts in memory, so they can be embedded from memory when necessary.
  - Solution 3: Extract the embedded skin parts as png files into the skin parts folder, so they can be embedded from file when necessary (see above).
  - Solution 4: When saving a skin with embedded parts, load the embedded parts from the skins in which they are embedded. Requires keeping track of which part was loaded from which file and is problematic when skin files that contain embedded parts are overridden.