### PR TITLE
Fix system.c mixing declarations breaking macOS pipeline

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1064,10 +1064,11 @@ void sphore_init(SEMAPHORE *sem)
 
 void sphore_wait(SEMAPHORE *sem)
 {
+	int result = 0;
+
 	lock_wait((*sem)->c_lock);
 
 	(*sem)->waiters++;
-	int result = 0;
 	while((*sem)->count == 0)
 		result = pthread_cond_wait(&(*sem)->c_nzcond, (LOCKINTERNAL *)(*sem)->c_lock);
 


### PR DESCRIPTION
mixing declarations and code is incompatible with standards before C99