### PR TITLE
Improve network code readability

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -108,10 +108,11 @@ public:
 	virtual const int *GetInput(int Tick) const = 0;
 
 	// remote console
-	virtual void RconAuth(const char *pUsername, const char *pPassword) = 0;
 	virtual bool RconAuthed() const = 0;
 	virtual bool UseTempRconCommands() const = 0;
-	virtual void Rcon(const char *pLine) = 0;
+
+	virtual void SendRconAuth(const char *pUsername, const char *pPassword) = 0;
+	virtual void SendRcon(const char *pLine) = 0;
 
 	// server info
 	virtual void GetServerInfo(class CServerInfo *pServerInfo) = 0;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -360,7 +360,7 @@ void CClient::SendReady()
 	SendMsg(&Msg, MSGFLAG_VITAL|MSGFLAG_FLUSH);
 }
 
-void CClient::RconAuth(const char *pName, const char *pPassword)
+void CClient::SendRconAuth(const char *pName, const char *pPassword)
 {
 	if(RconAuthed())
 		return;
@@ -370,21 +370,11 @@ void CClient::RconAuth(const char *pName, const char *pPassword)
 	SendMsg(&Msg, MSGFLAG_VITAL);
 }
 
-void CClient::Rcon(const char *pCmd)
+void CClient::SendRcon(const char *pCmd)
 {
 	CMsgPacker Msg(NETMSG_RCON_CMD, true);
 	Msg.AddString(pCmd, 256);
 	SendMsg(&Msg, MSGFLAG_VITAL);
-}
-
-bool CClient::ConnectionProblems() const
-{
-	return m_NetClient.GotProblems() != 0;
-}
-
-int CClient::GetInputtimeMarginStabilityScore()
-{
-	return m_PredictedTime.GetStabilityScore();
 }
 
 void CClient::SendInput()
@@ -429,6 +419,16 @@ void CClient::SendInput()
 const char *CClient::LatestVersion() const
 {
 	return m_aVersionStr;
+}
+
+bool CClient::ConnectionProblems() const
+{
+	return m_NetClient.GotProblems() != 0;
+}
+
+int CClient::GetInputtimeMarginStabilityScore()
+{
+	return m_PredictedTime.GetStabilityScore();
 }
 
 // TODO: OPT: do this alot smarter!
@@ -2267,13 +2267,13 @@ void CClient::Con_Screenshot(IConsole::IResult *pResult, void *pUserData)
 void CClient::Con_Rcon(IConsole::IResult *pResult, void *pUserData)
 {
 	CClient *pSelf = (CClient *)pUserData;
-	pSelf->Rcon(pResult->GetString(0));
+	pSelf->SendRcon(pResult->GetString(0));
 }
 
 void CClient::Con_RconAuth(IConsole::IResult *pResult, void *pUserData)
 {
 	CClient *pSelf = (CClient *)pUserData;
-	pSelf->RconAuth("", pResult->GetString(0));
+	pSelf->SendRconAuth("", pResult->GetString(0));
 }
 
 const char *CClient::DemoPlayer_Play(const char *pFilename, int StorageType)

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -212,18 +212,17 @@ public:
 	void SendInfo();
 	void SendEnterGame();
 	void SendReady();
+	void SendInput();
+	void SendRconAuth(const char *pName, const char *pPassword);
+	virtual void SendRcon(const char *pCmd);
 
 	virtual bool RconAuthed() const { return m_RconAuthed != 0; }
 	virtual bool UseTempRconCommands() const { return m_UseTempRconCommands != 0; }
-	void RconAuth(const char *pName, const char *pPassword);
-	virtual void Rcon(const char *pCmd);
 
 	virtual bool ConnectionProblems() const;
 	virtual int GetInputtimeMarginStabilityScore();
 
 	virtual bool SoundInitFailed() const { return m_SoundInitFailed; }
-
-	void SendInput();
 
 	// TODO: OPT: do this alot smarter!
 	virtual const int *GetInput(int Tick) const;

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -126,12 +126,12 @@ void CChat::OnStateChange(int NewState, int OldState)
 
 void CChat::ConSay(IConsole::IResult *pResult, void *pUserData)
 {
-	((CChat*)pUserData)->Say(CHAT_ALL, pResult->GetString(0));
+	((CChat*)pUserData)->SendChat(CHAT_ALL, pResult->GetString(0));
 }
 
 void CChat::ConSayTeam(IConsole::IResult *pResult, void *pUserData)
 {
-	((CChat*)pUserData)->Say(CHAT_TEAM, pResult->GetString(0));
+	((CChat*)pUserData)->SendChat(CHAT_TEAM, pResult->GetString(0));
 }
 
 void CChat::ConSaySelf(IConsole::IResult *pResult, void *pUserData)
@@ -149,7 +149,7 @@ void CChat::ConWhisper(IConsole::IResult *pResult, void *pUserData)
 	else
 	{
 		pChat->m_WhisperTarget = Target;
-		pChat->Say(CHAT_WHISPER, pResult->GetString(1));
+		pChat->SendChat(CHAT_WHISPER, pResult->GetString(1));
 	}
 }
 
@@ -282,7 +282,7 @@ bool CChat::OnInput(IInput::CEvent Event)
 			{
 				if(m_PendingChatCounter == 0 && m_LastChatSend+time_freq() < time_get())
 				{
-					Say(m_Mode, m_Input.GetString());
+					SendChat(m_Mode, m_Input.GetString());
 					AddEntry = true;
 				}
 				else if(m_PendingChatCounter < 3)
@@ -753,7 +753,7 @@ void CChat::OnRender()
 {
 	if(Client()->State() < IClient::STATE_ONLINE)
 		return;
-	
+
 	if(!Config()->m_ClShowChat)
 		return;
 
@@ -765,7 +765,7 @@ void CChat::OnRender()
 		{
 			if(i == 0)
 			{
-				Say(pEntry->m_Mode, pEntry->m_aText);
+				SendChat(pEntry->m_Mode, pEntry->m_aText);
 				break;
 			}
 		}
@@ -1311,7 +1311,7 @@ void CChat::OnRender()
 	HandleCommands(x+CategoryWidth, Height - 24.f, 200.0f-CategoryWidth);
 }
 
-void CChat::Say(int Mode, const char *pLine)
+void CChat::SendChat(int Mode, const char *pLine)
 {
 	m_LastChatSend = time_get();
 

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -129,7 +129,7 @@ public:
 	void AddLine(const char *pLine, int ClientID = SERVER_MSG, int Mode = CHAT_NONE, int TargetID = -1);
 	void Disable();
 	void EnableMode(int Mode, const char *pText = 0x0);
-	void Say(int Mode, const char *pLine);
+	void SendChat(int Mode, const char *pLine);
 
 	CChat();
 	virtual void OnInit();

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -103,9 +103,9 @@ void CGameConsole::CInstance::ExecuteLine(const char *pLine)
 	else
 	{
 		if(m_pGameConsole->Client()->RconAuthed())
-			m_pGameConsole->Client()->Rcon(pLine);
+			m_pGameConsole->Client()->SendRcon(pLine);
 		else
-			m_pGameConsole->Client()->RconAuth("", pLine);
+			m_pGameConsole->Client()->SendRconAuth("", pLine);
 	}
 }
 

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -23,7 +23,7 @@ void CEmoticon::ConKeyEmoticon(IConsole::IResult *pResult, void *pUserData)
 
 void CEmoticon::ConEmote(IConsole::IResult *pResult, void *pUserData)
 {
-	((CEmoticon *)pUserData)->Emote(pResult->GetInteger(0));
+	((CEmoticon *)pUserData)->SendEmote(pResult->GetInteger(0));
 }
 
 void CEmoticon::OnConsoleInit()
@@ -103,7 +103,7 @@ void CEmoticon::OnRender()
 	if(!m_Active)
 	{
 		if(m_WasActive && m_SelectedEmote != -1)
-			Emote(m_SelectedEmote);
+			SendEmote(m_SelectedEmote);
 		m_WasActive = false;
 		return;
 	}
@@ -166,7 +166,7 @@ void CEmoticon::OnRender()
 	RenderTools()->RenderCursor(m_SelectorMouse.x + Screen.w/2, m_SelectorMouse.y + Screen.h/2, 24.0f);
 }
 
-void CEmoticon::Emote(int Emoticon)
+void CEmoticon::SendEmote(int Emoticon)
 {
 	CNetMsg_Cl_Emoticon Msg;
 	Msg.m_Emoticon = Emoticon;

--- a/src/game/client/components/emoticon.h
+++ b/src/game/client/components/emoticon.h
@@ -28,7 +28,7 @@ public:
 	virtual void OnMessage(int MsgType, void *pRawMsg);
 	virtual bool OnCursorMove(float x, float y, int CursorType);
 
-	void Emote(int Emoticon);
+	void SendEmote(int Emoticon);
 };
 
 #endif

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -31,7 +31,7 @@ void CSpectator::ConSpectate(IConsole::IResult *pResult, void *pUserData)
 {
 	CSpectator *pSelf = (CSpectator *)pUserData;
 	if(pSelf->CanSpectate())
-		pSelf->Spectate(pResult->GetInteger(0), pResult->GetInteger(1));
+		pSelf->SendSpectate(pResult->GetInteger(0), pResult->GetInteger(1));
 }
 
 bool CSpectator::SpecModePossible(int SpecMode, int SpectatorID)
@@ -104,7 +104,7 @@ void CSpectator::HandleSpectateNextPrev(int Direction)
 		IterateSpecMode(Direction, &NewSpecMode, &NewSpectatorID);
 		if(SpecModePossible(NewSpecMode, NewSpectatorID))
 		{
-			Spectate(NewSpecMode, NewSpectatorID);
+			SendSpectate(NewSpecMode, NewSpectatorID);
 			return;
 		}
 	}
@@ -155,7 +155,7 @@ void CSpectator::OnRender()
 		if(m_WasActive)
 		{
 			if(m_SelectedSpecMode != NO_SELECTION)
-				Spectate(m_SelectedSpecMode, m_SelectedSpectatorID);
+				SendSpectate(m_SelectedSpecMode, m_SelectedSpectatorID);
 			m_WasActive = false;
 		}
 		return;
@@ -351,7 +351,7 @@ void CSpectator::OnReset()
 	m_SelectedSpectatorID = -1;
 }
 
-void CSpectator::Spectate(int SpecMode, int SpectatorID)
+void CSpectator::SendSpectate(int SpecMode, int SpectatorID)
 {
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{

--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -38,7 +38,7 @@ public:
 	virtual void OnRelease();
 	virtual void OnReset();
 
-	void Spectate(int SpecMode, int SpectatorID);
+	void SendSpectate(int SpecMode, int SpectatorID);
 };
 
 #endif

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -15,12 +15,12 @@ void CVoting::ConVote(IConsole::IResult *pResult, void *pUserData)
 {
 	CVoting *pSelf = (CVoting *)pUserData;
 	if(str_comp_nocase(pResult->GetString(0), "yes") == 0)
-		pSelf->Vote(VOTE_CHOICE_YES);
+		pSelf->SendVote(VOTE_CHOICE_YES);
 	else if(str_comp_nocase(pResult->GetString(0), "no") == 0)
-		pSelf->Vote(VOTE_CHOICE_NO);
+		pSelf->SendVote(VOTE_CHOICE_NO);
 }
 
-void CVoting::Callvote(const char *pType, const char *pValue, const char *pReason, bool ForceVote)
+void CVoting::SendCallvote(const char *pType, const char *pValue, const char *pReason, bool ForceVote)
 {
 	CNetMsg_Cl_CallVote Msg = {0};
 	Msg.m_Type = pType;
@@ -34,14 +34,14 @@ void CVoting::CallvoteSpectate(int ClientID, const char *pReason, bool ForceVote
 {
 	char aBuf[32];
 	str_format(aBuf, sizeof(aBuf), "%d", ClientID);
-	Callvote("spectate", aBuf, pReason, ForceVote);
+	SendCallvote("spectate", aBuf, pReason, ForceVote);
 }
 
 void CVoting::CallvoteKick(int ClientID, const char *pReason, bool ForceVote)
 {
 	char aBuf[32];
 	str_format(aBuf, sizeof(aBuf), "%d", ClientID);
-	Callvote("kick", aBuf, pReason, ForceVote);
+	SendCallvote("kick", aBuf, pReason, ForceVote);
 }
 
 void CVoting::CallvoteOption(int OptionID, const char *pReason, bool ForceVote)
@@ -51,7 +51,7 @@ void CVoting::CallvoteOption(int OptionID, const char *pReason, bool ForceVote)
 	{
 		if(OptionID == 0)
 		{
-			Callvote("option", pOption->m_aDescription, pReason, ForceVote);
+			SendCallvote("option", pOption->m_aDescription, pReason, ForceVote);
 			break;
 		}
 
@@ -69,7 +69,7 @@ void CVoting::RconRemoveVoteOption(int OptionID)
 		{
 			char aBuf[VOTE_DESC_LENGTH+32];
 			str_format(aBuf, sizeof(aBuf), "remove_vote \"%s\"", pOption->m_aDescription);
-			Client()->Rcon(aBuf);
+			Client()->SendRcon(aBuf);
 			break;
 		}
 
@@ -82,10 +82,10 @@ void CVoting::RconAddVoteOption(const char *pDescription, const char *pCommand)
 {
 	char aBuf[VOTE_DESC_LENGTH+VOTE_CMD_LENGTH+32];
 	str_format(aBuf, sizeof(aBuf), "add_vote \"%s\" \"%s\"", pDescription, pCommand);
-	Client()->Rcon(aBuf);
+	Client()->SendRcon(aBuf);
 }
 
-void CVoting::Vote(int Choice)
+void CVoting::SendVote(int Choice)
 {
 	CNetMsg_Cl_Vote Msg = { Choice };
 	Client()->SendPackMsg(&Msg, MSGFLAG_VITAL);

--- a/src/game/client/components/voting.h
+++ b/src/game/client/components/voting.h
@@ -24,7 +24,7 @@ class CVoting : public CComponent
 
 	void ClearOptions();
 	void Clear();
-	void Callvote(const char *pType, const char *pValue, const char *pReason, bool ForceVote);
+	void SendCallvote(const char *pType, const char *pValue, const char *pReason, bool ForceVote);
 
 	int m_NumVoteOptions;
 	CVoteOptionClient *m_pFirst;
@@ -49,8 +49,6 @@ public:
 	void RconRemoveVoteOption(int OptionID);
 	void RconAddVoteOption(const char *pDescription, const char *pCommand);
 
-	void Vote(int Choice);
-
 	int SecondsLeft() { return (m_Closetime - time_get())/time_freq(); }
 	bool IsVoting() { return m_Closetime > 0 && m_Closetime > time_get(); }
 	int TakenChoice() const { return m_Voted; }
@@ -59,6 +57,8 @@ public:
 	int CallvoteBlockTime() const { return m_CallvoteBlockTick > Client()->GameTick() ? (m_CallvoteBlockTick-Client()->GameTick())/Client()->GameTickSpeed() : 0; }
 	int NumVoteOptions() const { return m_NumVoteOptions; }
 	const CVoteOptionClient *FirstVoteOption() const { return m_pFirst; }
+
+	void SendVote(int Choice);
 };
 
 #endif

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -401,7 +401,7 @@ void CGameClient::OnInit()
 	m_pEditor->Init();
 	m_pMenus->RenderLoading(2);
 
-	OnReset();	
+	OnReset();
 
 	m_ServerMode = SERVERMODE_PURE;
 
@@ -1317,7 +1317,7 @@ void CGameClient::OnNewSnapshot()
 							EvolveCharacter(&pCharInfo->m_Prev, EvolvePrevTick);
 						if(pCharInfo->m_Cur.m_Tick)
 							EvolveCharacter(&pCharInfo->m_Cur, EvolveCurTick);
-						
+
 						m_aClients[Item.m_ID].m_Evolved = m_Snap.m_aCharacters[Item.m_ID].m_Cur;
 					}
 
@@ -1873,6 +1873,7 @@ void CGameClient::DoTeamChangeMessage(const char *pName, int ClientID, int Team)
 	m_pChat->AddLine(aBuf);
 }
 
+// ----- send functions -----
 void CGameClient::SendSwitchTeam(int Team)
 {
 	CNetMsg_Cl_SetTeam Msg;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -309,7 +309,7 @@ public:
 
 	int GetClientID(const char *pName);
 
-	// actions
+	// ----- send functions -----
 	// TODO: move these
 	void SendSwitchTeam(int Team);
 	void SendStartInfo();

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -241,7 +241,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 		char aMapName[128];
 		m_pEditor->ExtractName(pFileName, aMapName, sizeof(aMapName));
 		if(!str_comp(aMapName, CurrentServerInfo.m_aMap))
-			m_pEditor->Client()->Rcon("reload");
+			m_pEditor->Client()->SendRcon("reload");
 	}
 
 	return 1;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -437,7 +437,51 @@ void CGameContext::SendVoteStatus(int ClientID, int Total, int Yes, int No)
 	Msg.m_Pass = Total - (Yes+No);
 
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
+}
 
+void CGameContext::SendVoteClearOptions(int ClientID)
+{
+	CNetMsg_Sv_VoteClearOptions ClearMsg;
+	Server()->SendPackMsg(&ClearMsg, MSGFLAG_VITAL, ClientID);
+}
+
+void CGameContext::SendVoteOptions(int ClientID)
+{
+	CVoteOptionServer *pCurrent = m_pVoteOptionFirst;
+	while(pCurrent)
+	{
+		// count options for actual packet
+		int NumOptions = 0;
+		for(CVoteOptionServer *p = pCurrent; p && NumOptions < MAX_VOTE_OPTION_ADD; p = p->m_pNext, ++NumOptions);
+
+		// pack and send vote list packet
+		CMsgPacker Msg(NETMSGTYPE_SV_VOTEOPTIONLISTADD);
+		Msg.AddInt(NumOptions);
+		while(pCurrent && NumOptions--)
+		{
+			Msg.AddString(pCurrent->m_aDescription, VOTE_DESC_LENGTH);
+			pCurrent = pCurrent->m_pNext;
+		}
+		Server()->SendMsg(&Msg, MSGFLAG_VITAL, ClientID);
+	}
+}
+
+void CGameContext::SendTuningParams(int ClientID)
+{
+	CheckPureTuning();
+
+	CMsgPacker Msg(NETMSGTYPE_SV_TUNEPARAMS);
+	int *pParams = (int *)&m_Tuning;
+	for(unsigned i = 0; i < sizeof(m_Tuning)/sizeof(int); i++)
+		Msg.AddInt(pParams[i]);
+	Server()->SendMsg(&Msg, MSGFLAG_VITAL, ClientID);
+}
+
+void CGameContext::SendReadyToEnter(CPlayer *pPlayer)
+{
+	pPlayer->m_IsReadyToEnter = true;
+	CNetMsg_Sv_ReadyToEnter m;
+	Server()->SendPackMsg(&m, MSGFLAG_VITAL|MSGFLAG_FLUSH, pPlayer->GetCID());
 }
 
 void CGameContext::AbortVoteOnDisconnect(int ClientID)
@@ -473,17 +517,6 @@ void CGameContext::CheckPureTuning()
 			m_Tuning = p;
 		}
 	}
-}
-
-void CGameContext::SendTuningParams(int ClientID)
-{
-	CheckPureTuning();
-
-	CMsgPacker Msg(NETMSGTYPE_SV_TUNEPARAMS);
-	int *pParams = (int *)&m_Tuning;
-	for(unsigned i = 0; i < sizeof(m_Tuning)/sizeof(int); i++)
-		Msg.AddInt(pParams[i]);
-	Server()->SendMsg(&Msg, MSGFLAG_VITAL, ClientID);
 }
 
 void CGameContext::SwapTeams()
@@ -1128,35 +1161,10 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 
 			m_pController->OnPlayerInfoChange(pPlayer);
 
-			// send vote options
-			CNetMsg_Sv_VoteClearOptions ClearMsg;
-			Server()->SendPackMsg(&ClearMsg, MSGFLAG_VITAL, ClientID);
-
-			CVoteOptionServer *pCurrent = m_pVoteOptionFirst;
-			while(pCurrent)
-			{
-				// count options for actual packet
-				int NumOptions = 0;
-				for(CVoteOptionServer *p = pCurrent; p && NumOptions < MAX_VOTE_OPTION_ADD; p = p->m_pNext, ++NumOptions);
-
-				// pack and send vote list packet
-				CMsgPacker Msg(NETMSGTYPE_SV_VOTEOPTIONLISTADD);
-				Msg.AddInt(NumOptions);
-				while(pCurrent && NumOptions--)
-				{
-					Msg.AddString(pCurrent->m_aDescription, VOTE_DESC_LENGTH);
-					pCurrent = pCurrent->m_pNext;
-				}
-				Server()->SendMsg(&Msg, MSGFLAG_VITAL, ClientID);
-			}
-
-			// send tuning parameters to client
+			SendVoteClearOptions(ClientID);
+			SendVoteOptions(ClientID);
 			SendTuningParams(ClientID);
-
-			// client is ready to enter
-			pPlayer->m_IsReadyToEnter = true;
-			CNetMsg_Sv_ReadyToEnter m;
-			Server()->SendPackMsg(&m, MSGFLAG_VITAL|MSGFLAG_FLUSH, ClientID);
+			SendReadyToEnter(pPlayer);
 		}
 	}
 }
@@ -1491,8 +1499,7 @@ void CGameContext::ConClearVotes(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
 	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "cleared votes");
-	CNetMsg_Sv_VoteClearOptions VoteClearOptionsMsg;
-	pSelf->Server()->SendPackMsg(&VoteClearOptionsMsg, MSGFLAG_VITAL, -1);
+	pSelf->SendVoteClearOptions(-1);
 	pSelf->m_pVoteOptionHeap->Reset();
 	pSelf->m_pVoteOptionFirst = 0;
 	pSelf->m_pVoteOptionLast = 0;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -190,6 +190,7 @@ void CGameContext::CreateSound(vec2 Pos, int Sound, int64 Mask)
 	}
 }
 
+// ----- send functions -----
 void CGameContext::SendChat(int ChatterClientID, int Mode, int To, const char *pText)
 {
 	char aBuf[256];
@@ -394,7 +395,7 @@ void CGameContext::EndVote(int Type, bool Force)
 	SendVoteSet(Type, -1);
 }
 
-void CGameContext::ForceVote(int Type, const char *pDescription, const char *pReason)
+void CGameContext::SendForceVote(int Type, const char *pDescription, const char *pReason)
 {
 	CNetMsg_Sv_VoteSet Msg;
 	Msg.m_Type = Type;
@@ -902,7 +903,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 							Server()->SetRconCID(ClientID);
 							Console()->ExecuteLine(aCmd);
 							Server()->SetRconCID(IServer::RCON_CID_SERV);
-							ForceVote(VOTE_START_OP, aDesc, pReason);
+							SendForceVote(VOTE_START_OP, aDesc, pReason);
 							return;
 						}
 						m_VoteType = VOTE_START_OP;
@@ -973,7 +974,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 					Server()->SetRconCID(ClientID);
 					Console()->ExecuteLine(aCmd);
 					Server()->SetRconCID(IServer::RCON_CID_SERV);
-					ForceVote(VOTE_START_SPEC, aDesc, pReason);
+					SendForceVote(VOTE_START_SPEC, aDesc, pReason);
 					return;
 				}
 				m_VoteType = VOTE_START_SPEC;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -107,10 +107,6 @@ public:
 	void AbortVoteOnDisconnect(int ClientID);
 	void AbortVoteOnTeamChange(int ClientID);
 
-	void SendForceVote(int Type, const char *pDescription, const char *pReason);
-	void SendVoteSet(int Type, int ToClientID);
-	void SendVoteStatus(int ClientID, int Total, int Yes, int No);
-
 	int m_VoteCreator;
 	int m_VoteType;
 	int64 m_VoteCloseTime;
@@ -151,6 +147,8 @@ public:
 	void SendMotd(int ClientID);
 	void SendSettings(int ClientID);
 	void SendSkinChange(int ClientID, int TargetID);
+	void SendTuningParams(int ClientID);
+	void SendReadyToEnter(CPlayer *pPlayer);
 
 	void SendGameMsg(int GameMsgID, int ClientID);
 	void SendGameMsg(int GameMsgID, int ParaI1, int ClientID);
@@ -160,9 +158,14 @@ public:
 	void SendChatCommands(int ClientID);
 	void SendRemoveChatCommand(const CCommandManager::CCommand *pCommand, int ClientID);
 
+	void SendForceVote(int Type, const char *pDescription, const char *pReason);
+	void SendVoteSet(int Type, int ToClientID);
+	void SendVoteStatus(int ClientID, int Total, int Yes, int No);
+	void SendVoteClearOptions(int ClientID);
+	void SendVoteOptions(int ClientID);
+
 	//
 	void CheckPureTuning();
-	void SendTuningParams(int ClientID);
 
 	//
 	void SwapTeams();

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -104,11 +104,12 @@ public:
 	// voting
 	void StartVote(const char *pDesc, const char *pCommand, const char *pReason);
 	void EndVote(int Type, bool Force);
-	void ForceVote(int Type, const char *pDescription, const char *pReason);
-	void SendVoteSet(int Type, int ToClientID);
-	void SendVoteStatus(int ClientID, int Total, int Yes, int No);
 	void AbortVoteOnDisconnect(int ClientID);
 	void AbortVoteOnTeamChange(int ClientID);
+
+	void SendForceVote(int Type, const char *pDescription, const char *pReason);
+	void SendVoteSet(int Type, int ToClientID);
+	void SendVoteStatus(int ClientID, int Total, int Yes, int No);
 
 	int m_VoteCreator;
 	int m_VoteType;
@@ -142,7 +143,7 @@ public:
 	void CreateDeath(vec2 Pos, int Who);
 	void CreateSound(vec2 Pos, int Sound, int64 Mask=-1);
 
-	// network
+	// ----- send functions -----
 	void SendChat(int ChatterClientID, int Mode, int To, const char *pText);
 	void SendBroadcast(const char *pText, int ClientID);
 	void SendEmoticon(int ClientID, int Emoticon);

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -319,7 +319,7 @@ void IGameController::OnPlayerConnect(CPlayer *pPlayer)
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
 	// update game info
-	UpdateGameInfo(ClientID);
+	SendGameInfo(ClientID);
 }
 
 void IGameController::OnPlayerDisconnect(CPlayer *pPlayer)
@@ -848,7 +848,7 @@ void IGameController::CheckGameInfo()
 	m_GameInfo.m_ScoreLimit = Config()->m_SvScorelimit;
 	m_GameInfo.m_TimeLimit = Config()->m_SvTimelimit;
 	if(GameInfoChanged)
-		UpdateGameInfo(-1);
+		SendGameInfo(-1);
 }
 
 bool IGameController::IsFriendlyFire(int ClientID1, int ClientID2) const
@@ -883,7 +883,7 @@ bool IGameController::IsTeamChangeAllowed() const
 	return !GameServer()->m_World.m_Paused || (m_GameState == IGS_START_COUNTDOWN && m_GameStartTick == Server()->Tick());
 }
 
-void IGameController::UpdateGameInfo(int ClientID)
+void IGameController::SendGameInfo(int ClientID)
 {
 	CNetMsg_Sv_GameInfo GameInfoMsg;
 	GameInfoMsg.m_GameFlags = m_GameFlags;

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -122,7 +122,7 @@ protected:
 		int m_TimeLimit;
 	} m_GameInfo;
 
-	void UpdateGameInfo(int ClientID);
+	void SendGameInfo(int ClientID);
 
 public:
 	IGameController(class CGameContext *pGameServer);


### PR DESCRIPTION
The code base already started a convention of prefixing methods
that send a network message with `Send`

```
$ grep -Er 'void Send[A-Z][a-z]+\('
src/game/client/gameclient.h:   void SendKill();
src/game/server/gamecontext.h:  void SendChat(int ChatterClientID, int Mode, int To, const char *pText);
src/game/server/gamecontext.h:  void SendBroadcast(const char *pText, int ClientID);
src/game/server/gamecontext.h:  void SendEmoticon(int ClientID, int Emoticon);
src/game/server/gamecontext.h:  void SendMotd(int ClientID);
src/game/server/gamecontext.h:  void SendSettings(int ClientID);
src/mastersrv/mastersrv.cpp:void SendOk(NETADDR *pAddr, TOKEN Token)
src/mastersrv/mastersrv.cpp:void SendError(NETADDR *pAddr, TOKEN Token)
src/mastersrv/mastersrv.cpp:void SendCheck(NETADDR *pAddr, TOKEN Token)
src/versionsrv/versionsrv.cpp:static void SendVersion(NETADDR *pAddr, TOKEN ResponseToken)
src/versionsrv/versionsrv.cpp:static void SendMapversions(NETADDR *pAddr, TOKEN ResponseToken)
src/engine/client/client.h:     void SendInfo();
src/engine/client/client.h:     void SendReady();
src/engine/client/client.h:     void SendInput();
src/engine/shared/network.h:    void SendPacket(const NETADDR *pAddr, CNetPacketConstruct *pPacket);
src/engine/shared/network.h:    void SendControl(int ControlMsg, const void *pExtra, int ExtraSize);
src/engine/server/server.h:     void SendMap(int ClientID);
```

But not all methods followed this pattern. This commit cleans that up.

While reading the code it is now more obvious when a network message is
sent. See the following example.

Before it was hard to understand if ForceVote changes some internal
state or sends a network message.

```C++
Server()->SetRconCID(ClientID);
Console()->ExecuteLine(aCmd);
Server()->SetRconCID(IServer::RCON_CID_SERV);
ForceVote(VOTE_START_SPEC, aDesc, pReason);
```

Now it is clear that `SendForceVote` does send a message.

```C++
Server()->SetRconCID(ClientID);
Console()->ExecuteLine(aCmd);
Server()->SetRconCID(IServer::RCON_CID_SERV);
SendForceVote(VOTE_START_SPEC, aDesc, pReason);
```

Also chat.cpp had the methods `Say` and `AddLine` one sends a network
message the other just locally adds a new line to the chat log.

I renamed `Say` to `SendChat` which is also now matching the naming
of the server side. Any other method in chat.cpp can now be assumed to
not send any network message.

The method `UpdateGameInfo(int ClientID)` does not have any side
effects. It does not update any game info variables. The only thing it
does is sending the current game info to the ClientID. So the new name
`SendGameInfo(int ClientID)` is more descriptive.

The client sending the startinfo is a crucial part of building up
a healthy connection.

The server responds with 3 or more (depending on the amount of votes) messages.
That used to be one big wall of code that required comments to
understand where a new message starts. Now the protocol is easier to
understand while looking at the code. Without the need of comments.

```C++
if (MsgID == NETMSGTYPE_CL_STARTINFO)
{

	// [..]

	SendVoteClearOptions(ClientID);
	SendVoteOptions(ClientID);
	SendTuningParams(ClientID);
	SendReadyToEnter(pPlayer);
}
```