### PR TITLE
Flush NETMSG_PING_REPLY

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1286,7 +1286,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 		else if(Msg == NETMSG_PING)
 		{
 			CMsgPacker Msg(NETMSG_PING_REPLY, true);
-			SendMsg(&Msg, 0);
+			SendMsg(&Msg, MSGFLAG_FLUSH);
 		}
 		else if((pPacket->m_Flags&NET_CHUNKFLAG_VITAL) != 0 && Msg == NETMSG_RCON_CMD_ADD)
 		{
@@ -2104,7 +2104,7 @@ void CClient::Run()
 			}
 			else if(m_EditorActive)
 				m_EditorActive = false;
-			
+
 			m_pTextRender->Update();
 
 			Update();
@@ -2222,7 +2222,7 @@ void CClient::Con_Ping(IConsole::IResult *pResult, void *pUserData)
 	CClient *pSelf = (CClient *)pUserData;
 
 	CMsgPacker Msg(NETMSG_PING, true);
-	pSelf->SendMsg(&Msg, 0);
+	pSelf->SendMsg(&Msg, MSGFLAG_FLUSH);
 	pSelf->m_PingStartTime = time_get();
 }
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1066,7 +1066,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 		else if(Msg == NETMSG_PING)
 		{
 			CMsgPacker Msg(NETMSG_PING_REPLY, true);
-			SendMsg(&Msg, 0, ClientID);
+			SendMsg(&Msg, MSGFLAG_FLUSH, ClientID);
 		}
 		else
 		{


### PR DESCRIPTION
The client measures the time difference between
ping send and ping reply receive.
Without MSGFLAG_FLUSH the server keeps the chunk
until the next flush which makes the ping dependend on when the next flush happens.

Ping on localhost without flush flag:
```
[2023-01-25 20:51:47][client/network]: latency 45.84                                                                                                                                                               
[2023-01-25 20:51:49][client/network]: latency 45.86                                                                                                                                                               
[2023-01-25 20:51:49][client/network]: latency 45.38                                                                                                                                                               
[2023-01-25 20:51:50][client/network]: latency 28.97                                                                                                                                                               
[2023-01-25 20:51:50][client/network]: latency 33.64                                                                                                                                                               
[2023-01-25 20:51:51][client/network]: latency 89.99                                                                                                                                                               
[2023-01-25 20:51:51][client/network]: latency 62.38                                                                                                                                                               
[2023-01-25 20:51:52][client/network]: latency 73.60                                                                                                                                                               
[2023-01-25 20:51:53][client/network]: latency 27.91                                                                                                                                                               
[2023-01-25 20:51:54][client/network]: latency 73.30                                                                                                                                                               
[2023-01-25 20:51:54][client/network]: latency 44.89                                                                                                                                                               
[2023-01-25 20:51:55][client/network]: latency 23.77
```


Ping on localhost with flush flag:
```
[2023-01-25 20:52:21][client/network]: latency 38.26
[2023-01-25 20:52:22][client/network]: latency 31.80
[2023-01-25 20:52:23][client/network]: latency 17.60
[2023-01-25 20:52:23][client/network]: latency 38.19
[2023-01-25 20:52:23][client/network]: latency 38.81
[2023-01-25 20:52:24][client/network]: latency 45.54
[2023-01-25 20:52:24][client/network]: latency 31.63
[2023-01-25 20:52:25][client/network]: latency 34.30
[2023-01-25 20:52:25][client/network]: latency 24.53
[2023-01-25 20:52:26][client/network]: latency 31.75
[2023-01-25 20:52:26][client/network]: latency 31.71
[2023-01-25 20:52:26][client/network]: latency 31.66
```