### PR TITLE
Ensure line inputs are deactivated when they are not rendered

### DIFF
--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -36,6 +36,7 @@ void CLineInput::SetBuffer(char *pStr, int MaxSize, int MaxChars)
 		m_ScrollOffset = m_ScrollOffsetChange = 0.0f;
 		m_CaretPosition = vec2(0, 0);
 		m_Hidden = false;
+		m_WasRendered = false;
 	}
 	if(m_pStr && m_pStr != pLastStr)
 		UpdateStrData();
@@ -355,6 +356,7 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 
 void CLineInput::Render(bool Changed)
 {
+	m_WasRendered = true;
 	m_TextCursor.Reset();
 
 	if(!m_pStr)
@@ -423,6 +425,23 @@ void CLineInput::Render(bool Changed)
 
 void CLineInput::RenderCandidates()
 {
+	// Check if the active line input was not rendered and deactivate it in that case.
+	// This can happen e.g. when an input in the ingame menu is active and the menu is
+	// closed or when switching between menu and editor with an active input.
+	CLineInput *pActiveInput = GetActiveInput();
+	if(pActiveInput != nullptr)
+	{
+		if(pActiveInput->m_WasRendered)
+		{
+			pActiveInput->m_WasRendered = false;
+		}
+		else
+		{
+			pActiveInput->Deactivate();
+			return;
+		}
+	}
+
 	if(!s_pInput->HasComposition() || !s_pInput->GetCandidateCount())
 		return;
 

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -51,6 +51,7 @@ class CLineInput
 
 	bool m_Hidden;
 	bool m_WasChanged;
+	bool m_WasRendered;
 
 	void UpdateStrData();
 	enum EMoveDirection


### PR DESCRIPTION
Check if the active line input was not rendered and deactivate it in that case.

This can happen e.g. when an input in the ingame menu is active and the menu is closed or when switching between menu and editor with an active input.

This was causing the IME candidate list to be rendered ingame after closing the menu.