### PR TITLE
Fix segfault in `SDL_JoystickClose` on client quit

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2178,6 +2178,7 @@ void CClient::Run()
 	GameClient()->OnShutdown();
 	Disconnect();
 
+	m_pInput->Shutdown();
 	m_pGraphics->Shutdown();
 	m_pSound->Shutdown();
 	m_pTextRender->Shutdown();

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -75,13 +75,6 @@ CInput::CInput()
 	m_CandidateSelectedIndex = -1;
 }
 
-CInput::~CInput()
-{
-	if(m_pClipboardText)
-		SDL_free(m_pClipboardText);
-	CloseJoysticks();
-}
-
 void CInput::Init()
 {
 	StopTextInput();
@@ -93,6 +86,12 @@ void CInput::Init()
 	MouseModeRelative();
 
 	InitJoysticks();
+}
+
+void CInput::Shutdown()
+{
+	SDL_free(m_pClipboardText);
+	CloseJoysticks();
 }
 
 void CInput::InitJoysticks()
@@ -183,16 +182,11 @@ CInput::CJoystick::CJoystick(CInput *pInput, int Index, SDL_Joystick *pDelegate)
 
 void CInput::CloseJoysticks()
 {
-	for(array<CJoystick>::range r = m_aJoysticks.all(); !r.empty(); r.pop_front())
-		r.front().Close();
+	if(SDL_WasInit(SDL_INIT_JOYSTICK))
+		SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
+
 	m_aJoysticks.clear();
 	m_pActiveJoystick = 0x0;
-}
-
-void CInput::CJoystick::Close()
-{
-	if(SDL_JoystickGetAttached(m_pDelegate))
-		SDL_JoystickClose(m_pDelegate);
 }
 
 void CInput::SelectNextJoystick()

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -39,7 +39,6 @@ public:
 		int GetHatValue(int Hat);
 		bool Relative(float *pX, float *pY);
 		bool Absolute(float *pX, float *pY);
-		void Close();
 
 		static int GetJoystickHatKey(int Hat, int HatValue);
 	};
@@ -97,9 +96,9 @@ private:
 
 public:
 	CInput();
-	~CInput();
 
 	void Init();
+	void Shutdown();
 	int Update();
 
 	bool KeyIsPressed(int Key) const { return KeyState(Key); }

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -130,6 +130,7 @@ class IEngineInput : public IInput
 	MACRO_INTERFACE("engineinput", 0)
 public:
 	virtual void Init() = 0;
+	virtual void Shutdown() = 0;
 	virtual int Update() = 0;
 };
 


### PR DESCRIPTION
Instead of closing the joysticks manually, use `SDL_QuitSubSystem(SDL_INIT_JOYSTICK)` to quit the entire subsystem, which will also close all joysticks correctly.

The engine input destructor is replaced with a `Shutdown` method so we can control when it is called, i.e. before calling `SDL_Quit`, which forcefully quits all subsystems.

`CJoystick::Close` is removed as we don't need to close joysticks manually anymore.