### PR TITLE
Fix cmd5.py SyntaxWarning: invalid escape sequence

### DIFF
--- a/scripts/cmd5.py
+++ b/scripts/cmd5.py
@@ -8,7 +8,7 @@ def cstrip(lines):
 		l = re.sub("#.*".encode(), "".encode(), l)
 		l = re.sub("//.*".encode(), "".encode(), l)
 		d += l + " ".encode()
-	d = re.sub("\/\*.*?\*/".encode(), "".encode(), d) # remove /* */ comments
+	d = re.sub(r"\/\*.*?\*/".encode(), "".encode(), d) # remove /* */ comments
 	d = d.replace("\t".encode(), " ".encode()) # tab to space
 	d = re.sub("  *".encode(), " ".encode(), d) # remove double spaces
 	d = re.sub("".encode(), "".encode(), d) # remove /* */ comments


### PR DESCRIPTION
before:
```
$ python ./scripts/cmd5.py 
/Users/chillerdragon/Desktop/git/teeworlds/./scripts/cmd5.py:11: SyntaxWarning: invalid escape sequence '\/'
  d = re.sub("\/\*.*?\*/".encode(), "".encode(), d) # remove /* */ comments
#define GAME_NETVERSION_HASH "e9800998ecf8427e"
```

after:
```
$ python ./scripts/cmd5.py 
#define GAME_NETVERSION_HASH "e9800998ecf8427e"
```