### PR TITLE
Polyfill distutils.copy_tree because it was removed

### DIFF
--- a/scripts/download.py
+++ b/scripts/download.py
@@ -1,7 +1,7 @@
 import shutil, os, re, sys, zipfile
-from distutils.dir_util import copy_tree
 os.chdir(os.path.dirname(os.path.realpath(sys.argv[0])) + "/..")
 import twlib
+from twlib import copy_tree
 
 def unzip(filename, where):
 	try:

--- a/scripts/make_release.py
+++ b/scripts/make_release.py
@@ -1,7 +1,7 @@
 import shutil, optparse, os, re, sys, zipfile
-from distutils.dir_util import copy_tree
 os.chdir(os.path.dirname(os.path.realpath(sys.argv[0])) + "/..")
 import twlib
+from twlib import copy_tree
 
 arguments = optparse.OptionParser(usage="usage: %prog VERSION PLATFORM [options]\n\nVERSION  - Version number\nPLATFORM - Target platform (f.e. linux_x86, linux_x86_64, macos, src, win32, win64)")
 arguments.add_option("-l", "--url-languages", default = "http://github.com/teeworlds/teeworlds-translation/archive/master.zip", help = "URL from which the teeworlds language files will be downloaded")

--- a/scripts/twlib.py
+++ b/scripts/twlib.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 if sys.version_info[0] == 2:
 	import urllib
@@ -5,6 +6,14 @@ if sys.version_info[0] == 2:
 elif sys.version_info[0] == 3:
 	import urllib.request
 	url_lib = urllib.request
+
+try:
+	from distutils.dir_util import copy_tree
+except ModuleNotFoundError:
+	# distutils was removed in python 3.12
+	# https://peps.python.org/pep-0632/
+	def copy_tree(src, dst):
+		shutil.copytree(src, dst, dirs_exist_ok=True)
 
 def fetch_file(url):
 	print("trying %s" % url)


### PR DESCRIPTION
# what and why

The GitHub actions macOS CI pipeline is failing on this step if python 3.12 is used. (which is not the case on current master but at some point it would be nice to update to this or a newer version https://github.com/teeworlds/teeworlds/pull/3223)

https://github.com/teeworlds/teeworlds/blob/a1911c8f7d8458fb4076ef8e7651e8ef5e91ab3e/.github/workflows/build.yaml#L161

```
0s Run sudo python3 scripts/make_release.py master macos
Traceback (most recent call last):
  File "/Users/runner/work/teeworlds/teeworlds/scripts/make_release.py", line 2, in <module>
    from distutils.dir_util import copy_tree
ModuleNotFoundError: No module named 'distutils'
Error: Process completed with exit code 1.
```

I managed to reproduce the issue on my mac locally. By uninstalling the setuptools pip package. Sadly I did not manage to fix the CI by installing the setuptools pip package. Anyways to my knowledge none of the scripts in this repo depend on external pip packages so that would be a sloppy fix anyways.

The whole distutils package [is being removed from python](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated). So for newer versions it has to be replaced with something else. As far as I understood the [migration advice](https://peps.python.org/pep-0632/#migration-advice), users have to implement copy_tree them selfs. So I decided to polyfill it.

[Some dude on stackoverflow recommended to use shutils](https://stackoverflow.com/a/64340026).

It is using a python 3.8 option. So the poly fill only kicks in for versions that have it. Older versions should still have distutils.

# is it still working correctly?

<img width="1288" alt="macos_tw_release_no_distutils" src="https://github.com/teeworlds/teeworlds/assets/20344300/a1fd2f19-3f3d-4320-a5ed-d2c82ea4fac8">


I wanted to make sure that nothing broke. So my first test was running client and server and comparing the file in the volume by looking at it with my eyes. That was a success. The second test i did was comparing the sha1sum of the dmg files. That was a failure. Then I realised that .dmg file creation is non deterministic. And the old and new copy_tree would produce a new sha1sum of the dmg file on every run. So the test was flawed.

So that is why I decided to mount the volume and sha1sum every single file. And then diff all sha1sums of both volumes. And that showed no diff. So to my knowledge the same release is being created but the code is now more portable. And supports python version 3.12 and newer.

<img width="1346" alt="macos_tw_release_no_diff" src="https://github.com/teeworlds/teeworlds/assets/20344300/405c3bf1-3483-4c01-903e-d0a37abf6ae5">


```
ChillersMacBookPro:teeworlds chillerdragon$ git checkout pr_polyfill_copy_tree 
Switched to branch 'pr_polyfill_copy_tree'
ChillersMacBookPro:teeworlds chillerdragon$ python scripts/make_release.py master macos
cleaning target
download and extract languages
trying http://github.com/teeworlds/teeworlds-translation/archive/master.zip
download and extract maps
trying http://github.com/teeworlds/teeworlds-maps/archive/master.zip
adding files
making disk image
*** cleaning ***
done
ChillersMacBookPro:teeworlds chillerdragon$ mv teeworlds-master-macos.dmg pr_polyfill_copy_tree.dmg
ChillersMacBookPro:teeworlds chillerdragon$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
ChillersMacBookPro:teeworlds chillerdragon$ python scripts/make_release.py 
wrong number of arguments
scripts/make_release.py VERSION PLATFORM
ChillersMacBookPro:teeworlds chillerdragon$ python scripts/make_release.py master macos
cleaning target
download and extract languages
trying http://github.com/teeworlds/teeworlds-translation/archive/master.zip
download and extract maps
trying http://github.com/teeworlds/teeworlds-maps/archive/master.zip
adding files
making disk image
*** cleaning ***
done
ChillersMacBookPro:teeworlds chillerdragon$ mv teeworlds-master-macos.dmg master.dmg
ChillersMacBookPro:teeworlds chillerdragon$ open master.dmg 
ChillersMacBookPro:teeworlds chillerdragon$ open pr_polyfill_copy_tree.dmg 
ChillersMacBookPro:teeworlds chillerdragon$ cd /Volumes/Teeworlds
ChillersMacBookPro:Teeworlds chillerdragon$ find . -exec sha1sum {} \; 2>&1 | sort > /tmp/master.txt
ChillersMacBookPro:Teeworlds chillerdragon$ cd /Volumes/Teeworlds\ 1
ChillersMacBookPro:Teeworlds 1 chillerdragon$ find . -exec sha1sum {} \; 2>&1 | sort > /tmp/pr_polyfill_copy_tree.txt
ChillersMacBookPro:Teeworlds 1 chillerdragon$ git diff --no-index /tmp/master.txt /tmp/pr_polyfill_copy_tree.txt
ChillersMacBookPro:Teeworlds 1 chillerdragon$ sha1sum /tmp/master.txt /tmp/pr_polyfill_copy_tree.txt 
8a53e5b8e5bbf40296e1ed739d30354b1690af2b  /tmp/master.txt
8a53e5b8e5bbf40296e1ed739d30354b1690af2b  /tmp/pr_polyfill_copy_tree.txt
ChillersMacBookPro:Teeworlds 1 chillerdragon$ 
```
