### PR TITLE
The server never sends NETMSG_PING

### DIFF
--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -66,8 +66,9 @@ enum
 	NETMSG_AUTH_START,		//
 	NETMSG_AUTH_RESPONSE,	//
 
-	// sent by both
 	NETMSG_PING,
+
+	// sent by both
 	NETMSG_PING_REPLY,
 	NETMSG_ERROR,
 


### PR DESCRIPTION
Both server and client do reply with NETMSG_PING_REPLY if they receive a NETMSG_PING
But the server never does send a NETMSG_PING. So technically the client never replys with NETMSG_PING_REPLY but at least it could. There is no way to make the server send NETMSG_PING