### PR TITLE
Use Now instead of time_get()

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -702,9 +702,9 @@ void CClient::DebugRender()
 	Graphics()->MapScreen(0,0,Graphics()->ScreenWidth(),Graphics()->ScreenHeight());
 	Graphics()->QuadsBegin();
 
-	if(time_get()-LastSnap > time_freq())
+	if(Now-LastSnap > time_freq())
 	{
-		LastSnap = time_get();
+		LastSnap = Now;
 		Prev = Current;
 		net_stats(&Current);
 	}
@@ -2104,7 +2104,7 @@ void CClient::Run()
 			}
 			else if(m_EditorActive)
 				m_EditorActive = false;
-			
+
 			m_pTextRender->Update();
 
 			Update();

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -406,29 +406,29 @@ int CNetConnection::Update()
 	// send keep alives if nothing has happend for 250ms
 	if(State() == NET_CONNSTATE_ONLINE)
 	{
-		if(time_get()-m_LastSendTime > time_freq()/2) // flush connection after 500ms if needed
+		if(Now-m_LastSendTime > time_freq()/2) // flush connection after 500ms if needed
 		{
 			int NumFlushedChunks = Flush();
 			if(NumFlushedChunks && Config()->m_Debug)
 				dbg_msg("connection", "flushed connection due to timeout. %d chunks.", NumFlushedChunks);
 		}
 
-		if(time_get()-m_LastSendTime > time_freq())
+		if(Now-m_LastSendTime > time_freq())
 			SendControl(NET_CTRLMSG_KEEPALIVE, 0, 0);
 	}
 	else if(State() == NET_CONNSTATE_TOKEN)
 	{
-		if(time_get()-m_LastSendTime > time_freq()/2) // send a new token request every 500ms
+		if(Now-m_LastSendTime > time_freq()/2) // send a new token request every 500ms
 			SendControlWithToken(NET_CTRLMSG_TOKEN);
 	}
 	else if(State() == NET_CONNSTATE_CONNECT)
 	{
-		if(time_get()-m_LastSendTime > time_freq()/2) // send a new connect every 500ms
+		if(Now-m_LastSendTime > time_freq()/2) // send a new connect every 500ms
 			SendControlWithToken(NET_CTRLMSG_CONNECT);
 	}
 	else if(State() == NET_CONNSTATE_PENDING)
 	{
-		if(time_get()-m_LastSendTime > time_freq()/2) // send a new connect/accept every 500ms
+		if(Now-m_LastSendTime > time_freq()/2) // send a new connect/accept every 500ms
 			SendControl(NET_CTRLMSG_ACCEPT, 0, 0);
 	}
 


### PR DESCRIPTION
If there already is a ``int64 Now = time_get();`` in the current scope do not call ``time_get()`` again.