### PR TITLE
Delete selection with backspace/delete regardless of word mode

### DIFF
--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -221,7 +221,7 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 
 		if(Event.m_Key == KEY_BACKSPACE)
 		{
-			if(SelectionLength && !MoveWord)
+			if(SelectionLength)
 			{
 				SetRange("", m_SelectionStart, m_SelectionEnd);
 			}
@@ -241,7 +241,7 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 		}
 		else if(Event.m_Key == KEY_DELETE)
 		{
-			if(SelectionLength && !MoveWord)
+			if(SelectionLength)
 			{
 				SetRange("", m_SelectionStart, m_SelectionEnd);
 			}


### PR DESCRIPTION
Also delete the lineinput selection when pressing backspace/delete and the key for skipping words (Ctrl/GUI key, Alt on macOS) is held. This is consistent with the behavior in other applications.