### PR TITLE
[Editor2] Allow use middle mouse button to view move

### DIFF
--- a/src/game/editor/editor2.cpp
+++ b/src/game/editor/editor2.cpp
@@ -231,7 +231,7 @@ void CEditor2::Update()
 	if(!m_InputConsole.IsOpen())
 	{
 		// move view
-		if(MouseButtons&MOUSE_RIGHT)
+		if(MouseButtons&MOUSE_RIGHT || MouseButtons&MOUSE_MIDDLE)
 		{
 			m_MapViewMove = m_UiMouseDelta;
 		}


### PR DESCRIPTION
### Why
The old editor use middle mouse button to move view,
Also, many image processing software set this button to move view by default.

Right mouse button still could to move view