### PR TITLE
Let special characters be escaped in broadcasts (fixes #3253)

### DIFF
--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -157,6 +157,21 @@ void CBroadcast::OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg)
 	for(int i = 0; i < MsgLength && ServerMsgLen < MAX_BROADCAST_MSG_SIZE - 1; i++)
 	{
 		const char *c = pMsg->m_pMessage + i;
+
+		if(*c == '\\' && c[1] == '^')
+		{
+			aBuf[ServerMsgLen++] = c[1];
+			i++; // skip '^'
+			continue;
+		}
+
+		if (*c == '\\' && c[1] == '\\')
+		{
+			aBuf[ServerMsgLen++] = *c;
+			i++; // skip the second backslash
+			continue;
+		}
+
 		if(*c == '^' && i+3 < MsgLength && IsCharANum(c[1]) && IsCharANum(c[2])  && IsCharANum(c[3]))
 		{
 			SegmentColors[m_NumSegments] = vec4((c[1] - '0') / 9.0f, (c[2] - '0') / 9.0f, (c[3] - '0') / 9.0f, 1.0f);


### PR DESCRIPTION
With this pr now you can actually broadcast messages containing \n and ^rgb without it being processed as new lines or color codes.
Example: `broadcast Syntax for colors is \^123 and new line is \\n`
Result:
![screenshot_2024-07-25_01-09-39](https://github.com/user-attachments/assets/595755af-f9e7-4b9f-9485-e069f8c12ca3)
