### PR TITLE
Fix editor not loading map when double clicking after filtering list

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2795,6 +2795,10 @@ void CEditor::RenderFileDialog()
 				str_copy(m_aFilesSelectedName, m_FilteredFileList[m_FilesSelectedIndex]->m_aName, sizeof(m_aFilesSelectedName));
 			else
 				m_aFilesSelectedName[0] = '\0';
+			if(m_FilesSelectedIndex >= 0 && !m_FilteredFileList[m_FilesSelectedIndex]->m_IsDir)
+				m_FileDialogFileNameInput.Set(m_FilteredFileList[m_FilesSelectedIndex]->m_aFilename);
+			else
+				m_FileDialogFileNameInput.Clear();
 			s_ListBox.ScrollToSelected();
 		}
 	}


### PR DESCRIPTION
Loading the already selected map with double click or enter directly after filtering the maps list did not work, as the filename buffer (and its respective lineinput, which not shown in the Load file dialog) was not updated at that point.