### PR TITLE
Remove useless assignment to variable

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -393,7 +393,6 @@ void CMenus::RenderSkinSelection(CUIRect MainView)
 		}
 		m_SkinModified = true;
 	}
-	OldSelected = NewSelected;
 }
 
 void CMenus::RenderSkinPartSelection(CUIRect MainView)


### PR DESCRIPTION
Defined as

```
int OldSelected = -1;
```

set at the end of the function. Has no effect :shrug: 