### PR TITLE
Add console command history in the scrollback buffer

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -150,6 +150,10 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 				{
 					char *pEntry = m_History.Allocate(m_Input.GetLength()+1);
 					mem_copy(pEntry, m_Input.GetString(), m_Input.GetLength()+1);
+					// print out the user's commands before they get run
+					char aBuf[128];
+					str_format(aBuf, sizeof(aBuf), "> %s", m_Input.GetString());
+					PrintLine(aBuf, false);
 				}
 				ExecuteLine(m_Input.GetString());
 				m_Input.Clear();


### PR DESCRIPTION
When you enter a command into the console in Quake-based engines (such as *Source and Xonotic) and terminals, it prints the command out first so that it's clear what output came from which command. Example:

```
...
] sv_examplecmd
Example output
```

Often I find the Teeworlds console output confusing, as there is no indication where the output comes from. This PR just prints out the command prefixed with a `>` before it gets run, except if you're entering the rcon password or rcon shows `NOT CONNECTED>`.

Screenshot:
![Screenshot](https://i.ibb.co/V3WWwQz/Screenshot-20221115-172942.png)

I'm a little new to C++ so let me know if there's anything I could do better.
