### PR TITLE
Allow editor switch entities

### DIFF
--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -70,6 +70,7 @@ public:
 					fs_makedir(GetPath(TYPE_SAVE, "maps", aPath, sizeof(aPath)));
 					fs_makedir(GetPath(TYPE_SAVE, "downloadedmaps", aPath, sizeof(aPath)));
 					fs_makedir(GetPath(TYPE_SAVE, "skins", aPath, sizeof(aPath)));
+					fs_makedir(GetPath(TYPE_SAVE, "editor", aPath, sizeof(aPath)));
 				}
 				fs_makedir(GetPath(TYPE_SAVE, "dumps", aPath, sizeof(aPath)));
 				fs_makedir(GetPath(TYPE_SAVE, "demos", aPath, sizeof(aPath)));

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -652,6 +652,7 @@ public:
 		POPEVENT_LOAD_CURRENT,
 		POPEVENT_NEW,
 		POPEVENT_SAVE,
+		POPEVENT_ENTITIES,
 	};
 
 	int m_PopupEventType;
@@ -810,6 +811,7 @@ public:
 	static void CallbackOpenMap(const char *pFileName, int StorageType, void *pUser);
 	static void CallbackAppendMap(const char *pFileName, int StorageType, void *pUser);
 	static void CallbackSaveMap(const char *pFileName, int StorageType, void *pUser);
+	static void CallbackOpenEntities(const char *pFileName, int StorageType, void *pUser);
 
 	void PopupSelectImageInvoke(int Current, float x, float y);
 	int PopupSelectImageResult();

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -708,6 +708,8 @@ bool CEditor::PopupEvent(void *pContext, CUIRect View)
 		pEditor->UI()->DoLabel(&Label, "New map", 20.0f, TEXTALIGN_CENTER);
 	else if(pEditor->m_PopupEventType == POPEVENT_SAVE)
 		pEditor->UI()->DoLabel(&Label, "Save map", 20.0f, TEXTALIGN_CENTER);
+	else if(pEditor->m_PopupEventType == POPEVENT_ENTITIES)
+		pEditor->UI()->DoLabel(&Label, "Load entities", 20.0f, TEXTALIGN_CENTER);
 
 	View.HSplitBottom(10.0f, &View, 0);
 	View.HSplitBottom(20.0f, &View, &ButtonBar);
@@ -726,6 +728,8 @@ bool CEditor::PopupEvent(void *pContext, CUIRect View)
 		pEditor->UI()->DoLabel(&Label, "The map currently contains unsaved data; you may want to save it before you create a new map.\nContinue anyway?", 10.0f, TEXTALIGN_LEFT, Label.w-10.0f);
 	else if(pEditor->m_PopupEventType == POPEVENT_SAVE)
 		pEditor->UI()->DoLabel(&Label, "This file already exists.\nDo you want to overwrite it?", 10.0f, TEXTALIGN_LEFT);
+	else if(pEditor->m_PopupEventType == POPEVENT_ENTITIES)
+		pEditor->UI()->DoLabel(&Label, "The width or height of the entities texture is not divisible by 16", 10.0f, TEXTALIGN_LEFT);
 
 	// button bar
 	ButtonBar.VSplitLeft(30.0f, 0, &ButtonBar);
@@ -1201,6 +1205,7 @@ bool CEditor::PopupMenuFile(void *pContext, CUIRect View)
 	static int s_OpenCurrentButton = 0;
 	static int s_AppendButton = 0;
 	static int s_ExitButton = 0;
+	static int s_EntitiesButton = 0;
 
 	CUIRect Slot;
 	View.HSplitTop(2.0f, &Slot, &View);
@@ -1279,6 +1284,14 @@ bool CEditor::PopupMenuFile(void *pContext, CUIRect View)
 	if(pEditor->DoButton_MenuItem(&s_SaveAsButton, "Save As", 0, &Slot, 0, "Saves the current map under a new name"))
 	{
 		pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", "", pEditor->CallbackSaveMap, pEditor);
+		return true;
+	}
+
+	View.HSplitTop(10.0f, &Slot, &View);
+	View.HSplitTop(12.0f, &Slot, &View);
+	if(pEditor->DoButton_MenuItem(&s_EntitiesButton, "Load Entities", 0, &Slot, 0, "Load a image as the editor game entities"))
+	{
+		pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_IMG, "Load entities", "Load", "editor", "", pEditor->CallbackOpenEntities, pEditor);
 		return true;
 	}
 


### PR DESCRIPTION
### Why
Many mods have their own entities.In the past, if we needed to switch the entities, we need use the mod's entities.png to take the vanilla entities.png. Also, it spent more time to switch entities. 
This PR solve that problem, be different from DDNet, mapper put their entities images in %APPDATA%/editor, and they need to press this button to open a file dialog
![Screenshot](https://github.com/teeworlds/teeworlds/assets/65482653/000447b4-14b1-4135-95c7-29add5573c46)
Then they could choose entities files
![Screenshot](https://github.com/teeworlds/teeworlds/assets/65482653/2c8ee449-063e-437e-b254-5beee2973069)
The **Vanilla** entities file is a link of data/editor/entities.png