### PR TITLE
feat(ci): create nightly builds

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -16,27 +16,27 @@ jobs:
           cmake-args: -G "Unix Makefiles"
           build-args: --parallel
           package-file: teeworlds-*-linux_x86_64.tar.xz
-          env:
+          env: |
             CFLAGS: -Wdeclaration-after-statement -Werror
             CXXFLAGS: -Werror
         - os: ubuntu-20.04
           cmake-path: /usr/bin/
           cmake-args: -G "Unix Makefiles"
           package-file: teeworlds-*-linux_x86_64.tar.xz
-          env:
+          env: |
             CFLAGS: -Wdeclaration-after-statement -Werror
             CXXFLAGS: -Werror
         - os: macOS-latest
           cmake-args: -G "Unix Makefiles"
           build-args: --parallel
           package-file: teeworlds-*-osx.dmg
-          env:
+          env: |
             CFLAGS: -Wdeclaration-after-statement -Werror
             CXXFLAGS: -Werror
         - os: windows-latest
           cmake-args: -A x64
           package-file: teeworlds-*-win64.zip
-          env:
+          env: |
             CFLAGS: /WX
             CXXFLAGS: /WX
             LDFLAGS: /WX
@@ -99,7 +99,7 @@ jobs:
         ${{ matrix.cmake-path }}cmake --build . --config Release ${{ matrix.build-args }} --target package_default
         mkdir artifacts
         mv ${{ matrix.package-file }} artifacts
-# because each os is seperate proccess, each will replace the other so need a different tag.
+# because each os is seperate build, each will replace the other so it needs a different tag.
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -101,7 +101,7 @@ jobs:
         mv ${{ matrix.package-file }} artifacts
 
     - uses: "marvinpinto/action-automatic-releases@latest"
-        with:
+      with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "nightly-builds"
           prerelease: true

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -10,33 +10,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest, ubuntu-20.04]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         include:
         - os: ubuntu-latest
           cmake-args: -G "Unix Makefiles"
           build-args: --parallel
           package-file: teeworlds-*-linux_x86_64.tar.xz
-          env: |
-            CFLAGS: -Wdeclaration-after-statement -Werror
-            CXXFLAGS: -Werror
-        - os: ubuntu-20.04
-          cmake-path: /usr/bin/
-          cmake-args: -G "Unix Makefiles"
-          package-file: teeworlds-*-linux_x86_64.tar.xz
-          env: |
+          env:
             CFLAGS: -Wdeclaration-after-statement -Werror
             CXXFLAGS: -Werror
         - os: macOS-latest
           cmake-args: -G "Unix Makefiles"
           build-args: --parallel
           package-file: teeworlds-*-osx.dmg
-          env: |
+          env:
             CFLAGS: -Wdeclaration-after-statement -Werror
             CXXFLAGS: -Werror
         - os: windows-latest
           cmake-args: -A x64
           package-file: teeworlds-*-win64.zip
-          env: |
+          env:
             CFLAGS: /WX
             CXXFLAGS: /WX
             LDFLAGS: /WX

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -106,7 +106,7 @@ jobs:
           automatic_release_tag: "nightly-builds"
           prerelease: true
           title: "Nightly Teeworlds build"
-          files: "./release/artifacts/*"
+          files: "./artifacts/*"
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v1

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,6 +1,9 @@
-name: Build
+name: Build-nightly
 
-on: [push, pull_request]
+on:
+  push:
+      branches:
+        - 'nightly-unstable-build'
 
 jobs:
   build-cmake:
@@ -96,6 +99,14 @@ jobs:
         ${{ matrix.cmake-path }}cmake --build . --config Release ${{ matrix.build-args }} --target package_default
         mkdir artifacts
         mv ${{ matrix.package-file }} artifacts
+
+    - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "nightly-builds"
+          prerelease: true
+          title: "Nightly Teeworlds build"
+          files: "./release/artifacts/*"
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v1

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -3,7 +3,7 @@ name: Build-nightly
 on:
   push:
       branches:
-        - 'nightly-unstable-build'
+        - 'master'
 
 jobs:
   build-cmake:

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -103,9 +103,9 @@ jobs:
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "nightly-builds"
+          automatic_release_tag: "nightly-${{ matrix.os }}-builds"
           prerelease: true
-          title: "Nightly Teeworlds build"
+          title: "Nightly ${{ matrix.os }} Teeworlds build"
           files: "./release/artifacts"
 
     - name: Upload Artifacts

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -106,7 +106,7 @@ jobs:
           automatic_release_tag: "nightly-builds"
           prerelease: true
           title: "Nightly Teeworlds build"
-          files: "./artifacts/*"
+          files: "./release/artifacts"
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v1

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -99,7 +99,7 @@ jobs:
         ${{ matrix.cmake-path }}cmake --build . --config Release ${{ matrix.build-args }} --target package_default
         mkdir artifacts
         mv ${{ matrix.package-file }} artifacts
-
+# because each os is seperate proccess, each will replace the other so need a different tag.
     - uses: "marvinpinto/action-automatic-releases@latest"
       with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
You can see this at: https://github.com/cat-master21/teeworlds/releases. Each OS needs a different tag because they run on multiple machines meaning multiple times does automatic release get pushed and so the OSes replace themselves.