### PR TITLE
Change server log from "connecting online" to "connection online"

### DIFF
--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -350,7 +350,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr)
 			m_LastRecvTime = Now;
 			m_State = NET_CONNSTATE_ONLINE;
 			if(Config()->m_Debug)
-				dbg_msg("connection", "connecting online");
+				dbg_msg("connection", "connection online");
 		}
 	}
 


### PR DESCRIPTION
The client already says "got accept. connection online" and "connecting online" sounds a bit weird. I asked some natives and they told me "connection established" is the most badass way of saying it. But I rather keep the change as minimal as possible.

This is a breaking change for users parsing the logs.