### PR TITLE
Silence initial client info

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -686,7 +686,7 @@ void CGameContext::OnClientEnter(int ClientID)
 		ClientInfoMsg.m_pName = Server()->ClientName(i);
 		ClientInfoMsg.m_pClan = Server()->ClientClan(i);
 		ClientInfoMsg.m_Country = Server()->ClientCountry(i);
-		ClientInfoMsg.m_Silent = false;
+		ClientInfoMsg.m_Silent = true;
 		for(int p = 0; p < NUM_SKINPARTS; p++)
 		{
 			ClientInfoMsg.m_apSkinPartNames[p] = m_apPlayers[i]->m_TeeInfos.m_aaSkinPartNames[p];


### PR DESCRIPTION
When a new player joins it is being sent all the client info of the currently connected tees. This is marked as non silent which is misleading because the client does not actually print these as join messages. The reason why the client does not print it is because it does not have its m_LocalClientID set yet.

Setting it explicitly to silent makes it more obvious that this is not printing a chat message when reading the server code.

This change will not change anything that can be witnessed by end users.

This also ensures that when the client implementation changes it does not start printing unexpected "joined the game" messages in chat.