### PR TITLE
Implement smooth scrolling for UI editbox and chat input, don't blink the caret shortly after moving

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -928,6 +928,7 @@ void CChat::OnRender()
 			pCursor->m_MaxWidth = Width-190.0f-s_CategoryCursor.Width();
 
 			float ScrollOffset = m_Input.GetScrollOffset();
+			float ScrollOffsetChange = m_Input.GetScrollOffsetChange();
 			pCursor->MoveTo(CursorPosition.x, CursorPosition.y - ScrollOffset);
 			pCursor->m_MaxLines = -1;
 			pCursor->m_Flags = TEXTFLAG_WORD_WRAP;
@@ -977,11 +978,16 @@ void CChat::OnRender()
 			Graphics()->ClipDisable();
 
 			// scroll to keep the caret inside the clipping rect
-			const float CaretPositionY = m_Input.GetCaretPosition().y + InputFontSize * 0.5f;
+			const float CaretPositionY = m_Input.GetCaretPosition().y + InputFontSize * 0.5f - ScrollOffsetChange;
 			if(CaretPositionY < ClippingRect.y)
-				m_Input.SetScrollOffset(maximum(0.0f, ScrollOffset - InputFontSize));
+				ScrollOffsetChange -= InputFontSize;
 			else if(CaretPositionY + InputFontSize * 0.35f > ClippingRect.y + ClippingRect.h)
-				m_Input.SetScrollOffset(ScrollOffset + InputFontSize);
+				ScrollOffsetChange += InputFontSize;
+
+			UI()->DoSmoothScrollLogic(&ScrollOffset, &ScrollOffsetChange, ClippingRect.h, pCursor->BoundingBox().h);
+
+			m_Input.SetScrollOffset(ScrollOffset);
+			m_Input.SetScrollOffsetChange(ScrollOffsetChange);
 		}
 	}
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -974,7 +974,7 @@ void CChat::OnRender()
 			const float XScale = Graphics()->ScreenWidth()/Width;
 			const float YScale = Graphics()->ScreenHeight()/Height;
 			Graphics()->ClipEnable((int)(ClippingRect.x*XScale), (int)(ClippingRect.y*YScale), (int)(ClippingRect.w*XScale), (int)(ClippingRect.h*YScale));
-			m_Input.Render();
+			m_Input.Render(m_Input.WasChanged());
 			Graphics()->ClipDisable();
 
 			// scroll to keep the caret inside the clipping rect

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -560,7 +560,7 @@ void CGameConsole::OnRender()
 		pInputCursor->MoveTo(x, y + FontSize * 1.35f);
 
 		pConsole->m_Input.Activate(CONSOLE); // ensure the input is active
-		pConsole->m_Input.Render();
+		pConsole->m_Input.Render(pConsole->m_Input.WasChanged());
 
 		y -= (pInputCursor->LineCount() - 1) * FontSize;
 

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -386,9 +386,11 @@ void CGameConsole::PossibleCommandsRenderCallback(int Index, const char *pStr, v
 		Rect.Draw(vec4(229.0f/255.0f,185.0f/255.0f,4.0f/255.0f,0.85f), pInfo->m_pCursor->m_FontSize/3);
 
 		// scroll when out of sight
-		if(Rect.x - *pInfo->m_pOffsetChange < 0.0f)
+		const bool MoveLeft = Rect.x - *pInfo->m_pOffsetChange < 0.0f;
+		const bool MoveRight = Rect.x + Rect.w - *pInfo->m_pOffsetChange > pInfo->m_Width;
+		if(MoveLeft && !MoveRight)
 			*pInfo->m_pOffsetChange -= -Rect.x + pInfo->m_Width/4.0f;
-		else if(Rect.x + Rect.w - *pInfo->m_pOffsetChange > pInfo->m_Width)
+		else if(!MoveLeft && MoveRight)
 			*pInfo->m_pOffsetChange += Rect.x + Rect.w - pInfo->m_Width + pInfo->m_Width/4.0f;
 	}
 	else

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -32,7 +32,7 @@ void CLineInput::SetBuffer(char *pStr, int MaxSize, int MaxChars)
 	m_WasChanged = m_pStr && pLastStr && m_WasChanged;
 	if(!pLastStr)
 	{
-		m_ScrollOffset = 0;
+		m_ScrollOffset = m_ScrollOffsetChange = 0.0f;
 		m_CaretPosition = vec2(0, 0);
 		m_Hidden = false;
 	}

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -44,6 +44,7 @@ class CLineInput
 	int m_SelectionEnd;
 
 	float m_ScrollOffset;
+	float m_ScrollOffsetChange;
 	vec2 m_CaretPosition;
 
 	bool m_Hidden;
@@ -102,6 +103,8 @@ public:
 	// used either for vertical or horizontal scrolling
 	float GetScrollOffset() const { return m_ScrollOffset; }
 	void SetScrollOffset(float ScrollOffset) { m_ScrollOffset = ScrollOffset; }
+	float GetScrollOffsetChange() const { return m_ScrollOffsetChange; }
+	void SetScrollOffsetChange(float ScrollOffsetChange) { m_ScrollOffsetChange = ScrollOffsetChange; }
 
 	vec2 GetCaretPosition() const { return m_CaretPosition; } // only updated while the input is active
 

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -5,6 +5,7 @@
 
 #include <base/vmath.h>
 
+#include <engine/client.h>
 #include <engine/graphics.h>
 #include <engine/input.h>
 #include <engine/textrender.h>
@@ -23,6 +24,7 @@ class CLineInput
 	static IInput *s_pInput;
 	static ITextRender *s_pTextRender;
 	static IGraphics *s_pGraphics;
+	static IClient *s_pClient;
 
 	static CLineInput *s_pActiveInput;
 	static EInputPriority s_ActiveInputPriority;
@@ -64,7 +66,13 @@ class CLineInput
 	void OnDeactivate();
 
 public:
-	static void Init(IInput *pInput, ITextRender *pTextRender, IGraphics *pGraphics) { s_pInput = pInput; s_pTextRender = pTextRender; s_pGraphics = pGraphics; }
+	static void Init(IInput *pInput, ITextRender *pTextRender, IGraphics *pGraphics, IClient *pClient)
+	{
+		s_pInput = pInput;
+		s_pTextRender = pTextRender;
+		s_pGraphics = pGraphics;
+		s_pClient = pClient;
+	}
 	static void RenderCandidates();
 
 	static CLineInput *GetActiveInput() { return s_pActiveInput; }
@@ -114,7 +122,7 @@ public:
 	bool ProcessInput(const IInput::CEvent &Event);
 	bool WasChanged() { bool Changed = m_WasChanged; m_WasChanged = false; return Changed; }
 
-	void Render();
+	void Render(bool Changed);
 
 	bool IsActive() const { return GetActiveInput() == this; }
 	void Activate(EInputPriority Priority);

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -305,6 +305,35 @@ bool CUI::DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float 
 	return true;
 }
 
+void CUI::DoSmoothScrollLogic(float *pScrollOffset, float *pScrollOffsetChange, float ViewPortSize, float TotalSize, float ScrollSpeed)
+{
+	// instant scrolling if distance too long
+	if(absolute(*pScrollOffsetChange) > ViewPortSize)
+	{
+		*pScrollOffset += *pScrollOffsetChange;
+		*pScrollOffsetChange = 0.0f;
+	}
+	// smooth scrolling
+	if(*pScrollOffsetChange)
+	{
+		const float Delta = *pScrollOffsetChange * clamp(Client()->RenderFrameTime() * ScrollSpeed, 0.0f, 1.0f);
+		*pScrollOffset += Delta;
+		*pScrollOffsetChange -= Delta;
+	}
+	// clamp to first item
+	if(*pScrollOffset < 0.0f)
+	{
+		*pScrollOffset = 0.0f;
+		*pScrollOffsetChange = 0.0f;
+	}
+	// clamp to last item
+	if(TotalSize > ViewPortSize && *pScrollOffset > TotalSize - ViewPortSize)
+	{
+		*pScrollOffset = TotalSize - ViewPortSize;
+		*pScrollOffsetChange = 0.0f;
+	}
+}
+
 void CUI::ApplyCursorAlign(class CTextCursor *pCursor, const CUIRect *pRect, int Align)
 {
 	pCursor->m_Align = Align;
@@ -389,6 +418,7 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 
 	bool UpdateOffset = false;
 	float ScrollOffset = pLineInput->GetScrollOffset();
+	float ScrollOffsetChange = pLineInput->GetScrollOffsetChange();
 
 	static bool s_DoScroll = false;
 	static int s_SelectionStartOffset = -1;
@@ -397,16 +427,14 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 	CUIRect Textbox;
 	pRect->VMargin(VSpacing, &Textbox);
 
+	float ScrollSpeed = 10.0f;
 	if(Active)
 	{
-		static float s_ScrollStartX = 0.0f;
-
 		int CursorOffset = pLineInput->GetCursorOffset();
 
 		if(Inside && MouseButton(0) && !Changed)
 		{
 			s_DoScroll = true;
-			s_ScrollStartX = MouseX();
 			const float MxRel = MouseX() - Textbox.x;
 			float TotalTextWidth = 0.0f;
 			for(int i = 1, Offset = 0; i <= pLineInput->GetNumChars(); i++)
@@ -414,7 +442,7 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 				const int PrevOffset = Offset;
 				Offset = str_utf8_forward(pDisplayStr, Offset);
 				const float AddedTextWidth = TextRender()->TextWidth(FontSize, pDisplayStr + PrevOffset, Offset - PrevOffset);
-				if(TotalTextWidth + AddedTextWidth/2.0f - ScrollOffset > MxRel)
+				if(TotalTextWidth + AddedTextWidth/2.0f - ScrollOffset - ScrollOffsetChange > MxRel)
 				{
 					CursorOffset = PrevOffset;
 					if(s_SelectionStartOffset < 0)
@@ -438,18 +466,20 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 		}
 		else if(s_DoScroll)
 		{
-			// do scrolling
-			if(MouseX() < Textbox.x && s_ScrollStartX-MouseX() > 10.0f)
+			if(absolute(ScrollOffsetChange) < 10.0f)
 			{
-				CursorOffset = str_utf8_rewind(pDisplayStr, CursorOffset);
-				s_ScrollStartX = MouseX();
-				UpdateOffset = true;
-			}
-			else if(MouseX() > Textbox.x+Textbox.w && MouseX()-s_ScrollStartX > 10.0f)
-			{
-				CursorOffset = str_utf8_forward(pDisplayStr, CursorOffset);
-				s_ScrollStartX = MouseX();
-				UpdateOffset = true;
+				if(MouseX() < Textbox.x)
+				{
+					CursorOffset = str_utf8_rewind(pDisplayStr, CursorOffset);
+					ScrollSpeed *= clamp(Textbox.x - MouseX(), 1.0f, Textbox.w / 8.0f);
+					UpdateOffset = true;
+				}
+				else if(MouseX() > Textbox.x + Textbox.w)
+				{
+					CursorOffset = str_utf8_forward(pDisplayStr, CursorOffset);
+					ScrollSpeed *= clamp(MouseX() - Textbox.x - Textbox.w, 1.0f, Textbox.w / 8.0f);
+					UpdateOffset = true;
+				}
 			}
 		}
 		else if(!Inside && MouseButton(0))
@@ -519,28 +549,17 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 	// check if the text has to be moved
 	if(Active && !JustGotActive && (UpdateOffset || Changed))
 	{
-		const float CaretX = pLineInput->GetCaretPosition().x - Textbox.x;
-		if(CaretX - ScrollOffset > Textbox.w)
-		{
-			// move to the left
-			do
-			{
-				ScrollOffset += clamp(pLineInput->GetCursor()->Width() - ScrollOffset - Textbox.w, 0.1f, Textbox.w / 3.0f);
-			}
-			while(CaretX - ScrollOffset > Textbox.w);
-		}
-		else if(CaretX - ScrollOffset < 0.0f)
-		{
-			// move to the right
-			do
-			{
-				ScrollOffset = maximum(0.0f, ScrollOffset - Textbox.w / 3.0f);
-			}
-			while(CaretX - ScrollOffset < 0.0f);
-		}
+		const float CaretX = pLineInput->GetCaretPosition().x - Textbox.x - ScrollOffset - ScrollOffsetChange;
+		if(CaretX > Textbox.w)
+			ScrollOffsetChange += CaretX - Textbox.w;
+		else if(CaretX < 0.0f)
+			ScrollOffsetChange += CaretX;
 	}
 
+	DoSmoothScrollLogic(&ScrollOffset, &ScrollOffsetChange, Textbox.w, pCursor->Width(), ScrollSpeed);
+
 	pLineInput->SetScrollOffset(ScrollOffset);
+	pLineInput->SetScrollOffsetChange(ScrollOffsetChange);
 
 	return Changed;
 }

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -84,7 +84,7 @@ void CUI::Init(class IKernel *pKernel)
 	m_pInput = pKernel->RequestInterface<IInput>();
 	m_pTextRender = pKernel->RequestInterface<ITextRender>();
 	CUIRect::Init(m_pGraphics);
-	CLineInput::Init(m_pInput, m_pTextRender, m_pGraphics);
+	CLineInput::Init(m_pInput, m_pTextRender, m_pGraphics, m_pClient);
 	CUIElementBase::Init(this);
 }
 
@@ -447,6 +447,7 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 					CursorOffset = PrevOffset;
 					if(s_SelectionStartOffset < 0)
 						s_SelectionStartOffset = CursorOffset;
+					UpdateOffset = true;
 					break;
 				}
 				TotalTextWidth += AddedTextWidth;
@@ -456,6 +457,7 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 					CursorOffset = pLineInput->GetLength();
 					if(s_SelectionStartOffset < 0)
 						s_SelectionStartOffset = CursorOffset;
+					UpdateOffset = true;
 				}
 			}
 		}
@@ -543,7 +545,7 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 	ClipEnable(pRect);
 	Textbox.x -= ScrollOffset;
 	ApplyCursorAlign(pCursor, &Textbox, TEXTALIGN_ML);
-	pLineInput->Render();
+	pLineInput->Render(UpdateOffset || Changed);
 	ClipDisable();
 
 	// check if the text has to be moved

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -259,6 +259,7 @@ public:
 
 	bool DoButtonLogic(const void *pID, const CUIRect *pRect, int Button = 0);
 	bool DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *pY);
+	void DoSmoothScrollLogic(float *pScrollOffset, float *pScrollOffsetChange, float ViewPortSize, float TotalSize, float ScrollSpeed = 10.0f);
 
 	// labels
 	void DoLabel(const CUIRect *pRect, const char *pText, float FontSize, int Align = TEXTALIGN_TL, float LineWidth = -1.0f, bool MultiLine = true);


### PR DESCRIPTION
## Smooth UI editbox scrolling

Before:

https://user-images.githubusercontent.com/23437060/164890862-d277811b-f57f-428f-b8e2-d307cf507fdb.mp4

After:

https://user-images.githubusercontent.com/23437060/164890868-699cd631-1f9f-40f9-b1f6-81995a223ccb.mp4


## Smooth chat input scrolling

Before:

https://user-images.githubusercontent.com/23437060/164890884-facbb160-8bb4-4220-a7e8-67f8bb5cd6c1.mp4

After:

https://user-images.githubusercontent.com/23437060/164890885-e21b62c6-fa68-4973-a7ae-56319eb7002e.mp4

## Caret rendering

Always render (don't blink) the caret for 0.5 seconds after it has been moved, which makes it easier to follow the position of the caret. See videos above (set speed to 0.5x to make it easier to see in the videos, which are only 30 fps). It's also implemented like this on the editor2 branch already. 

### Refactor console smooth scrolling

Reuse the smooth scrolling logic in console, UI and chat. This required to invert the sign of the scroll offset in the console so it's consistent with chat and UI scrolling.