### PR TITLE
Only send CNetMsg_De_ClientLeave while recording

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -901,11 +901,14 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 		{
 			DoLeaveMessage(m_aClients[pMsg->m_ClientID].m_aName, pMsg->m_ClientID, pMsg->m_pReason);
 
-			CNetMsg_De_ClientLeave Msg;
-			Msg.m_pName = m_aClients[pMsg->m_ClientID].m_aName;
-			Msg.m_ClientID = pMsg->m_ClientID;
-			Msg.m_pReason = pMsg->m_pReason;
-			Client()->SendPackMsg(&Msg, MSGFLAG_NOSEND | MSGFLAG_RECORD);
+			if(m_pDemoRecorder->IsRecording())
+			{
+				CNetMsg_De_ClientLeave Msg;
+				Msg.m_pName = m_aClients[pMsg->m_ClientID].m_aName;
+				Msg.m_ClientID = pMsg->m_ClientID;
+				Msg.m_pReason = pMsg->m_pReason;
+				Client()->SendPackMsg(&Msg, MSGFLAG_NOSEND | MSGFLAG_RECORD);
+			}
 		}
 
 		m_GameInfo.m_NumPlayers--;


### PR DESCRIPTION
It is only used for demos so do not send it if
no demo record is running. Same as the counter part CNetMsg_De_ClientEnter already does it

```
if(m_pDemoRecorder->IsRecording())
{
	CNetMsg_De_ClientEnter Msg;
	Msg.m_pName = pMsg->m_pName;
	Msg.m_ClientID =
	pMsg->m_ClientID;
	Msg.m_Team = pMsg->m_Team;
	Client()->SendPackMsg(&Msg,
	MSGFLAG_NOSEND|MSGFLAG_RECORD);
}
```

Does not change behavior or fix any bug as far as I am aware. Just makes it more obvious while reading the code
that the **De** message is only used for **De**mos. Also makes the code consistent matching all the other occurrences of the de messages:

https://github.com/teeworlds/teeworlds/blob/26d24ec061d44e6084b2d77a9b8a0a48e354eba6/src/game/client/gameclient.cpp#L843-L850

https://github.com/teeworlds/teeworlds/blob/26d24ec061d44e6084b2d77a9b8a0a48e354eba6/src/game/server/gamecontext.cpp#L703-L710

https://github.com/teeworlds/teeworlds/blob/26d24ec061d44e6084b2d77a9b8a0a48e354eba6/src/game/server/gamecontext.cpp#L755-L761