### PR TITLE
Remove unreachable dmg indicator code

### DIFF
--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -55,12 +55,6 @@ void CEffects::DamageIndicator(vec2 Pos, int Amount, float Angle, int ClientID)
 	if(Amount == 0)
 		return;
 
-	if (ClientID < 0 || ClientID >= MAX_CLIENTS)
-	{
-		m_pClient->m_pDamageind->Create(vec2(Pos.x, Pos.y), direction(Angle));
-		return;
-	}
-
 	m_aDamageTaken[ClientID]++;
 
 	// create healthmod indicator


### PR DESCRIPTION
https://github.com/teeworlds/teeworlds/blob/a1911c8f7d8458fb4076ef8e7651e8ef5e91ab3e/datasrc/network.py#L253

```python
NetEvent("Damage:Common", [ # Unused yet
	NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
	NetIntAny("m_Angle"),
	NetIntRange("m_HealthAmount", 0, 9),
	NetIntRange("m_ArmorAmount", 0, 9),
	NetBool("m_Self"),
]),
```

Snap items with a m_ClientID out of range will be dropped during snap item validation.


Thanks to @TsFreddie the original author of this code for helping me figure this out c: