### PR TITLE
Fix twlib.py SSL error

### DIFF
--- a/scripts/twlib.py
+++ b/scripts/twlib.py
@@ -4,6 +4,8 @@ if sys.version_info[0] == 2:
 	url_lib = urllib
 elif sys.version_info[0] == 3:
 	import urllib.request
+	import ssl
+	ssl._create_default_https_context = ssl._create_unverified_context
 	url_lib = urllib.request
 
 def fetch_file(url):


### PR DESCRIPTION
On my mac creating a release fails with the following error

```
$ python scripts/make_release.py master macos
cleaning target
download and extract languages
trying http://github.com/teeworlds/teeworlds-translation/archive/master.zip
couldn't download languages
```

The actual error is hidden by the try block in twlib.py removing that shows the following issue

```
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/urllib/request.py", line 1392, in https_open
    return self.do_open(http.client.HTTPSConnection, req,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/urllib/request.py", line 1347, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1000)>
```