### PR TITLE
Fix CStorage::ReadFile

### DIFF
--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -398,11 +398,11 @@ public:
 		*pResultLen = 0;
 		if(!File)
 		{
-			return true;
+			return false;
 		}
 		io_read_all(File, ppResult, pResultLen);
 		io_close(File);
-		return false;
+		return true;
 	}
 
 	char *ReadFileStr(const char *pFilename, int Type)


### PR DESCRIPTION
### About this bug
This bug is now no any crash problem for teeworlds, because this function is unused (This function added in commit 81376fdeaaffc3f51021b4309998a259525f9f28)

We usually return `true` when we load a file successfully,
But in the past, CStorage::ReadFile return `false`, also, it return `true` when load failed

### Why this bug is only being discovered now
`because this function is unused`