### PR TITLE
Fix undefined behavior in fixed point number conversion and random_int

### DIFF
--- a/src/base/math.h
+++ b/src/base/math.h
@@ -50,13 +50,27 @@ inline T bezier(const T p0, const T p1, const T p2, const T p3, TB amount)
 inline int random_int() { return (((rand() & 0xffff) << 16) | (rand() & 0xffff)) & 0x7FFFFFFF; }
 inline float random_float() { return rand()/(float)(RAND_MAX); }
 
+const int fxpscale = 1 << 10;
+
 // float to fixed
-inline int f2fx(float v) { return (int)(v*(float)(1<<10)); }
-inline float fx2f(int v) { return v*(1.0f/(1<<10)); }
+inline int f2fx(float v)
+{
+	return (int)(v * fxpscale);
+}
+inline float fx2f(int v)
+{
+	return v / (float)fxpscale;
+}
 
 // int to fixed
-inline int i2fx(int v) { return v<<10; }
-inline int fx2i(int v) { return v>>10; }
+inline int i2fx(int v)
+{
+	return v * fxpscale;
+}
+inline int fx2i(int v)
+{
+	return v / fxpscale;
+}
 
 inline int gcd(int a, int b)
 {
@@ -73,11 +87,32 @@ class fxp
 {
 	int value;
 public:
-	void set(int v) { value = v; }
-	int get() const { return value; }
-	fxp &operator = (int v) { value = v<<10; return *this; }
-	fxp &operator = (float v) { value = (int)(v*(float)(1<<10)); return *this; }
-	operator float() const { return value/(float)(1<<10); }
+	void set(int v)
+	{
+		value = v;
+	}
+	int get() const
+	{
+		return value;
+	}
+	fxp &operator=(int v)
+	{
+		value = i2fx(v);
+		return *this;
+	}
+	fxp &operator=(float v)
+	{
+		value = f2fx(v);
+		return *this;
+	}
+	operator int() const
+	{
+		return fx2i(value);
+	}
+	operator float() const
+	{
+		return fx2f(value);
+	}
 };
 
 const float pi = 3.1415926535897932384626433f;

--- a/src/base/math.h
+++ b/src/base/math.h
@@ -47,8 +47,15 @@ inline T bezier(const T p0, const T p1, const T p2, const T p3, TB amount)
 	return mix(c20, c21, amount); // c30
 }
 
-inline int random_int() { return (((rand() & 0xffff) << 16) | (rand() & 0xffff)) & 0x7FFFFFFF; }
-inline float random_float() { return rand()/(float)(RAND_MAX); }
+inline int random_int()
+{
+	return ((rand() & 0x7fff) << 16) | (rand() & 0xffff);
+}
+
+inline float random_float()
+{
+	return rand() / (float)RAND_MAX;
+}
 
 const int fxpscale = 1 << 10;
 

--- a/src/base/math.h
+++ b/src/base/math.h
@@ -5,7 +5,7 @@
 
 #include <stdlib.h>
 
-template <typename T>
+template<typename T>
 inline T clamp(T val, T min, T max)
 {
 	if(val < min)
@@ -17,20 +17,20 @@ inline T clamp(T val, T min, T max)
 
 inline float sign(float f)
 {
-	return f<0.0f?-1.0f:1.0f;
+	return f < 0.0f ? -1.0f : 1.0f;
 }
 
 inline int round_to_int(float f)
 {
-	if(f > 0)
-		return (int)(f+0.5f);
-	return (int)(f-0.5f);
+	if(f > 0.0f)
+		return (int)(f + 0.5f);
+	return (int)(f - 0.5f);
 }
 
 template<typename T, typename TB>
 inline T mix(const T a, const T b, TB amount)
 {
-	return a + (b-a)*amount;
+	return a + (b - a) * amount;
 }
 
 template<typename T, typename TB>
@@ -124,8 +124,22 @@ public:
 
 const float pi = 3.1415926535897932384626433f;
 
-template <typename T> inline T minimum(T a, T b) { return a<b?a:b; }
-template <typename T> inline T maximum(T a, T b) { return a>b?a:b; }
-template <typename T> inline T absolute(T a) { return a<T(0)?-a:a; }
+template<typename T>
+inline T minimum(T a, T b)
+{
+	return a < b ? a : b;
+}
+
+template<typename T>
+inline T maximum(T a, T b)
+{
+	return a > b ? a : b;
+}
+
+template<typename T>
+inline T absolute(T a)
+{
+	return a < T(0) ? -a : a;
+}
 
 #endif // BASE_MATH_H


### PR DESCRIPTION
- Shifting signed integers (in `fx2i` and `i2fx`) is undefined behavior. The shifts are replaced with equivalent multiplication and division.
- Internally, the `random_int()` function may shift a bit into the sign bit, which is undefined behavior. The masks are adjusted so this is no longer the case.