### PR TITLE
ci: use `fail-fast: false`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,7 @@ jobs:
   build-cmake:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest, ubuntu-20.04]
         include:
@@ -108,6 +109,7 @@ jobs:
   build-bam:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
 


### PR DESCRIPTION
I think it would be better to have this option so that you can see all tests results and none of them would be cancelled due to failing some of the tests before. So you can see immediately how bad of a programmer person who made a pull request is.