### PR TITLE
Fix ingame menu buttons when mouse is held and released ingame / when mouse is held ingame and released in menu

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1776,10 +1776,10 @@ void CMenus::OnRender()
 				TextRender()->TextOutlined(&s_Cursor, aBuf, -1);
 			}
 
-			UI()->FinishCheck();
 		}
 	}
 
+	UI()->FinishCheck();
 	UI()->ClearHotkeys();
 }
 

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -230,7 +230,7 @@ public:
 	const void *LastActiveItem() const { return m_pLastActiveItem; }
 
 	void StartCheck() { m_ActiveItemValid = false; }
-	void FinishCheck() { if(!m_ActiveItemValid) SetActiveItem(0); }
+	void FinishCheck() { if(!m_ActiveItemValid && m_pActiveItem != 0) { SetActiveItem(0); m_pHotItem = 0; m_pBecommingHotItem = 0; } }
 
 	bool MouseInside(const CUIRect *pRect) const { return pRect->Inside(m_MouseX, m_MouseY); }
 	bool MouseInsideClip() const { return !IsClipped() || MouseInside(ClipArea()); }


### PR DESCRIPTION
Fixes the following behavior:

1. Player is ingame and the ingame menu is opened with Esc
2. The left mouse button is held down on one of the ingame menu buttons (e.g. the spectate button)
3. The ingame menu is closed without moving the mouse away from the button
4. The left mouse button is released while ingame
5. The menu is opened again
    - Current behavior: The hovered button is immediately activated, as soon as the menu opens, due to the released mouse state being handled as a click.
    - Fixed behavior: The button is not activated. Instead the call to `FinishCheck` is moved so it's also called when the menu is not active, to clear the active UI item in that case.


As well as the following:
1. The menu is closed while the mouse cursor is hovering over a button.
2. The mouse button is pressed and held while the menu is closed.
3. The menu is opened again.
   - Current behavior: The menu button is already held down and when the player releases the mouse button it will immediately be activated.
   - Fixed behavior: The button is not activated immediately, by clearing the hot item and next hot item variables in `FinishCheck`.

The latter behavior can still occur when entering the editor instead of closing the ingame menu.