### PR TITLE
Add demo skipping to 0%, 10%, ..., 90% with number/keypad keys, refactoring

### DIFF
--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -34,6 +34,7 @@ public:
 	public:
 		bool m_Paused;
 		float m_Speed;
+		int m_SpeedIndex;
 
 		int m_FirstTick;
 		int m_CurrentTick;
@@ -52,6 +53,7 @@ public:
 
 	~IDemoPlayer() {}
 	virtual void SetSpeed(float Speed) = 0;
+	virtual void SetSpeedIndex(int Offset) = 0;
 	virtual int SetPos(float Percent) = 0;
 	virtual int SetPos(int WantedTick) = 0;
 	virtual void Pause() = 0;

--- a/src/engine/keys.h
+++ b/src/engine/keys.h
@@ -327,4 +327,20 @@ enum
 inline int KeyToKeycode(int Key) { return (Key>=0x80) ? (Key-0x80)|(1<<30) : Key; }
 inline int KeycodeToKey(int Keycode) { return (Keycode&(1<<30)) ? Keycode-(1<<30)+0x80 : Keycode; }
 
+inline int DigitToNumberKey(int Digit)
+{
+	if(Digit < 0 || Digit > 9)
+		return KEY_UNKNOWN;
+	return KEY_0 + Digit;
+}
+
+inline int DigitToKeypadKey(int Digit)
+{
+	if(Digit < 0 || Digit > 9)
+		return KEY_UNKNOWN;
+	if(Digit == 0)
+		return KEY_KP_0;
+	return KEY_KP_1 + Digit - 1;
+}
+
 #endif

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -338,6 +338,7 @@ void CDemoRecorder::AddDemoMarker()
 }
 
 
+const float CDemoPlayer::ms_aSpeeds[] = {0.05f, 0.1f, 0.25f, 0.5f, 0.75f, 1.0f, 2.0f, 4.0f, 8.0f};
 
 CDemoPlayer::CDemoPlayer(class CSnapshotDelta *pSnapshotDelta)
 {
@@ -633,7 +634,8 @@ const char *CDemoPlayer::Load(const char *pFilename, int StorageType, const char
 	m_Info.m_NextTick = -1;
 	m_Info.m_Info.m_CurrentTick = -1;
 	m_Info.m_PreviousTick = -1;
-	m_Info.m_Info.m_Speed = 1;
+	m_Info.m_Info.m_Speed = 1.0f;
+	m_Info.m_Info.m_SpeedIndex = 5;
 
 	m_LastSnapshotDataSize = -1;
 
@@ -770,6 +772,12 @@ int CDemoPlayer::SetPos(int WantedTick)
 void CDemoPlayer::SetSpeed(float Speed)
 {
 	m_Info.m_Info.m_Speed = Speed;
+}
+
+void CDemoPlayer::SetSpeedIndex(int Offset)
+{
+	m_Info.m_Info.m_SpeedIndex = clamp<int>(m_Info.m_Info.m_SpeedIndex + Offset, 0, sizeof(ms_aSpeeds) / sizeof(ms_aSpeeds[0]) - 1);
+	SetSpeed(ms_aSpeeds[m_Info.m_Info.m_SpeedIndex]);
 }
 
 int CDemoPlayer::Update()

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -71,6 +71,8 @@ public:
 	};
 
 private:
+	static const float ms_aSpeeds[];
+
 	IListener *m_pListener;
 
 
@@ -117,6 +119,7 @@ public:
 	void Unpause();
 	int Stop();
 	void SetSpeed(float Speed);
+	void SetSpeedIndex(int Offset);
 	int SetPos(float Percent);
 	int SetPos(int WantedTick);
 	const CInfo *BaseInfo() const { return &m_Info.m_Info; }

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -199,8 +199,8 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			// Go to previous/next marker if ctrl is held.
 			// Go to start/end if there is no marker.
 
-			// Threshold to consider all ticks close to a marker to be that markers position.
-			// Necessary, as setting the demo players position does not set it to exactly the desired tick.
+			// Threshold to consider all ticks close to a marker to be that marker's position.
+			// Necessary, as setting the demo player's position does not set it to exactly the desired tick.
 			const int Threshold = 10;
 
 			if(SkipForwards)

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -75,14 +75,14 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	if(m_SeekBarActivatedTime < Now - 5*time_freq())
 		m_SeekBarActive = false;
 
+	bool SeekBarActivate = false;
 	if(m_MenuActive)
 	{
 		MainView.HSplitTop(SeekBarHeight, &SeekBar, &ButtonBar);
 		ButtonBar.HSplitTop(Margins, 0, &ButtonBar);
 		ButtonBar.HSplitBottom(NameBarHeight, &ButtonBar, &NameBar);
 		NameBar.HSplitTop(4.0f, 0, &NameBar);
-		m_SeekBarActive = true;
-		m_SeekBarActivatedTime = Now;
+		SeekBarActivate = true;
 	}
 	else
 		SeekBar = MainView;
@@ -182,9 +182,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			DemoPlayer()->Pause();
 		else
 			DemoPlayer()->Unpause();
-
-		m_SeekBarActive = true;
-		m_SeekBarActivatedTime = Now;
+		SeekBarActivate = true;
 	}
 
 	// skip forward/backward using left/right arrow keys
@@ -253,10 +251,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		}
 
 		PositionToSeek = clamp(DesiredTick, 0, TotalTicks-1)/(float)TotalTicks;
-
-		// Show the seek bar for a few seconds after skipping
-		m_SeekBarActive = true;
-		m_SeekBarActivatedTime = Now;
+		SeekBarActivate = true;
 	}
 
 	// Advance single frame forward/backward with period/comma key
@@ -268,8 +263,11 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		DemoPlayer()->SetPos(pInfo->m_CurrentTick + (TickForwards ? 3 : 0));
 		m_pClient->m_SuppressEvents = false;
 		DemoPlayer()->Pause();
+		SeekBarActivate = true;
+	}
 
-		// Show the seek bar for a few seconds after skipping
+	if(SeekBarActivate)
+	{
 		m_SeekBarActive = true;
 		m_SeekBarActivatedTime = Now;
 	}

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -35,11 +35,9 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	const float NameBarHeight = 20.0f;
 	const float Margins = 5.0f;
 
-	float TotalHeight;
+	float TotalHeight = SeekBarHeight + Margins * 2;
 	if(m_MenuActive)
-		TotalHeight = SeekBarHeight+ButtonbarHeight+NameBarHeight+Margins*3;
-	else
-		TotalHeight = SeekBarHeight+Margins*2;
+		TotalHeight += ButtonbarHeight + NameBarHeight + Margins;
 
 	MainView.HSplitBottom(TotalHeight, 0, &MainView);
 	MainView.VSplitLeft(50.0f, 0, &MainView);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -170,8 +170,10 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		PositionToSeek = 0.0f;
 	}
 
-	bool IncreaseDemoSpeed = UI()->KeyPress(KEY_MOUSE_WHEEL_UP) || UI()->KeyPress(KEY_PLUS) || UI()->KeyPress(KEY_KP_PLUS);
-	bool DecreaseDemoSpeed = UI()->KeyPress(KEY_MOUSE_WHEEL_DOWN) || UI()->KeyPress(KEY_MINUS) || UI()->KeyPress(KEY_KP_MINUS);
+	if(UI()->KeyPress(KEY_MOUSE_WHEEL_UP) || UI()->KeyPress(KEY_PLUS) || UI()->KeyPress(KEY_KP_PLUS))
+		DemoPlayer()->SetSpeedIndex(+1);
+	else if(UI()->KeyPress(KEY_MOUSE_WHEEL_DOWN) || UI()->KeyPress(KEY_MINUS) || UI()->KeyPress(KEY_KP_MINUS))
+		DemoPlayer()->SetSpeedIndex(-1);
 
 	// add spacebar for toggling Play/Pause
 	if(UI()->KeyPress(KEY_SPACE))
@@ -317,14 +319,14 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		ButtonBar.VSplitLeft(ButtonbarHeight, &Button, &ButtonBar);
 		static CButtonContainer s_SlowDownButton;
 		if(DoButton_SpriteID(&s_SlowDownButton, IMAGE_DEMOBUTTONS, SPRITE_DEMOBUTTON_SLOWER, false, &Button, CUIRect::CORNER_ALL))
-			DecreaseDemoSpeed = true;
+			DemoPlayer()->SetSpeedIndex(-1);
 
 		// fastforward
 		ButtonBar.VSplitLeft(Margins, 0, &ButtonBar);
 		ButtonBar.VSplitLeft(ButtonbarHeight, &Button, &ButtonBar);
 		static CButtonContainer s_FastForwardButton;
 		if(DoButton_SpriteID(&s_FastForwardButton, IMAGE_DEMOBUTTONS, SPRITE_DEMOBUTTON_FASTER, false, &Button, CUIRect::CORNER_ALL))
-			IncreaseDemoSpeed = true;
+			DemoPlayer()->SetSpeedIndex(+1);
 
 		// speed meter
 		ButtonBar.VSplitLeft(Margins*3, 0, &ButtonBar);
@@ -344,29 +346,6 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		char aBuf[128];
 		str_format(aBuf, sizeof(aBuf), Localize("Demofile: %s"), aDemoName);
 		UI()->DoLabel(&NameBar, aBuf, Button.h*0.5f, TEXTALIGN_TL, NameBar.w);
-	}
-
-	if(IncreaseDemoSpeed)
-	{
-		if(pInfo->m_Speed < 0.1f) DemoPlayer()->SetSpeed(0.1f);
-		else if(pInfo->m_Speed < 0.25f) DemoPlayer()->SetSpeed(0.25f);
-		else if(pInfo->m_Speed < 0.5f) DemoPlayer()->SetSpeed(0.5f);
-		else if(pInfo->m_Speed < 0.75f) DemoPlayer()->SetSpeed(0.75f);
-		else if(pInfo->m_Speed < 1.0f) DemoPlayer()->SetSpeed(1.0f);
-		else if(pInfo->m_Speed < 2.0f) DemoPlayer()->SetSpeed(2.0f);
-		else if(pInfo->m_Speed < 4.0f) DemoPlayer()->SetSpeed(4.0f);
-		else DemoPlayer()->SetSpeed(8.0f);
-	}
-	else if(DecreaseDemoSpeed)
-	{
-		if(pInfo->m_Speed > 4.0f) DemoPlayer()->SetSpeed(4.0f);
-		else if(pInfo->m_Speed > 2.0f) DemoPlayer()->SetSpeed(2.0f);
-		else if(pInfo->m_Speed > 1.0f) DemoPlayer()->SetSpeed(1.0f);
-		else if(pInfo->m_Speed > 0.75f) DemoPlayer()->SetSpeed(0.75f);
-		else if(pInfo->m_Speed > 0.5f) DemoPlayer()->SetSpeed(0.5f);
-		else if(pInfo->m_Speed > 0.25f) DemoPlayer()->SetSpeed(0.25f);
-		else if(pInfo->m_Speed > 0.1f) DemoPlayer()->SetSpeed(0.1f);
-		else DemoPlayer()->SetSpeed(0.05f);
 	}
 
 	if(PositionToSeek >= 0.0f && PositionToSeek <= 1.0f)

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -251,6 +251,19 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		PositionToSeek = clamp(DesiredTick, 0, TotalTicks-1)/(float)TotalTicks;
 		SeekBarActivate = true;
 	}
+	else
+	{
+		// Skip to 0%, 10%, ..., 90% with number keys
+		for(int Digit = 0; Digit < 10; ++Digit)
+		{
+			if(UI()->KeyPress(DigitToNumberKey(Digit)) || UI()->KeyPress(DigitToKeypadKey(Digit)))
+			{
+				PositionToSeek = Digit / 10.0f;
+				SeekBarActivate = true;
+				break;
+			}
+		}
+	}
 
 	// Advance single frame forward/backward with period/comma key
 	const bool TickForwards = UI()->KeyPress(KEY_PERIOD);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -45,7 +45,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	MainView.VSplitLeft(50.0f, 0, &MainView);
 	MainView.VSplitRight(450.0f, &MainView, 0);
 
-	if (m_SeekBarActive || m_MenuActive) // only draw the background if SeekBar or Menu is active
+	if(m_SeekBarActive || m_MenuActive) // only draw the background if SeekBar or Menu is active
 		MainView.Draw(vec4(0.0f, 0.0f, 0.0f, Config()->m_ClMenuAlpha/100.0f), 10.0f, CUIRect::CORNER_T);
 
 	MainView.Margin(5.0f, &MainView);
@@ -62,7 +62,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	// we can toggle the seekbar using CTRL
 	if(!m_MenuActive && !s_LastCtrlDown && CtrlDown)
 	{
-		if (m_SeekBarActive)
+		if(m_SeekBarActive)
 			m_SeekBarActive = false;
 		else
 		{

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -48,7 +48,6 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 
 	MainView.Margin(5.0f, &MainView);
 
-	CUIRect SeekBar, ButtonBar, NameBar;
 
 	const bool CtrlDown = UI()->KeyIsPressed(KEY_LCTRL) || UI()->KeyIsPressed(KEY_RCTRL);
 	static bool s_LastCtrlDown = CtrlDown;
@@ -73,6 +72,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	if(m_SeekBarActivatedTime < Now - 5*time_freq())
 		m_SeekBarActive = false;
 
+	CUIRect SeekBar, ButtonBar, NameBar;
 	bool SeekBarActivate = false;
 	if(m_MenuActive)
 	{


### PR DESCRIPTION
Pressing the 0 - 9 number/keypad keys in the demo player will skip to 0% - 90% of the demo length.