### PR TITLE
Fix m_pa* variable naming to m_ap*

### DIFF
--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -712,7 +712,7 @@ CTextRender::CTextRender()
 	m_pGlyphMap = 0;
 	m_NumVariants = 0;
 	m_CurrentVariant = -1;
-	m_paVariants = 0;
+	m_pVariants = 0;
 
 	mem_zero(m_apFontData, sizeof(m_apFontData));
 }
@@ -736,8 +736,8 @@ void CTextRender::Shutdown()
 
 	FT_Done_FreeType(m_FTLibrary);
 
-	if(m_paVariants)
-		mem_free(m_paVariants);
+	if(m_pVariants)
+		mem_free(m_pVariants);
 
 	for(int i = 0; i < MAX_FACES; ++i)
 		if(m_apFontData[i])
@@ -798,18 +798,18 @@ void CTextRender::LoadFonts(IStorage *pStorage, IConsole *pConsole)
 	{
 		m_NumVariants = rVariant.u.object.length;
 		json_object_entry *Entries = rVariant.u.object.values;
-		m_paVariants = (CFontLanguageVariant *)mem_alloc(sizeof(CFontLanguageVariant)*m_NumVariants);
+		m_pVariants = (CFontLanguageVariant *)mem_alloc(sizeof(CFontLanguageVariant)*m_NumVariants);
 		for(int i = 0; i < m_NumVariants; ++i)
 		{
 			char aFileName[128];
 			str_format(aFileName, sizeof(aFileName), "languages/%s.json", (const char *)Entries[i].name);
-			str_copy(m_paVariants[i].m_aLanguageFile, aFileName, sizeof(m_paVariants[i].m_aLanguageFile));
+			str_copy(m_pVariants[i].m_aLanguageFile, aFileName, sizeof(m_pVariants[i].m_aLanguageFile));
 
 			json_value *pFamilyName = rVariant.u.object.values[i].value;
 			if(pFamilyName->type == json_string)
-				str_copy(m_paVariants[i].m_aFamilyName, pFamilyName->u.string.ptr, sizeof(m_paVariants[i].m_aFamilyName));
+				str_copy(m_pVariants[i].m_aFamilyName, pFamilyName->u.string.ptr, sizeof(m_pVariants[i].m_aFamilyName));
 			else
-				m_paVariants[i].m_aFamilyName[0] = 0;
+				m_pVariants[i].m_aFamilyName[0] = 0;
 		}
 	}
 }
@@ -821,13 +821,13 @@ void CTextRender::SetFontLanguageVariant(const char *pLanguageFile)
 
 	char *pFamilyName = NULL;
 
-	if(m_paVariants)
+	if(m_pVariants)
 	{
 		for(int i = 0; i < m_NumVariants; ++i)
 		{
-			if(str_comp_filenames(pLanguageFile, m_paVariants[i].m_aLanguageFile) == 0)
+			if(str_comp_filenames(pLanguageFile, m_pVariants[i].m_aLanguageFile) == 0)
 			{
-				pFamilyName = m_paVariants[i].m_aFamilyName;
+				pFamilyName = m_pVariants[i].m_aFamilyName;
 				m_CurrentVariant = i;
 				break;
 			}

--- a/src/engine/client/textrender.h
+++ b/src/engine/client/textrender.h
@@ -162,7 +162,7 @@ class CTextRender : public IEngineTextRender
 	// support regional variant fonts
 	int m_NumVariants;
 	int m_CurrentVariant;
-	CFontLanguageVariant *m_paVariants;
+	CFontLanguageVariant *m_pVariants;
 
 	FT_Library m_FTLibrary;
 

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -389,7 +389,7 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr)
 				if(Result.m_pCommand[0] == '+')
 				{
 					// insert the stroke direction token
-					Result.AddArgument(m_paStrokeStr[Stroke]);
+					Result.AddArgument(m_apStrokeStr[Stroke]);
 					IsStrokeCommand = 1;
 				}
 
@@ -812,8 +812,8 @@ CConsole::CConsole(int FlagMask)
 	m_pRecycleList = 0;
 	m_TempCommands.Reset();
 	m_StoreCommands = true;
-	m_paStrokeStr[0] = "0";
-	m_paStrokeStr[1] = "1";
+	m_apStrokeStr[0] = "0";
+	m_apStrokeStr[1] = "1";
 	m_pTempMapListHeap = 0;
 	m_pFirstMapEntry = 0;
 	m_pLastMapEntry = 0;

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -36,7 +36,7 @@ class CConsole : public IConsole
 
 	int m_FlagMask;
 	bool m_StoreCommands;
-	const char *m_paStrokeStr[2];
+	const char *m_apStrokeStr[2];
 	CCommand *m_pFirstCommand;
 
 	class CExecFile

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -65,11 +65,11 @@ typename CNetBan::CBan<T> *CNetBan::CBanPool<T, HashCount>::Add(const T *pData, 
 		m_pFirstFree = pBan->m_pNext;
 
 	// add it to the hash list
-	if(m_paaHashList[pNetHash->m_HashIndex][pNetHash->m_Hash])
-		m_paaHashList[pNetHash->m_HashIndex][pNetHash->m_Hash]->m_pHashPrev = pBan;
+	if(m_aapHashList[pNetHash->m_HashIndex][pNetHash->m_Hash])
+		m_aapHashList[pNetHash->m_HashIndex][pNetHash->m_Hash]->m_pHashPrev = pBan;
 	pBan->m_pHashPrev = 0;
-	pBan->m_pHashNext = m_paaHashList[pNetHash->m_HashIndex][pNetHash->m_Hash];
-	m_paaHashList[pNetHash->m_HashIndex][pNetHash->m_Hash] = pBan;
+	pBan->m_pHashNext = m_aapHashList[pNetHash->m_HashIndex][pNetHash->m_Hash];
+	m_aapHashList[pNetHash->m_HashIndex][pNetHash->m_Hash] = pBan;
 
 	// insert it into the used list
 	if(m_pFirstUsed)
@@ -123,7 +123,7 @@ int CNetBan::CBanPool<T, HashCount>::Remove(CBan<T> *pBan)
 	if(pBan->m_pHashPrev)
 		pBan->m_pHashPrev->m_pHashNext = pBan->m_pHashNext;
 	else
-		m_paaHashList[pBan->m_NetHash.m_HashIndex][pBan->m_NetHash.m_Hash] = pBan->m_pHashNext;
+		m_aapHashList[pBan->m_NetHash.m_HashIndex][pBan->m_NetHash.m_Hash] = pBan->m_pHashNext;
 	pBan->m_pHashNext = pBan->m_pHashPrev = 0;
 
 	// remove from used list
@@ -198,7 +198,7 @@ void CNetBan::CBanPool<T, HashCount>::Update(CBan<CDataType> *pBan, const CBanIn
 template<class T, int HashCount>
 void CNetBan::CBanPool<T, HashCount>::Reset()
 {
-	mem_zero(m_paaHashList, sizeof(m_paaHashList));
+	mem_zero(m_aapHashList, sizeof(m_aapHashList));
 	mem_zero(m_aBans, sizeof(m_aBans));
 	m_pFirstUsed = 0;
 	m_CountUsed = 0;

--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -116,10 +116,10 @@ protected:
 		bool IsFull() const { return m_CountUsed == MAX_BANS; }
 
 		CBan<CDataType> *First() const { return m_pFirstUsed; }
-		CBan<CDataType> *First(const CNetHash *pNetHash) const { return m_paaHashList[pNetHash->m_HashIndex][pNetHash->m_Hash]; }
+		CBan<CDataType> *First(const CNetHash *pNetHash) const { return m_aapHashList[pNetHash->m_HashIndex][pNetHash->m_Hash]; }
 		CBan<CDataType> *Find(const CDataType *pData, const CNetHash *pNetHash) const
 		{
-			for(CBan<CDataType> *pBan = m_paaHashList[pNetHash->m_HashIndex][pNetHash->m_Hash]; pBan; pBan = pBan->m_pHashNext)
+			for(CBan<CDataType> *pBan = m_aapHashList[pNetHash->m_HashIndex][pNetHash->m_Hash]; pBan; pBan = pBan->m_pHashNext)
 			{
 				if(NetComp(&pBan->m_Data, pData) == 0)
 					return pBan;
@@ -135,7 +135,7 @@ protected:
 			MAX_BANS=1024,
 		};
 
-		CBan<CDataType> *m_paaHashList[HashCount][256];
+		CBan<CDataType> *m_aapHashList[HashCount][256];
 		CBan<CDataType> m_aBans[MAX_BANS];
 		CBan<CDataType> *m_pFirstFree;
 		CBan<CDataType> *m_pFirstUsed;

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -854,7 +854,7 @@ void CHud::RenderSpectatorNotification()
 void CHud::RenderReadyUpNotification()
 {
 	if(m_pClient->m_LocalClientID != -1
-		&& !(m_pClient->m_Snap.m_paPlayerInfos[m_pClient->m_LocalClientID]->m_PlayerFlags&PLAYERFLAG_READY))
+		&& !(m_pClient->m_Snap.m_apPlayerInfos[m_pClient->m_LocalClientID]->m_PlayerFlags&PLAYERFLAG_READY))
 	{
 		static CTextCursor s_Cursor(16.0f);
 
@@ -994,7 +994,7 @@ void CHud::OnRender()
 			RenderHealthAndAmmo(m_pClient->m_Snap.m_pLocalCharacter);
 			if(Race && m_pClient->m_LocalClientID != -1)
 			{
-				RenderRaceTime(m_pClient->m_Snap.m_paPlayerInfosRace[m_pClient->m_LocalClientID]);
+				RenderRaceTime(m_pClient->m_Snap.m_apPlayerInfosRace[m_pClient->m_LocalClientID]);
 				RenderCheckpoint();
 			}
 		}
@@ -1005,7 +1005,7 @@ void CHud::OnRender()
 				RenderHealthAndAmmo(&m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID].m_Cur);
 				if(Race)
 				{
-					RenderRaceTime(m_pClient->m_Snap.m_paPlayerInfosRace[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID]);
+					RenderRaceTime(m_pClient->m_Snap.m_apPlayerInfosRace[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID]);
 					RenderCheckpoint();
 				}
 			}

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -553,7 +553,7 @@ void CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 		{
 			if(i == m_pClient->m_LocalClientID || !m_pClient->m_aClients[i].m_Active || m_pClient->m_aClients[i].m_Team != Teams[Team] ||
 				(FilterSpectators && m_pClient->m_aClients[i].m_Team == TEAM_SPECTATORS) ||
-				(!FilterSpectators && m_pClient->m_Snap.m_paPlayerInfos[i] && (m_pClient->m_Snap.m_paPlayerInfos[i]->m_PlayerFlags&PLAYERFLAG_ADMIN)))
+				(!FilterSpectators && m_pClient->m_Snap.m_apPlayerInfos[i] && (m_pClient->m_Snap.m_apPlayerInfos[i]->m_PlayerFlags&PLAYERFLAG_ADMIN)))
 				continue;
 			if(m_CallvoteSelectedPlayer == i)
 				Selected = NumOptions;

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -133,7 +133,7 @@ float CScoreboard::RenderSpectators(float x, float y, float w)
 		s_SpectatorCursors[i].Reset();
 		s_SpectatorCursors[i].m_FontSize = FontSize;
 
-		const CNetObj_PlayerInfo *pInfo = m_pClient->m_Snap.m_paPlayerInfos[0];
+		const CNetObj_PlayerInfo *pInfo = m_pClient->m_Snap.m_apPlayerInfos[0];
 		if(!pInfo || m_pClient->m_aClients[i].m_Team != TEAM_SPECTATORS || Lines > MaxLines)
 			continue;
 
@@ -342,9 +342,9 @@ float CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const c
 		else
 		{
 			if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorID >= 0 &&
-				m_pClient->m_Snap.m_paPlayerInfos[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID])
+				m_pClient->m_Snap.m_apPlayerInfos[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID])
 			{
-				int Score = m_pClient->m_Snap.m_paPlayerInfos[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID]->m_Score;
+				int Score = m_pClient->m_Snap.m_apPlayerInfos[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID]->m_Score;
 				str_format(aBuf, sizeof(aBuf), "%d", Score);
 			}
 			else if(m_pClient->m_Snap.m_pLocalInfo)

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -47,7 +47,7 @@ bool CSpectator::SpecModePossible(int SpecMode, int SpectatorID)
 			&& m_pClient->m_aClients[m_pClient->m_LocalClientID].m_Team != TEAM_SPECTATORS
 			&& (SpectatorID == m_pClient->m_LocalClientID
 				|| m_pClient->m_aClients[m_pClient->m_LocalClientID].m_Team != m_pClient->m_aClients[SpectatorID].m_Team
-				|| (m_pClient->m_Snap.m_paPlayerInfos[SpectatorID] && (m_pClient->m_Snap.m_paPlayerInfos[SpectatorID]->m_PlayerFlags&PLAYERFLAG_DEAD))))
+				|| (m_pClient->m_Snap.m_apPlayerInfos[SpectatorID] && (m_pClient->m_Snap.m_apPlayerInfos[SpectatorID]->m_PlayerFlags&PLAYERFLAG_DEAD))))
 		{
 			return false;
 		}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -124,7 +124,7 @@ static CMapLayers gs_MapLayersBackGround(CMapLayers::TYPE_BACKGROUND);
 static CMapLayers gs_MapLayersForeGround(CMapLayers::TYPE_FOREGROUND);
 
 CGameClient::CStack::CStack() { m_Num = 0; }
-void CGameClient::CStack::Add(class CComponent *pComponent) { m_paComponents[m_Num++] = pComponent; }
+void CGameClient::CStack::Add(class CComponent *pComponent) { m_apComponents[m_Num++] = pComponent; }
 
 const char *CGameClient::Version() const { return GAME_VERSION; }
 const char *CGameClient::NetVersion() const { return GAME_NETVERSION; }
@@ -336,11 +336,11 @@ void CGameClient::OnConsoleInit()
 	Console()->Chain("player_skin_eyes", ConchainSkinChange, this);
 
 	for(int i = 0; i < m_All.m_Num; i++)
-		m_All.m_paComponents[i]->m_pClient = this;
+		m_All.m_apComponents[i]->m_pClient = this;
 
 	// let all the other components register their console commands
 	for(int i = 0; i < m_All.m_Num; i++)
-		m_All.m_paComponents[i]->OnConsoleInit();
+		m_All.m_apComponents[i]->OnConsoleInit();
 
 	//
 	m_SuppressEvents = false;
@@ -373,7 +373,7 @@ void CGameClient::OnInit()
 	// determine total work for loading all components
 	int TotalWorkAmount = g_pData->m_NumImages + 4 + 1 + 1 + 2; // +4=load init, +1=font, +1=localization, +2=editor
 	for(int i = m_All.m_Num-1; i >= 0; --i)
-		TotalWorkAmount += m_All.m_paComponents[i]->GetInitAmount();
+		TotalWorkAmount += m_All.m_apComponents[i]->GetInitAmount();
 
 	m_pMenus->InitLoading(TotalWorkAmount);
 	m_pMenus->RenderLoading(4);
@@ -388,7 +388,7 @@ void CGameClient::OnInit()
 
 	// init all components
 	for(int i = m_All.m_Num-1; i >= 0; --i)
-		m_All.m_paComponents[i]->OnInit(); // this will call RenderLoading again
+		m_All.m_apComponents[i]->OnInit(); // this will call RenderLoading again
 
 	// load textures
 	for(int i = 0; i < g_pData->m_NumImages; i++)
@@ -425,7 +425,7 @@ void CGameClient::OnUpdate()
 	{
 		for(int h = 0; h < m_Input.m_Num; h++)
 		{
-			if(m_Input.m_paComponents[h]->OnCursorMove(x, y, CursorType))
+			if(m_Input.m_apComponents[h]->OnCursorMove(x, y, CursorType))
 				break;
 		}
 	}
@@ -439,7 +439,7 @@ void CGameClient::OnUpdate()
 
 		for(int h = 0; h < m_Input.m_Num; h++)
 		{
-			if(m_Input.m_paComponents[h]->OnInput(e))
+			if(m_Input.m_apComponents[h]->OnInput(e))
 				break;
 		}
 	}
@@ -457,8 +457,8 @@ void CGameClient::OnConnected()
 
 	for(int i = 0; i < m_All.m_Num; i++)
 	{
-		m_All.m_paComponents[i]->OnMapLoad();
-		m_All.m_paComponents[i]->OnReset();
+		m_All.m_apComponents[i]->OnMapLoad();
+		m_All.m_apComponents[i]->OnReset();
 	}
 
 	m_ServerMode = SERVERMODE_PURE;
@@ -480,7 +480,7 @@ void CGameClient::OnReset()
 	}
 
 	for(int i = 0; i < m_All.m_Num; i++)
-		m_All.m_paComponents[i]->OnReset();
+		m_All.m_apComponents[i]->OnReset();
 
 	if(Client()->State() < IClient::STATE_ONLINE)
 	{
@@ -611,7 +611,7 @@ void CGameClient::OnRender()
 
 	// render all systems
 	for(int i = 0; i < m_All.m_Num; i++)
-		m_All.m_paComponents[i]->OnRender();
+		m_All.m_apComponents[i]->OnRender();
 
 	// clear all events/input for this frame
 	Input()->Clear();
@@ -623,7 +623,7 @@ void CGameClient::OnRelease()
 {
 	// release all systems
 	for(int i = 0; i < m_All.m_Num; i++)
-		m_All.m_paComponents[i]->OnRelease();
+		m_All.m_apComponents[i]->OnRelease();
 }
 
 void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
@@ -809,7 +809,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker)
 
 	// TODO: this should be done smarter
 	for(int i = 0; i < m_All.m_Num; i++)
-		m_All.m_paComponents[i]->OnMessage(MsgId, pRawMsg);
+		m_All.m_apComponents[i]->OnMessage(MsgId, pRawMsg);
 
 	if(MsgId == NETMSGTYPE_SV_CLIENTINFO && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
@@ -1028,13 +1028,13 @@ void CGameClient::OnStateChange(int NewState, int OldState)
 
 	// then change the state
 	for(int i = 0; i < m_All.m_Num; i++)
-		m_All.m_paComponents[i]->OnStateChange(NewState, OldState);
+		m_All.m_apComponents[i]->OnStateChange(NewState, OldState);
 }
 
 void CGameClient::OnShutdown()
 {
 	for(int i = 0; i < m_All.m_Num; i++)
-		m_All.m_paComponents[i]->OnShutdown();
+		m_All.m_apComponents[i]->OnShutdown();
 }
 void CGameClient::OnEnterGame() {}
 
@@ -1257,7 +1257,7 @@ void CGameClient::OnNewSnapshot()
 				int ClientID = Item.m_ID;
 				if(ClientID < MAX_CLIENTS && m_aClients[ClientID].m_Active)
 				{
-					m_Snap.m_paPlayerInfos[ClientID] = pInfo;
+					m_Snap.m_apPlayerInfos[ClientID] = pInfo;
 					m_Snap.m_aInfoByScore[ClientID].m_pPlayerInfo = pInfo;
 					m_Snap.m_aInfoByScore[ClientID].m_ClientID = ClientID;
 
@@ -1281,7 +1281,7 @@ void CGameClient::OnNewSnapshot()
 				int ClientID = Item.m_ID;
 				if(ClientID < MAX_CLIENTS && m_aClients[ClientID].m_Active)
 				{
-					m_Snap.m_paPlayerInfosRace[ClientID] = pInfo;
+					m_Snap.m_apPlayerInfosRace[ClientID] = pInfo;
 				}
 			}
 			else if(Item.m_Type == NETOBJTYPE_CHARACTER)
@@ -1381,7 +1381,7 @@ void CGameClient::OnNewSnapshot()
 			}
 			else if(Item.m_Type == NETOBJTYPE_FLAG)
 			{
-				m_Snap.m_paFlags[Item.m_ID%2] = (const CNetObj_Flag *)pData;
+				m_Snap.m_apFlags[Item.m_ID%2] = (const CNetObj_Flag *)pData;
 			}
 		}
 	}
@@ -1449,16 +1449,16 @@ void CGameClient::OnNewSnapshot()
 	// calc some player stats
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
-		if(!m_Snap.m_paPlayerInfos[i])
+		if(!m_Snap.m_apPlayerInfos[i])
 			continue;
 
 		// count not ready players
 		if(m_Snap.m_pGameData && (m_Snap.m_pGameData->m_GameStateFlags&(GAMESTATEFLAG_STARTCOUNTDOWN|GAMESTATEFLAG_PAUSED|GAMESTATEFLAG_WARMUP)) &&
-			m_Snap.m_pGameData->m_GameStateEndTick == 0 && m_aClients[i].m_Team != TEAM_SPECTATORS && !(m_Snap.m_paPlayerInfos[i]->m_PlayerFlags&PLAYERFLAG_READY))
+			m_Snap.m_pGameData->m_GameStateEndTick == 0 && m_aClients[i].m_Team != TEAM_SPECTATORS && !(m_Snap.m_apPlayerInfos[i]->m_PlayerFlags&PLAYERFLAG_READY))
 			m_Snap.m_NotReadyCount++;
 
 		// count alive players per team
-		if((m_GameInfo.m_GameFlags&GAMEFLAG_SURVIVAL) && m_aClients[i].m_Team != TEAM_SPECTATORS && !(m_Snap.m_paPlayerInfos[i]->m_PlayerFlags&PLAYERFLAG_DEAD))
+		if((m_GameInfo.m_GameFlags&GAMEFLAG_SURVIVAL) && m_aClients[i].m_Team != TEAM_SPECTATORS && !(m_Snap.m_apPlayerInfos[i]->m_PlayerFlags&PLAYERFLAG_DEAD))
 			m_Snap.m_AliveCount[m_aClients[i].m_Team]++;
 	}
 
@@ -1720,7 +1720,7 @@ void CGameClient::CClientData::UpdateBotRenderInfo(CGameClient *pGameClient, int
 		{0x74,0xc7,0xa3},
 	};
 
-	if(pGameClient->m_Snap.m_paPlayerInfos[ClientID] && pGameClient->m_Snap.m_paPlayerInfos[ClientID]->m_PlayerFlags&PLAYERFLAG_BOT)
+	if(pGameClient->m_Snap.m_apPlayerInfos[ClientID] && pGameClient->m_Snap.m_apPlayerInfos[ClientID]->m_PlayerFlags&PLAYERFLAG_BOT)
 	{
 		m_RenderInfo.m_BotTexture = pGameClient->m_pSkins->m_BotTexture;
 		if(!m_RenderInfo.m_BotColor.a) // bot color has not been set; pick a random color once

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -24,7 +24,7 @@ class CGameClient : public IGameClient
 		CStack();
 		void Add(class CComponent *pComponent);
 
-		class CComponent *m_paComponents[MAX_COMPONENTS];
+		class CComponent *m_apComponents[MAX_COMPONENTS];
 		int m_Num;
 	};
 
@@ -155,7 +155,7 @@ public:
 		const CNetObj_PlayerInfo *m_pLocalInfo;
 		const CNetObj_SpectatorInfo *m_pSpectatorInfo;
 		const CNetObj_SpectatorInfo *m_pPrevSpectatorInfo;
-		const CNetObj_Flag *m_paFlags[2];
+		const CNetObj_Flag *m_apFlags[2];
 		const CNetObj_GameData *m_pGameData;
 		const CNetObj_GameDataTeam *m_pGameDataTeam;
 		const CNetObj_GameDataFlag *m_pGameDataFlag;
@@ -165,8 +165,8 @@ public:
 		int m_NotReadyCount;
 		int m_AliveCount[NUM_TEAMS];
 
-		const CNetObj_PlayerInfo *m_paPlayerInfos[MAX_CLIENTS];
-		const CNetObj_PlayerInfoRace *m_paPlayerInfosRace[MAX_CLIENTS];
+		const CNetObj_PlayerInfo *m_apPlayerInfos[MAX_CLIENTS];
+		const CNetObj_PlayerInfoRace *m_apPlayerInfosRace[MAX_CLIENTS];
 		CPlayerInfoItem m_aInfoByScore[MAX_CLIENTS];
 
 		// spectate data


### PR DESCRIPTION
Fixed using the following shell script

```
#!/bin/sh

grep -rEo '\bm_paa[A-Z][a-zA-Z0-9]+' src | cut -d':' -f2- | sort -u |
while read -r var
        do
                new="m_aap$(printf '%s' "$var" | cut -c 6-)"
                perl -i -p -e's/\b'"$var"'\b/'"$new"'/g' $(find . -name
'*.h' -o -name '*.cpp' -o -name '*.c')
        done

grep -rEo '\bm_pa[A-Z][a-zA-Z0-9]+' src | cut -d':' -f2- | sort -u |
while read -r var
        do
                new="m_ap$(printf '%s' "$var" | cut -c 5-)"
                perl -i -p -e's/\b'"$var"'\b/'"$new"'/g' $(find . -name
'*.h' -o -name '*.cpp' -o -name '*.c')
        done
```