### PR TITLE
Use djb2 for snapshot item hashlist

### DIFF
--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -96,6 +96,11 @@ enum
 	HASHLIST_SIZE = 256,
 };
 
+inline unsigned CalcHashID(int Key)
+{
+	return ((Key >> 12) & 0xf0) | (Key & 0xf);
+}
+
 static void GenerateHash(CItemList *pHashlist, const CSnapshot *pSnapshot)
 {
 	for(int i = 0; i < HASHLIST_SIZE; i++)
@@ -104,7 +109,7 @@ static void GenerateHash(CItemList *pHashlist, const CSnapshot *pSnapshot)
 	for(int i = 0; i < pSnapshot->NumItems(); i++)
 	{
 		int Key = pSnapshot->GetItem(i)->Key();
-		int HashID = ((Key>>12)&0xf0) | (Key&0xf);
+		unsigned HashID = CalcHashID(Key);
 		if(pHashlist[HashID].m_Num != 64)
 		{
 			pHashlist[HashID].m_aIndex[pHashlist[HashID].m_Num] = i;
@@ -116,7 +121,7 @@ static void GenerateHash(CItemList *pHashlist, const CSnapshot *pSnapshot)
 
 static int GetItemIndexHashed(int Key, const CItemList *pHashlist)
 {
-		int HashID = ((Key>>12)&0xf0) | (Key&0xf);
+		unsigned HashID = CalcHashID(Key);
 		for(int i = 0; i < pHashlist[HashID].m_Num; i++)
 		{
 			if(pHashlist[HashID].m_aKeys[i] == Key)

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -84,16 +84,17 @@ void CSnapshot::DebugDump() const
 
 // CSnapshotDelta
 
-struct CItemList
-{
-	int m_Num;
-	int m_aKeys[64];
-	int m_aIndex[64];
-};
-
 enum
 {
 	HASHLIST_SIZE = 256,
+	HASHLIST_BUCKET_SIZE = 64,
+};
+
+struct CItemList
+{
+	int m_Num;
+	int m_aKeys[HASHLIST_BUCKET_SIZE];
+	int m_aIndex[HASHLIST_BUCKET_SIZE];
 };
 
 inline unsigned CalcHashID(int Key)
@@ -110,7 +111,7 @@ static void GenerateHash(CItemList *pHashlist, const CSnapshot *pSnapshot)
 	{
 		int Key = pSnapshot->GetItem(i)->Key();
 		unsigned HashID = CalcHashID(Key);
-		if(pHashlist[HashID].m_Num != 64)
+		if(pHashlist[HashID].m_Num < HASHLIST_BUCKET_SIZE)
 		{
 			pHashlist[HashID].m_aIndex[pHashlist[HashID].m_Num] = i;
 			pHashlist[HashID].m_aKeys[pHashlist[HashID].m_Num] = Key;

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -99,7 +99,11 @@ struct CItemList
 
 inline unsigned CalcHashID(int Key)
 {
-	return ((Key >> 12) & 0xf0) | (Key & 0xf);
+	// djb2 (http://www.cse.yorku.ca/~oz/hash.html)
+	unsigned Hash = 5381;
+	for(unsigned Shift = 0; Shift < sizeof(int); Shift++)
+		Hash = ((Hash << 5) + Hash) + ((Key >> (Shift * 8)) & 0xFF);
+	return Hash % HASHLIST_SIZE;
 }
 
 static void GenerateHash(CItemList *pHashlist, const CSnapshot *pSnapshot)


### PR DESCRIPTION
The previous hash function was heavily biased towards the hash buckets 64-79, making those buckets overflow faster, which results in snapshot CRC errors and lags.

Using the djb2 hash yields an almost even distribution over the entire range of values.

Source for djb2: http://www.cse.yorku.ca/~oz/hash.html
(we incidentally use the same implementation for `str_quickhash`)

Sample which compares the usage of hash buckets in the test map from https://github.com/ddnet/ddnet/issues/5454 with the old and new hash function: [SnapshotHash.csv](https://github.com/ddnet/ddnet/files/9285148/SnapshotHash.csv) (this table also differentiates between the source and target of the snapshot delta)