### PR TITLE
Add .ccls-cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ versionsrv*
 .vscode
 *.vcxproj
 *.vcxproj.filters
+.ccls-cache
 compile_commands.json
 cscope.files
 cscope.out


### PR DESCRIPTION
.ccls-cache is the folder that the [ccls language server](https://github.com/MaskRay/ccls) uses for index caching.