### PR TITLE
Fix make_release.py options

### DIFF
--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -8,7 +8,7 @@ arguments.add_option("-l", "--url-languages", default = "http://github.com/teewo
 arguments.add_option("-m", "--url-maps", default = "http://github.com/teeworlds/teeworlds-maps/archive/master.zip", help = "URL from which the teeworlds maps files will be downloaded")
 arguments.add_option("-s", "--source-dir", help = "Source directory which is used for building the package")
 (options, arguments) = arguments.parse_args()
-if len(sys.argv) != 3:
+if len(arguments) != 2:
 	print("wrong number of arguments")
 	print(sys.argv[0], "VERSION PLATFORM")
 	sys.exit(-1)


### PR DESCRIPTION
The help page advertises options such as -m and -s but none of these can be used because the script refuses to launch if more than 2 arguments are passed

```
$ python scripts/make_release.py -h
Usage: make_release.py VERSION PLATFORM [options]

VERSION  - Version number
PLATFORM - Target platform (f.e. linux_x86, linux_x86_64, macos, src, win32, win64)

Options:
  -h, --help            show this help message and exit
  -l URL_LANGUAGES, --url-languages=URL_LANGUAGES
                        URL from which the teeworlds language files will be
                        downloaded
  -m URL_MAPS, --url-maps=URL_MAPS
                        URL from which the teeworlds maps files will be
                        downloaded
  -s SOURCE_DIR, --source-dir=SOURCE_DIR
                        Source directory which is used for building the
                        package
$ python scripts/make_release.py master macos --url-maps=https://github.com/teeworlds/teeworlds-translation/archive/master.zip
wrong number of arguments
scripts/make_release.py VERSION PLATFORM
```