### PR TITLE
Make the editor image selection popup list scrollable

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3824,7 +3824,7 @@ void CEditor::Render()
 		m_EditorOffsetY = 0;
 		m_ZoomLevel = 100;
 	}
-	if(m_Dialog == DIALOG_NONE && UI()->MouseInside(&View))
+	if(m_Dialog == DIALOG_NONE && !UI()->IsPopupActive() && UI()->MouseInside(&View))
 	{
 		// Determines in which direction to zoom.
 		int Zoom = 0;


### PR DESCRIPTION
Make the editor image selection popup list scrollable with a `CScrollRegion` to support maps with many images.

The width of the popup and list are also increased to support images with longer names.

Editor world/map scrolling with the mouse wheel is disabled while a popup is active, to better support popups with scrollable content.

Before:

![images-list old](https://user-images.githubusercontent.com/23437060/182029666-58752c7a-f7cd-44ee-8c54-89948cd23b01.png)

After:

![images-list new](https://user-images.githubusercontent.com/23437060/182029669-dcf599cb-0518-4c78-ae33-b5508d1623a2.png)
